### PR TITLE
fix\!: change blocksSameAction default value to true

### DIFF
--- a/Sources/LockmanComposable/LockmanComposableMacros.swift
+++ b/Sources/LockmanComposable/LockmanComposableMacros.swift
@@ -76,9 +76,9 @@ public macro LockmanSingleExecution() = #externalMacro(module: "LockmanMacros", 
 ///     var lockmanInfo: LockmanPriorityBasedInfo {
 ///       switch self {
 ///       case .highPriorityTask:
-///         return .init(priority: 100, perBoundary: false, blocksSameAction: false)
+///         return .init(priority: 100, perBoundary: false, blocksSameAction: true)
 ///       case .lowPriorityTask:
-///         return .init(priority: 10, perBoundary: false, blocksSameAction: false)
+///         return .init(priority: 10, perBoundary: false, blocksSameAction: true)
 ///       }
 ///     }
 ///   }

--- a/Sources/LockmanCore/Strategies/PriorityBasedStrategy/LockmanPriorityBasedInfo.swift
+++ b/Sources/LockmanCore/Strategies/PriorityBasedStrategy/LockmanPriorityBasedInfo.swift
@@ -70,7 +70,7 @@ public struct LockmanPriorityBasedInfo: LockmanInfo, Sendable, Equatable {
   /// `actionId` from being locked, regardless of priority levels. This is useful
   /// for operations that must be unique per action type.
   ///
-  /// When set to `false` (default), actions with the same `actionId` follow the
+  /// When set to `false`, actions with the same `actionId` follow the
   /// normal priority rules and can coexist based on their priority levels.
   ///
   /// ## Use Cases
@@ -104,7 +104,7 @@ public struct LockmanPriorityBasedInfo: LockmanInfo, Sendable, Equatable {
   /// - Parameters:
   ///   - actionId: A unique identifier for the action
   ///   - priority: The priority level and concurrency behavior for this action
-  ///   - blocksSameAction: Whether to block other actions with the same actionId (default: false)
+  ///   - blocksSameAction: Whether to block other actions with the same actionId (default: true)
   ///
   /// ## Design Note
   /// The `uniqueId` is automatically generated to ensure each instance has
@@ -113,7 +113,7 @@ public struct LockmanPriorityBasedInfo: LockmanInfo, Sendable, Equatable {
   public init(
     actionId: LockmanActionId,
     priority: Priority,
-    blocksSameAction: Bool = false
+    blocksSameAction: Bool = true
   ) {
     self.actionId = actionId
     self.uniqueId = UUID()

--- a/Tests/LockmanCoreTests/LockmanEdgeCaseTests.swift
+++ b/Tests/LockmanCoreTests/LockmanEdgeCaseTests.swift
@@ -116,9 +116,9 @@ final class LockmanEdgeCaseTests: XCTestCase {
     let strategy  = LockmanPriorityBasedStrategy()
     let boundaryId = "priority-test"
 
-    let noneInfo1 = LockmanPriorityBasedInfo(actionId: "none-action", priority: .none)
-    let noneInfo2 = LockmanPriorityBasedInfo(actionId: "none-action", priority: .none)
-    let highInfo = LockmanPriorityBasedInfo(actionId: "none-action", priority: .high(.exclusive))
+    let noneInfo1 = LockmanPriorityBasedInfo(actionId: "none-action", priority: .none, blocksSameAction: false)
+    let noneInfo2 = LockmanPriorityBasedInfo(actionId: "none-action", priority: .none, blocksSameAction: false)
+    let highInfo = LockmanPriorityBasedInfo(actionId: "none-action", priority: .high(.exclusive), blocksSameAction: false)
 
     // First none priority should succeed
     XCTAssertEqual(strategy.canLock(id: boundaryId, info: noneInfo1), .success)

--- a/Tests/LockmanCoreTests/PriorityBasedTests/LockmanPriorityBasedInfoTests.swift
+++ b/Tests/LockmanCoreTests/PriorityBasedTests/LockmanPriorityBasedInfoTests.swift
@@ -23,23 +23,23 @@ private struct TestBoundaryId: LockmanBoundaryId {
 
 /// Factory for creating test info instances with clear intent
 private enum TestInfoFactory {
-  static func none(_ actionId: String = "noneAction", blocksSameAction: Bool = false) -> LockmanPriorityBasedInfo {
+  static func none(_ actionId: String = "noneAction", blocksSameAction: Bool = true) -> LockmanPriorityBasedInfo {
     LockmanPriorityBasedInfo(actionId: actionId, priority: .none, blocksSameAction: blocksSameAction)
   }
 
-  static func lowExclusive(_ actionId: String = "lowExclusive", blocksSameAction: Bool = false) -> LockmanPriorityBasedInfo {
+  static func lowExclusive(_ actionId: String = "lowExclusive", blocksSameAction: Bool = true) -> LockmanPriorityBasedInfo {
     LockmanPriorityBasedInfo(actionId: actionId, priority: .low(.exclusive), blocksSameAction: blocksSameAction)
   }
 
-  static func lowReplaceable(_ actionId: String = "lowReplaceable", blocksSameAction: Bool = false) -> LockmanPriorityBasedInfo {
+  static func lowReplaceable(_ actionId: String = "lowReplaceable", blocksSameAction: Bool = true) -> LockmanPriorityBasedInfo {
     LockmanPriorityBasedInfo(actionId: actionId, priority: .low(.replaceable), blocksSameAction: blocksSameAction)
   }
 
-  static func highExclusive(_ actionId: String = "highExclusive", blocksSameAction: Bool = false) -> LockmanPriorityBasedInfo {
+  static func highExclusive(_ actionId: String = "highExclusive", blocksSameAction: Bool = true) -> LockmanPriorityBasedInfo {
     LockmanPriorityBasedInfo(actionId: actionId, priority: .high(.exclusive), blocksSameAction: blocksSameAction)
   }
 
-  static func highReplaceable(_ actionId: String = "highReplaceable", blocksSameAction: Bool = false) -> LockmanPriorityBasedInfo {
+  static func highReplaceable(_ actionId: String = "highReplaceable", blocksSameAction: Bool = true) -> LockmanPriorityBasedInfo {
     LockmanPriorityBasedInfo(actionId: actionId, priority: .high(.replaceable), blocksSameAction: blocksSameAction)
   }
 }
@@ -63,7 +63,7 @@ final class LockmanPriorityBasedInfoTests: XCTestCase {
     for (info, expectedPriority) in testCases {
       XCTAssertEqual(info.actionId, actionId)
       XCTAssertEqual(info.priority, expectedPriority)
-      XCTAssertFalse(info.blocksSameAction) // Default value
+      XCTAssertTrue(info.blocksSameAction) // Default value
     }
   }
 
@@ -72,7 +72,7 @@ final class LockmanPriorityBasedInfoTests: XCTestCase {
 
     // Test default value
     let info1 = LockmanPriorityBasedInfo(actionId: actionId, priority: .high(.exclusive))
-    XCTAssertFalse(info1.blocksSameAction)
+    XCTAssertTrue(info1.blocksSameAction)
 
     // Test explicit false
     let info2 = LockmanPriorityBasedInfo(actionId: actionId, priority: .high(.exclusive), blocksSameAction: false)

--- a/Tests/LockmanCoreTests/PriorityBasedTests/LockmanPriorityBasedStrategyTests.swift
+++ b/Tests/LockmanCoreTests/PriorityBasedTests/LockmanPriorityBasedStrategyTests.swift
@@ -31,23 +31,23 @@ private extension TestBoundaryId {
 
 /// Factory for creating priority-based test info
 private enum TestInfoFactory {
-  static func none(_ actionId: String = "noneAction", blocksSameAction: Bool = false) -> LockmanPriorityBasedInfo {
+  static func none(_ actionId: String = "noneAction", blocksSameAction: Bool = true) -> LockmanPriorityBasedInfo {
     LockmanPriorityBasedInfo(actionId: actionId, priority: .none, blocksSameAction: blocksSameAction)
   }
 
-  static func lowExclusive(_ actionId: String = "lowExclusive", blocksSameAction: Bool = false) -> LockmanPriorityBasedInfo {
+  static func lowExclusive(_ actionId: String = "lowExclusive", blocksSameAction: Bool = true) -> LockmanPriorityBasedInfo {
     LockmanPriorityBasedInfo(actionId: actionId, priority: .low(.exclusive), blocksSameAction: blocksSameAction)
   }
 
-  static func lowReplaceable(_ actionId: String = "lowReplaceable", blocksSameAction: Bool = false) -> LockmanPriorityBasedInfo {
+  static func lowReplaceable(_ actionId: String = "lowReplaceable", blocksSameAction: Bool = true) -> LockmanPriorityBasedInfo {
     LockmanPriorityBasedInfo(actionId: actionId, priority: .low(.replaceable), blocksSameAction: blocksSameAction)
   }
 
-  static func highExclusive(_ actionId: String = "highExclusive", blocksSameAction: Bool = false) -> LockmanPriorityBasedInfo {
+  static func highExclusive(_ actionId: String = "highExclusive", blocksSameAction: Bool = true) -> LockmanPriorityBasedInfo {
     LockmanPriorityBasedInfo(actionId: actionId, priority: .high(.exclusive), blocksSameAction: blocksSameAction)
   }
 
-  static func highReplaceable(_ actionId: String = "highReplaceable", blocksSameAction: Bool = false) -> LockmanPriorityBasedInfo {
+  static func highReplaceable(_ actionId: String = "highReplaceable", blocksSameAction: Bool = true) -> LockmanPriorityBasedInfo {
     LockmanPriorityBasedInfo(actionId: actionId, priority: .high(.replaceable), blocksSameAction: blocksSameAction)
   }
 }


### PR DESCRIPTION
## Summary
- Changed the default value of `blocksSameAction` parameter from `false` to `true` in `LockmanPriorityBasedInfo`
- This provides safer default behavior by preventing multiple instances of the same action from running concurrently

## Changes
- Updated default parameter value in `LockmanPriorityBasedInfo` initializer from `false` to `true`
- Updated parameter documentation to reflect new default
- Updated test factory methods in both test files to use new default
- Fixed `testNonePriorityBehaviorWithConflicts` test that relied on old default behavior by explicitly setting `blocksSameAction: false`
- Updated macro example documentation to show `blocksSameAction: true`

## Breaking Change
⚠️ **BREAKING CHANGE**: The default value of `blocksSameAction` has changed from `false` to `true`.

Existing code that relies on the old default behavior will need to explicitly set `blocksSameAction: false` to maintain the same behavior.

```swift
// Before (implicit false)
let info = LockmanPriorityBasedInfo(actionId: "search", priority: .high(.replaceable))

// After (if you need the old behavior)
let info = LockmanPriorityBasedInfo(actionId: "search", priority: .high(.replaceable), blocksSameAction: false)
```

## Test Plan
- [x] All existing tests pass
- [x] Updated test factory methods to reflect new default
- [x] Fixed tests that depended on old default behavior

🤖 Generated with [Claude Code](https://claude.ai/code)