### PR TITLE
fix: update GitHub Actions workflows to use Xcode 16.2

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -17,8 +17,8 @@ jobs:
   build:
     runs-on: macos-14
     steps:
-      - name: Select Xcode 16.0
-        run: sudo xcode-select -s /Applications/Xcode_16.0.app
+      - name: Select Xcode 16.2
+        run: sudo xcode-select -s /Applications/Xcode_16.2.app
 
       - name: Checkout Package
         uses: actions/checkout@v4

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -20,8 +20,8 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
       
-      - name: Select Xcode 16.0
-        run: sudo xcode-select -s /Applications/Xcode_16.0.app
+      - name: Select Xcode 16.2
+        run: sudo xcode-select -s /Applications/Xcode_16.2.app
       
       - name: Install swift-format
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,8 +28,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       
-      - name: Select Xcode 16.0
-        run: sudo xcode-select -s /Applications/Xcode_16.0.app
+      - name: Select Xcode 16.2
+        run: sudo xcode-select -s /Applications/Xcode_16.2.app
       
       - name: Build for release
         run: swift build -c release


### PR DESCRIPTION
## Summary
- Fix GitHub Actions workflow failures by updating Xcode version from 16.0 to 16.2
- Affects three workflow files: `format.yml`, `release.yml`, and `documentation.yml`
- Resolves CI/CD pipeline failures due to unavailable Xcode 16.0 on macOS-14 runners

## Changes
- **format.yml**: Updated Xcode selection from 16.0 to 16.2
- **release.yml**: Updated Xcode selection from 16.0 to 16.2  
- **documentation.yml**: Updated Xcode selection from 16.0 to 16.2

## Root Cause
According to [GitHub's runner-images documentation](https://github.com/actions/runner-images/blob/main/images/macos/macos-14-Readme.md), Xcode 16.0 is not available on macOS-14 runners. The available Xcode 16.x versions are:
- Xcode 16.2 (latest available)
- Xcode 16.1

## Test plan
- [x] Verified available Xcode versions on macOS-14 runners via GitHub documentation
- [x] Updated all three affected workflow files consistently
- [ ] CI workflows should now pass without Xcode selection errors

## Related Issue
Fixes the workflow failure seen in: https://github.com/takeshishimada/Lockman/actions/runs/15823691944/job/44598555056

🤖 Generated with [Claude Code](https://claude.ai/code)