### PR TITLE
fix: exclude 0.1.0 tag from documentation generation

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -37,7 +37,7 @@ jobs:
           rm -rf docs-out/main;
           git tag -l --sort=-v:refname | grep -e "\d\+\.\d\+.0" | tail -n +6 | xargs -I {} rm -rf {};
 
-          for tag in $(echo "main"; git tag -l --sort=-v:refname | grep -e "\d\+\.\d\+.0" | head -6);
+          for tag in $(echo "main"; git tag -l --sort=-v:refname | grep -e "\d\+\.\d\+.0" | grep -v "^0\.1\.0$" | head -6);
           do
             if [ -d "docs-out/$tag/data/documentation/lockman" ] 
             then 


### PR DESCRIPTION
## Summary
- Exclude 0.1.0 tag from documentation generation to prevent build failures

## Problem
The 0.1.0 tag doesn't have swift-docc-plugin in its Package.swift, causing the documentation workflow to fail with:
```
error: Unknown subcommand or plugin name 'generate-documentation'
```

## Solution
Add a grep filter to exclude the 0.1.0 tag from the documentation generation process.

## Changes
- Added `grep -v "^0\.1\.0$"` to filter out 0.1.0 from the tag list

## Test plan
- [x] Verify the grep filter correctly excludes 0.1.0
- [ ] Documentation workflow should run without errors
- [ ] Only 0.2.0 and future tags will be processed

🤖 Generated with [Claude Code](https://claude.ai/code)