### PR TITLE
docs: remove incorrect contact badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [![CI](https://github.com/takeshishimada/Lockman/workflows/CI/badge.svg)](https://github.com/takeshishimada/Lockman/actions?query=workflow%3ACI)
 [![Swift 5.9](https://img.shields.io/badge/swift-5.9-ED523F.svg?style=flat)](https://swift.org/download/)
-[![@takeshishimada](https://img.shields.io/badge/contact-@takeshishimada-1DA1F2.svg?style=flat&logo=twitter)](https://twitter.com/takeshishimada)
 
 A library for building action exclusive control with feedback-first approach, with responsiveness, transparency, and declarative design in mind.
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -2,7 +2,6 @@
 
 [![CI](https://github.com/takeshishimada/Lockman/workflows/CI/badge.svg)](https://github.com/takeshishimada/Lockman/actions?query=workflow%3ACI)
 [![Swift 5.9](https://img.shields.io/badge/swift-5.9-ED523F.svg?style=flat)](https://swift.org/download/)
-[![@takeshishimada](https://img.shields.io/badge/contact-@takeshishimada-1DA1F2.svg?style=flat&logo=twitter)](https://twitter.com/takeshishimada)
 
 フィードバックファーストなアプローチで、応答性、透明性、宣言的設計を重視したアクション排他制御ライブラリ
 


### PR DESCRIPTION
## Summary
Remove incorrect Twitter contact badge from README files.

## Changes
- Removed `@takeshishimada` Twitter contact badge from both README.md and README_ja.md
- The badge does not belong to the repository owner

## Result
- Clean badge row with only CI and Swift version badges

🤖 Generated with [Claude Code](https://claude.ai/code)