### PR TITLE
docs: fix test commands in claude.md to use correct scheme

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,6 +132,9 @@ Every PR must have at least one label from each applicable category:
 ## Testing
 Use the following commands to run tests:
 ```bash
-make XCODEBUILD_ARGUMENT="test" CONFIG=Debug PLATFORM="IOS" WORKSPACE=.github/package.xcworkspace xcodebuild
-make XCODEBUILD_ARGUMENT="test" CONFIG=Debug PLATFORM="MACOS" WORKSPACE=.github/package.xcworkspace xcodebuild
+# iOS tests
+xcodebuild test -configuration Debug -scheme "Lockman-Package" -destination "platform=iOS Simulator,name=iPhone 16" -workspace .github/package.xcworkspace
+
+# macOS tests  
+xcodebuild test -configuration Debug -scheme "Lockman-Package" -destination "platform=macOS" -workspace .github/package.xcworkspace
 ```


### PR DESCRIPTION
## Summary
- Fix test commands that were failing due to incorrect scheme name
- Update commands to work with current project configuration

## Changes
- Replaced make commands with direct xcodebuild commands
- Changed scheme from "LockmanComposable" to "Lockman-Package" 
- Simplified test commands for both iOS and macOS platforms
- Verified both commands execute successfully

## Test plan
- [x] Run iOS test command: `xcodebuild test -configuration Debug -scheme "Lockman-Package" -destination "platform=iOS Simulator,name=iPhone 16" -workspace .github/package.xcworkspace`
- [x] Run macOS test command: `xcodebuild test -configuration Debug -scheme "Lockman-Package" -destination "platform=macOS" -workspace .github/package.xcworkspace`
- [x] Both tests pass successfully

🤖 Generated with [Claude Code](https://claude.ai/code)