### PR TITLE
ci: pin swift-macro-compatibility-check to v1.0.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,7 +149,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Run Swift Macro Compatibility Check
-        uses: Matejkob/swift-macro-compatibility-check@v1
+        uses: Matejkob/swift-macro-compatibility-check@v1.0.0
         with:
           run-tests: false
           major-versions-only: true


### PR DESCRIPTION
## Summary
- Pin Matejkob/swift-macro-compatibility-check action to v1.0.0 for stability

## Changes
- Updated the action version from `@v1` to `@v1.0.0` in ci.yml

## Rationale
Using a specific version tag ensures CI workflow stability and prevents unexpected changes from newer versions.

🤖 Generated with [Claude Code](https://claude.ai/code)