### PR TITLE
Remove unimplemented extractMetadata from LockmanDynamicCondition macro

### DIFF
--- a/Sources/LockmanComposable/LockmanComposableMacros.swift
+++ b/Sources/LockmanComposable/LockmanComposableMacros.swift
@@ -263,7 +263,6 @@ public macro LockmanCompositeStrategy<S1: LockmanStrategy, S2: LockmanStrategy, 
 /// Apply this macro to an enum declaration to automatically generate:
 /// - Protocol conformance to `LockmanDynamicConditionAction`
 /// - `actionName` property that returns the enum case name as a String
-/// - `extractMetadata()` method that extracts enum associated values as metadata
 /// - `lockmanInfo` property with default condition (always success)
 /// - Default `strategyId` implementation is provided by the protocol
 ///
@@ -327,7 +326,7 @@ public macro LockmanCompositeStrategy<S1: LockmanStrategy, S2: LockmanStrategy, 
 /// }
 /// ```
 @attached(extension, conformances: LockmanDynamicConditionAction)
-@attached(member, names: named(actionName), named(extractMetadata), named(lockmanInfo))
+@attached(member, names: named(actionName), named(lockmanInfo))
 public macro LockmanDynamicCondition() = #externalMacro(
   module: "LockmanMacros",
   type: "LockmanDynamicConditionMacro"


### PR DESCRIPTION
## Summary
- Remove references to the unimplemented `extractMetadata` method from the `@LockmanDynamicCondition` macro

## Details
The `extractMetadata` method was documented in the macro but never actually implemented. This PR removes:
- The documentation comment mentioning `extractMetadata()` 
- The `extractMetadata` name from the `@attached(member, names:)` declaration

## Impact
- No breaking changes - the method was never generated or used
- Cleans up the documentation to match the actual implementation

## Note
This is the same fix as #19 but applied to the `docs/add-docc-documentation` branch to ensure consistency across branches.

🤖 Generated with [Claude Code](https://claude.ai/code)