### PR TITLE
docs: remove redundant library description from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [![CI](https://github.com/takeshishimada/Lockman/workflows/CI/badge.svg)](https://github.com/takeshishimada/Lockman/actions?query=workflow%3ACI)
 [![Swift 5.9](https://img.shields.io/badge/swift-5.9-ED523F.svg?style=flat)](https://swift.org/download/)
-[![@takeshishimada](https://img.shields.io/badge/contact-@takeshishimada-1DA1F2.svg?style=flat&logo=twitter)](https://twitter.com/takeshishimada)
 
 A library for building action exclusive control with feedback-first approach, with responsiveness, transparency, and declarative design in mind.
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CI](https://github.com/takeshishimada/Lockman/workflows/CI/badge.svg)](https://github.com/takeshishimada/Lockman/actions?query=workflow%3ACI)
 [![Swift 5.9](https://img.shields.io/badge/swift-5.9-ED523F.svg?style=flat)](https://swift.org/download/)
 
-A library for building action exclusive control with feedback-first approach, with responsiveness, transparency, and declarative design in mind.
+Lockman is a Swift library that solves concurrent action control issues in The Composable Architecture (TCA) applications, with responsiveness, transparency, and declarative design in mind.
 
 * [Design Philosophy](#design-philosophy)
 * [Overview](#overview)
@@ -31,8 +31,6 @@ Traditional UI development has solved problems by simply prohibiting simultaneou
 Users expect some form of feedback even when pressing buttons simultaneously. It's crucial to clearly separate immediate response at the UI layer from appropriate mutual exclusion control at the business logic layer.
 
 ## Overview
-
-Lockman is a Swift library that solves concurrent action control issues in The Composable Architecture (TCA) applications.
 
 Lockman provides the following control strategies to address common problems in app development:
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -2,7 +2,6 @@
 
 [![CI](https://github.com/takeshishimada/Lockman/workflows/CI/badge.svg)](https://github.com/takeshishimada/Lockman/actions?query=workflow%3ACI)
 [![Swift 5.9](https://img.shields.io/badge/swift-5.9-ED523F.svg?style=flat)](https://swift.org/download/)
-[![@takeshishimada](https://img.shields.io/badge/contact-@takeshishimada-1DA1F2.svg?style=flat&logo=twitter)](https://twitter.com/takeshishimada)
 
 フィードバックファーストなアプローチで、応答性、透明性、宣言的設計を重視したアクション排他制御ライブラリ
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -3,7 +3,7 @@
 [![CI](https://github.com/takeshishimada/Lockman/workflows/CI/badge.svg)](https://github.com/takeshishimada/Lockman/actions?query=workflow%3ACI)
 [![Swift 5.9](https://img.shields.io/badge/swift-5.9-ED523F.svg?style=flat)](https://swift.org/download/)
 
-フィードバックファーストなアプローチで、応答性、透明性、宣言的設計を重視したアクション排他制御ライブラリ
+LockmanはThe Composable Architecture（TCA）アプリケーションにおける並行アクションの制御問題を解決するSwiftライブラリです。応答性、透明性、宣言的設計を重視しています。
 
 * [設計思想](#設計思想)
 * [概要](#概要)
@@ -31,8 +31,6 @@ WWDC18「Designing Fluid Interfaces」では、優れたインターフェース
 ユーザーは押下可能なボタンに対して、同時押しの場合でも何らかのフィードバックを期待します。UI層での即座の応答と、ビジネスロジック層での適切な排他制御を明確に分離することが重要です。
 
 ## 概要
-
-LockmanはThe Composable Architecture（TCA）アプリケーションにおける並行アクションの制御問題を解決するSwiftライブラリです。
 
 Lockmanは以下の制御戦略を提供し、実際のアプリ開発で頻繁に発生する問題に対処します：
 


### PR DESCRIPTION
## Summary
- Removed redundant library description that appeared in both the header and Overview sections
- Consolidated into a single, more specific description at the top of the README
- This improves readability by eliminating unnecessary repetition

## Test plan
- [x] Verify README renders correctly in GitHub
- [x] Ensure all sections flow naturally after the change
- [x] Confirm no broken links or formatting issues

🤖 Generated with [Claude Code](https://claude.ai/code)