### PR TITLE
ci: update GitHub Actions runners to macOS-15

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: macos-14
+    runs-on: macos-15
     steps:
       - name: Select Xcode 16.2
         run: sudo xcode-select -s /Applications/Xcode_16.2.app

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   swift_format:
     name: swift-format
-    runs-on: macos-14
+    runs-on: macos-15
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
   build-and-test:
     name: Build and Test
     needs: validate-release
-    runs-on: macos-14
+    runs-on: macos-15
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- GitHub ActionsのランナーをmacOS-14からmacOS-15に更新

## Changes
- `documentation.yml`: macOS-15に更新（DocCプラグインの互換性向上のため）
- `format.yml`: macOS-15に更新（一貫性のため）
- `release.yml`: macOS-15に更新（一貫性のため）

## Test plan
- [ ] GitHub Actionsワークフローが正常に実行されることを確認
- [ ] documentation.ymlのDocC生成が成功することを確認
- [ ] format.ymlのswift-formatが正常に動作することを確認
- [ ] release.ymlのビルドとテストが成功することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)