### PR TITLE
docs: add PR label mapping instructions to enforce proper labeling

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,63 @@ Develop a library to implement exclusive control of user actions in application 
   4. Create a Pull Request for review
 - Always work on feature branches (e.g., feat/xxx, fix/xxx, refactor/xxx)
 
+### PR Creation Command
+When creating a PR, use the following command format:
+```bash
+gh pr create \
+  --title "type: description" \
+  --assignee @me \
+  --label "label1,label2" \
+  --body "PR body content"
+```
+- Always include `--assignee @me` to assign yourself
+- The `--title` should follow the semantic commit format
+- The `--body` should include Summary, Changes, and Test plan sections
+- Use `--label` to add appropriate labels based on the mappings below
+
+### Automatic Label Mapping
+Apply labels based on the PR title prefix:
+
+**Change Type Labels (required):**
+- `feat:` → `enhancement`
+- `fix:` → `bug`
+- `docs:` → `documentation`
+- `refactor:` → `refactor`
+- `test:` → `test`
+- `perf:` → `performance`
+- `chore:` → `enhancement`
+- `ci:` → `enhancement`
+- `breaking:` or `!:` → `breaking change`
+
+**Module Labels (add if changes affect specific modules):**
+- Changes in `Sources/LockmanCore/` → `core`
+- Changes in `Sources/LockmanComposable/` → `composable`
+- Changes in `Sources/LockmanMacros/` → `macro`
+
+**Example Commands:**
+```bash
+# Documentation change
+gh pr create \
+  --title "docs: update README" \
+  --assignee @me \
+  --label "documentation" \
+  --body "..."
+
+# Feature affecting LockmanCore
+gh pr create \
+  --title "feat: add new locking strategy" \
+  --assignee @me \
+  --label "enhancement,core" \
+  --body "..."
+
+# Refactoring with breaking changes
+gh pr create \
+  --title "refactor!: restructure API" \
+  --assignee @me \
+  --label "refactor,breaking change" \
+  --body "..."
+```
+
 ### PR Title Format
 PR titles should follow the semantic commit format:
 - `feat:` New features


### PR DESCRIPTION
## Summary
- Add explicit instructions for proper PR labeling to ensure all PRs have required labels
- Resolve issue where PRs were being created without labels

## Changes
- Added "Automatic Label Mapping" section with:
  - Mapping from PR title prefixes to GitHub labels
  - Module-specific label guidelines
  - Complete example commands for common scenarios
- Updated PR creation command to include `--label` option
- Clarified that labels should be added based on both change type and affected modules

## Test plan
- [x] Verify that this PR itself has the correct label (`documentation`)
- [x] Confirm that the label mapping matches existing repository labels
- [ ] Future PRs created by Claude Code will include appropriate labels

🤖 Generated with [Claude Code](https://claude.ai/code)