### PR TITLE
docs: add code formatting rule to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,11 @@ Develop a library to implement exclusive control of user actions in application 
 - Documentation is provided through SwiftDoc comments in source code and DocC documentation
 - Update documentation when changing source code
 
+## Code Formatting
+- Run `make format` before committing changes to ensure consistent code style
+- This command uses swift-format to format all Swift files in the project
+- Code formatting is required for all PRs
+
 ## Pull Request
 - Commit messages must follow Semantic Commit Message rules
 - Apply appropriate labels based on the type of change and affected modules


### PR DESCRIPTION
## Summary
- Add code formatting requirement to CLAUDE.md documentation
- Require `make format` to be run before committing changes
- Ensure consistent code style across all PRs

## Changes
- Added "Code Formatting" section to CLAUDE.md
- Documented the requirement to run `make format` before commits
- Specified that code formatting is required for all PRs

## Test plan
- [x] Documentation change only - no code changes to test
- [x] Verified that `make format` command exists in Makefile

🤖 Generated with [Claude Code](https://claude.ai/code)