### PR TITLE
docs: add PR creation command instructions to enforce assignee rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,18 @@ Develop a library to implement exclusive control of user actions in application 
   4. Create a Pull Request for review
 - Always work on feature branches (e.g., feat/xxx, fix/xxx, refactor/xxx)
 
+### PR Creation Command
+When creating a PR, use the following command format:
+```bash
+gh pr create \
+  --title "type: description" \
+  --assignee @me \
+  --body "PR body content"
+```
+- Always include `--assignee @me` to assign yourself
+- The `--title` should follow the semantic commit format
+- The `--body` should include Summary, Changes, and Test plan sections
+
 ### PR Title Format
 PR titles should follow the semantic commit format:
 - `feat:` New features


### PR DESCRIPTION
## Summary
- Add explicit PR creation command format to ensure assignees are always set
- Resolve issue where PRs were being created without assignees despite the rule in claude.md

## Changes
- Added "PR Creation Command" section with:
  - Complete `gh pr create` command format
  - Required `--assignee @me` flag
  - Instructions for title and body formatting
- Positioned after Git Branch Protection Rules for logical flow

## Test plan
- [x] Verify that this PR itself has an assignee set
- [ ] Confirm that future PRs created by Claude Code will have assignees

🤖 Generated with [Claude Code](https://claude.ai/code)