### PR TITLE
docs: fix missing parameter documentation in DocC

### DIFF
--- a/Sources/Lockman/Composable/ReduceWithLock.swift
+++ b/Sources/Lockman/Composable/ReduceWithLock.swift
@@ -382,7 +382,10 @@ extension ReduceWithLock {
   ///   - lockAction: LockmanAction providing lock information and strategy type
   ///   - cancelID: Unique identifier for effect cancellation and lock boundary
   ///   - lockCondition: Optional action-level condition that supplements the reducer-level condition
-  ///   - fileID, filePath, line, column: Source location for debugging (auto-populated)
+  ///   - fileID: Source file identifier for debugging (auto-populated)
+  ///   - filePath: Source file path for debugging (auto-populated)
+  ///   - line: Source line number for debugging (auto-populated)
+  ///   - column: Source column number for debugging (auto-populated)
   /// - Returns: Effect that executes with appropriate locking based on all conditions
   public func withLock<B: LockmanBoundaryId>(
     state: State,
@@ -471,7 +474,10 @@ extension ReduceWithLock {
   ///   - lockAction: LockmanAction providing lock information and strategy type
   ///   - cancelID: Unique identifier for effect cancellation and lock boundary
   ///   - lockCondition: Optional action-level condition that supplements the reducer-level condition
-  ///   - fileID, filePath, line, column: Source location for debugging (auto-populated)
+  ///   - fileID: Source file identifier for debugging (auto-populated)
+  ///   - filePath: Source file path for debugging (auto-populated)
+  ///   - line: Source line number for debugging (auto-populated)
+  ///   - column: Source column number for debugging (auto-populated)
   /// - Returns: Effect that executes with appropriate locking based on all conditions
   public func withLock<B: LockmanBoundaryId, A: LockmanAction>(
     state: State,

--- a/Sources/Lockman/Core/Strategies/Core/LockmanStrategyContainer.swift
+++ b/Sources/Lockman/Core/Strategies/Core/LockmanStrategyContainer.swift
@@ -225,7 +225,7 @@ public final class LockmanStrategyContainer: @unchecked Sendable {
   ///
   /// - Parameters:
   ///   - id: The strategy identifier to look up
-  ///   - infoType: The expected `LockmanInfo` type (for type inference)
+  ///   - expecting: The expected `LockmanInfo` type (for type inference)
   /// - Returns: An `AnyLockmanStrategy<I>` wrapping the registered strategy instance
   /// - Throws: `LockmanError.strategyNotRegistered` if no strategy with this ID is registered
   ///


### PR DESCRIPTION
## Summary
- Fixed DocC documentation warnings for missing parameter documentation
- Resolved parameter name mismatch in documentation

## Changes
- Split combined parameter documentation in `ReduceWithLock.swift` for `fileID`, `filePath`, `line`, and `column` parameters
- Fixed parameter name mismatch in `LockmanStrategyContainer.swift` (changed `infoType` to `expecting` to match actual parameter name)

## Test plan
- [x] Verified documentation builds without warnings
- [x] Confirmed parameter names match function signatures

🤖 Generated with [Claude Code](https://claude.ai/code)