### PR TITLE
feat: add Swift DocC Plugin v1.0.0

### DIFF
--- a/Lockman.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Lockman.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "0f0ad5c938d7de6a6ebaea0db46c6aa723bde6f2191467e8ba83404bf304985e",
+  "originHash" : "07e448a1109c07996d108a1e0c911f8c17d6290e1041e274b30cea59123992b0",
   "pins" : [
     {
       "identity" : "combine-schedulers",
@@ -8,24 +8,6 @@
       "state" : {
         "revision" : "5928286acce13def418ec36d05a001a9641086f2",
         "version" : "1.0.3"
-      }
-    },
-    {
-      "identity" : "octokit.swift",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/nerdishbynature/octokit.swift",
-      "state" : {
-        "revision" : "cd108b387782d8509e64e298cf4800dc47fc40ae",
-        "version" : "0.14.0"
-      }
-    },
-    {
-      "identity" : "requestkit",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/nerdishbynature/RequestKit.git",
-      "state" : {
-        "revision" : "e4d905fed938807e36d87f28375f88b7c1c26840",
-        "version" : "3.3.0"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "2a26391f52cca4262f708750a488c4d96ad5636d7c801f31f37add41d968c490",
+  "originHash" : "c399713f89b677443152dd0d7461016a01ce22cf373da3035d66f9069f714c59",
   "pins" : [
     {
       "identity" : "combine-schedulers",
@@ -71,6 +71,15 @@
       "state" : {
         "revision" : "4c90d6b2b9bf0911af87b103bb40f41771891596",
         "version" : "1.9.2"
+      }
+    },
+    {
+      "identity" : "swift-docc-plugin",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-docc-plugin",
+      "state" : {
+        "revision" : "3303b164430d9a7055ba484c8ead67a52f7b74f6",
+        "version" : "1.0.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -27,6 +27,7 @@ let package = Package(
     .package(url: "https://github.com/swiftlang/swift-syntax", "509.0.0"..<"602.0.0"),
     .package(url: "https://github.com/pointfreeco/swift-macro-testing", from: "0.2.0"),
     .package(url: "https://github.com/apple/swift-collections.git", from: "1.1.4"),
+    .package(url: "https://github.com/swiftlang/swift-docc-plugin", exact: "1.0.0"),
   ],
   targets: [
     // Core target without TCA dependency

--- a/Package@swift-6.0.swift
+++ b/Package@swift-6.0.swift
@@ -27,6 +27,7 @@ let package = Package(
     .package(url: "https://github.com/swiftlang/swift-syntax", "509.0.0"..<"602.0.0"),
     .package(url: "https://github.com/pointfreeco/swift-macro-testing", from: "0.2.0"),
     .package(url: "https://github.com/apple/swift-collections.git", from: "1.1.4"),
+    .package(url: "https://github.com/swiftlang/swift-docc-plugin", exact: "1.0.0"),
   ],
   targets: [
     // Core target without TCA dependency


### PR DESCRIPTION
## Summary
Add Swift DocC Plugin v1.0.0 to enable documentation generation capabilities for the Lockman library.

## Changes
- Add Swift DocC Plugin v1.0.0 dependency to Package.swift
- Add Swift DocC Plugin v1.0.0 dependency to Package@swift-6.0.swift
- Update Package.resolved files with new dependency

## Test plan
- [x] Build succeeds with `swift build`
- [x] DocC plugin is properly integrated and available
- [x] Code formatting applied with `make format`

🤖 Generated with [Claude Code](https://claude.ai/code)