### PR TITLE
fix: resolve test compilation warnings for Swift 6 compatibility

### DIFF
--- a/Tests/LockmanCoreTests/DynamicConditionStrategy/LockmanDynamicConditionStrategyTests.swift
+++ b/Tests/LockmanCoreTests/DynamicConditionStrategy/LockmanDynamicConditionStrategyTests.swift
@@ -3,7 +3,7 @@ import XCTest
 @testable import LockmanCore
 
 // Helper class for thread-safe mutable state in tests
-private final class Atomic<Value> {
+private final class Atomic<Value>: @unchecked Sendable {
   private var _value: Value
   private let lock = NSLock()
   


### PR DESCRIPTION
## Summary
- Fix compilation warnings in test code related to Swift 6 strict concurrency checking
- Make test helper classes and functions compatible with Sendable requirements

## Changes
- Added `@unchecked Sendable` conformance to `Atomic` class in tests
  - The class is already thread-safe with NSLock, so this is safe
- Fixed MainActor closure capture warnings by:
  - Adding `Sendable` constraint to generic parameter in `onMainActor` helper
  - Marking closures as `@Sendable`
- Converted local functions to `@Sendable` closures to avoid capture warnings
- All changes are in test code only, no production code changes

## Test plan
- [x] All affected tests pass
- [x] No compilation warnings in test code
- [x] Tests maintain their original functionality

🤖 Generated with [Claude Code](https://claude.ai/code)