### PR TITLE
fix: sync internal Logger state when enabling logging through Lockman.debug

### DIFF
--- a/Sources/LockmanCore/Debug/LockmanLogger.swift
+++ b/Sources/LockmanCore/Debug/LockmanLogger.swift
@@ -20,7 +20,13 @@ public final class LockmanLogger: @unchecked Sendable {
   /// Public accessor for logging state
   public var isEnabled: Bool {
     get { _isEnabled.withCriticalRegion { $0 } }
-    set { _isEnabled.withCriticalRegion { $0 = newValue } }
+    set { 
+      _isEnabled.withCriticalRegion { $0 = newValue }
+      // Also update the internal Logger state
+      Task { @MainActor in
+        Logger.shared.isEnabled = newValue
+      }
+    }
   }
 
   // MARK: - Initialization

--- a/Tests/LockmanCoreTests/Debug/LockmanLoggerTests.swift
+++ b/Tests/LockmanCoreTests/Debug/LockmanLoggerTests.swift
@@ -1,0 +1,98 @@
+import XCTest
+@testable @_spi(Logging) import LockmanCore
+
+final class LockmanLoggerTests: XCTestCase {
+  
+  func testLoggerEnablement() async throws {
+    // Given
+    let logger = LockmanLogger.shared
+    
+    // When: Enable logging
+    logger.isEnabled = true
+    
+    // Wait for async task to complete
+    try await Task.sleep(nanoseconds: 100_000_000) // 0.1 seconds
+    
+    // Then: Both loggers should be enabled
+    await MainActor.run {
+      XCTAssertTrue(logger.isEnabled, "LockmanLogger should be enabled")
+      XCTAssertTrue(Logger.shared.isEnabled, "Internal Logger should also be enabled")
+    }
+    
+    // When: Disable logging
+    logger.isEnabled = false
+    
+    // Wait for async task to complete
+    try await Task.sleep(nanoseconds: 100_000_000) // 0.1 seconds
+    
+    // Then: Both loggers should be disabled
+    await MainActor.run {
+      XCTAssertFalse(logger.isEnabled, "LockmanLogger should be disabled")
+      XCTAssertFalse(Logger.shared.isEnabled, "Internal Logger should also be disabled")
+    }
+  }
+  
+  func testLogOutput() async throws {
+    // Given
+    let logger = LockmanLogger.shared
+    
+    // Clear any existing logs
+    await MainActor.run {
+      Logger.shared.clear()
+    }
+    
+    // When: Enable logging and log a message
+    logger.isEnabled = true
+    try await Task.sleep(nanoseconds: 100_000_000) // 0.1 seconds
+    
+    // Create a test lock info
+    struct TestInfo: LockmanInfo {
+      var actionId: String { "testAction" }
+      var uniqueId: UUID { UUID() }
+      var debugDescription: String { "TestInfo(actionId: \(actionId))" }
+    }
+    
+    let info = TestInfo()
+    logger.logCanLock(
+      result: LockmanResult.success,
+      strategy: "TestStrategy",
+      boundaryId: "testBoundary",
+      info: info
+    )
+    
+    // Wait for async logging to complete
+    try await Task.sleep(nanoseconds: 200_000_000) // 0.2 seconds
+    
+    // Then: Check if log was recorded
+    await MainActor.run {
+      let logs = Logger.shared.logs
+      XCTAssertFalse(logs.isEmpty, "Logs should not be empty")
+      
+      if let lastLog = logs.last {
+        XCTAssertTrue(lastLog.contains("✅"), "Log should contain success emoji")
+        XCTAssertTrue(lastLog.contains("TestStrategy"), "Log should contain strategy name")
+        XCTAssertTrue(lastLog.contains("testBoundary"), "Log should contain boundary ID")
+        XCTAssertTrue(lastLog.contains("testAction"), "Log should contain action ID")
+      }
+    }
+    
+    // Cleanup
+    logger.isEnabled = false
+  }
+  
+  func testDebugAPI() async throws {
+    // Test the public API
+    Lockman.debug.isLoggingEnabled = true
+    
+    // Wait for async task to complete
+    try await Task.sleep(nanoseconds: 100_000_000) // 0.1 seconds
+    
+    await MainActor.run {
+      XCTAssertTrue(LockmanLogger.shared.isEnabled)
+      XCTAssertTrue(Logger.shared.isEnabled)
+    }
+    
+    // Cleanup
+    Lockman.debug.isLoggingEnabled = false
+  }
+}


### PR DESCRIPTION
## Summary
- Fixed issue where `Lockman.debug.isLoggingEnabled = true` didn't produce any log output
- Root cause: Internal `Logger.shared.isEnabled` was not synchronized with `LockmanLogger.shared.isEnabled`

## Changes
### Bug Fix
- Modified `LockmanLogger.isEnabled` setter to also update `Logger.shared.isEnabled`
- Uses async Task to update MainActor-isolated Logger state

### Tests Added
- `testLoggerEnablement`: Verifies both loggers are synchronized when enabled/disabled
- `testLogOutput`: Confirms actual log messages are recorded when logging is enabled
- `testDebugAPI`: Tests the public API `Lockman.debug.isLoggingEnabled`

## Test plan
- [x] Added comprehensive unit tests for logger state synchronization
- [x] All tests pass successfully
- [x] Verified log output appears when `Lockman.debug.isLoggingEnabled = true`

## Before Fix
```swift
Lockman.debug.isLoggingEnabled = true
// No log output appeared even though logging was "enabled"
```

## After Fix
```swift
Lockman.debug.isLoggingEnabled = true
// Logs now appear correctly:
// ✅ [Lockman] canLock succeeded - Strategy: SingleExecution, BoundaryId: main, Info: ...
```

🤖 Generated with [Claude Code](https://claude.ai/code)