### PR TITLE
chore: update .editorconfig to align with .swift-format settings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -2,36 +2,41 @@
 # https://editorconfig.org
 root = true
 
-# 全ファイル共通設定
+# Default settings for all files
 [*]
 charset = utf-8
 end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
 
-# Swift/Objective-C ファイル
+# Swift files - aligned with .swift-format settings
 [*.{swift,h,m,mm}]
 indent_style = space
 indent_size = 2
 tab_width = 2
-max_line_length = 120
+max_line_length = 100  # Aligned with .swift-format lineLength
 
-# 設定ファイル
+# Configuration files
 [*.{yml,yaml,json}]
 indent_style = space
 indent_size = 2
 
-# Ruby系ファイル (CocoaPods, Fastlane等)
+# Ruby files (CocoaPods, Fastlane, etc.)
 [{Podfile,Fastfile,Matchfile,*.rb}]
 indent_style = space
 indent_size = 2
 
-# Markdown (trailing whitespace保持)
+# Markdown (preserve trailing whitespace for line breaks)
 [*.md]
 trim_trailing_whitespace = false
 max_line_length = off
 
-# シェルスクリプト
+# Shell scripts
 [*.{sh,bash}]
 indent_style = space
 indent_size = 2
+
+# Makefile (requires tabs)
+[{Makefile,*.mk}]
+indent_style = tab
+indent_size = 4


### PR DESCRIPTION
## Summary
- Updated .editorconfig to match .swift-format configuration
- Improved consistency between editor and formatter settings

## Changes
- Changed `max_line_length` from 120 to 100 for Swift files to match `.swift-format` lineLength setting
- Updated comments from Japanese to English for better international collaboration
- Added Makefile section with proper tab settings (indent_style = tab)
- Improved clarity and consistency of section comments

## Context
This ensures that editors respect the same line length limit as our swift-format configuration, preventing formatting conflicts and improving code consistency.

## Test plan
- [x] Verified that .editorconfig max_line_length matches .swift-format lineLength
- [x] Confirmed all section comments are clear and in English
- [x] Added missing Makefile configuration for proper tab handling

🤖 Generated with [Claude Code](https://claude.ai/code)