### PR TITLE
docs: clarify PR guidelines with detailed label usage

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,23 +17,47 @@ Develop a library to implement exclusive control of user actions in application 
 
 ## Pull Request
 - Commit messages must follow Semantic Commit Message rules
-- Apply appropriate labels
+- Apply appropriate labels based on the type of change and affected modules
 - Assign yourself as the assignee
 - Direct commits to main and develop branches are prohibited - all changes must be made through Pull Requests
 
-## Label Guidelines
-In addition to GitHub standard labels, use the following custom labels:
+### PR Title Format
+PR titles should follow the semantic commit format:
+- `feat:` New features
+- `fix:` Bug fixes
+- `docs:` Documentation changes
+- `style:` Code style changes (formatting, missing semicolons, etc.)
+- `refactor:` Code refactoring
+- `perf:` Performance improvements
+- `test:` Test additions or updates
+- `chore:` Maintenance tasks (updating dependencies, etc.)
+- `ci:` CI/CD configuration changes
 
-### Change Types
-- breaking change: Backward-incompatible changes
-- performance: Performance improvements
-- refactor: Code refactoring
-- test: Test additions/modifications
+### Required Labels
+Every PR must have at least one label from each applicable category:
 
-### Module-Specific
-- core: LockmanCore module related
-- composable: LockmanComposable module related
-- macro: Macro implementation related
+1. **Change Type** (required):
+   - `enhancement`: New features or improvements
+   - `bug`: Bug fixes
+   - `documentation`: Documentation updates
+   - `refactor`: Code refactoring
+   - `test`: Test-related changes
+   - `performance`: Performance optimizations
+   - `breaking change`: Changes that break backward compatibility
+
+2. **Module** (if applicable):
+   - `core`: Changes to LockmanCore module
+   - `composable`: Changes to LockmanComposable module
+   - `macro`: Changes to macro implementations
+
+3. **Additional Labels** (optional):
+   - `good first issue`: Suitable for newcomers
+   - `help wanted`: Requesting additional help
+   - `question`: Needs clarification
+   - `duplicate`: Duplicate of existing issue/PR
+   - `invalid`: Invalid issue/PR
+   - `wontfix`: Will not be addressed
+
 
 ## Testing
 Use the following commands to run tests:


### PR DESCRIPTION
## Summary
- Clarify PR guidelines in CLAUDE.md based on actual repository labels
- Add comprehensive PR creation rules for better contributor guidance

## Changes
- Added PR title format section with semantic commit prefixes
- Documented required and optional label categories:
  - Change Type labels (required)
  - Module labels (when applicable)
  - Additional labels (optional)
- Removed duplicate "Label Guidelines" section that was redundant
- Based all guidelines on actual labels retrieved from the repository

## Label Usage
Following the new guidelines:
- **Change Type**: `documentation` (Documentation updates)
- **Module**: Not applicable (affects project-wide documentation)

🤖 Generated with [Claude Code](https://claude.ai/code)