### PR TITLE
feat: add ConcurrencyLimited strategy for managing concurrent executions

### DIFF
--- a/Sources/Lockman/Core/Errors/LockmanConcurrencyLimitedError.swift
+++ b/Sources/Lockman/Core/Errors/LockmanConcurrencyLimitedError.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+/// Errors specific to concurrency-limited locking.
+public enum LockmanConcurrencyLimitedError: LockmanError {
+  /// The concurrency limit has been reached.
+  case concurrencyLimitReached(concurrencyId: String, limit: Int, current: Int)
+
+  public var errorDescription: String? {
+    switch self {
+    case let .concurrencyLimitReached(concurrencyId, limit, current):
+      return "Concurrency limit reached for '\(concurrencyId)': \(current)/\(limit)"
+    }
+  }
+
+  public var failureReason: String? {
+    switch self {
+    case .concurrencyLimitReached:
+      return
+        "Cannot execute action because the maximum number of concurrent executions has been reached"
+    }
+  }
+}

--- a/Sources/Lockman/Core/Lockman.swift
+++ b/Sources/Lockman/Core/Lockman.swift
@@ -102,6 +102,7 @@ public enum LockmanManager {
       try container.register(LockmanSingleExecutionStrategy.shared)
       try container.register(LockmanPriorityBasedStrategy.shared)
       try container.register(LockmanGroupCoordinationStrategy.shared)
+      try container.register(LockmanConcurrencyLimitedStrategy.shared)
     } catch {
       // Registration failure is silently ignored as it's handled gracefully
     }

--- a/Sources/Lockman/Core/Strategies/ConcurrencyLimitedStrategy/ConcurrencyGroup.swift
+++ b/Sources/Lockman/Core/Strategies/ConcurrencyLimitedStrategy/ConcurrencyGroup.swift
@@ -1,0 +1,7 @@
+/// Protocol for defining concurrency groups with their limits.
+public protocol ConcurrencyGroup: Sendable {
+  /// Unique identifier for this concurrency group.
+  var id: String { get }
+  /// The concurrency limit for this group.
+  var limit: ConcurrencyLimit { get }
+}

--- a/Sources/Lockman/Core/Strategies/ConcurrencyLimitedStrategy/ConcurrencyLimit.swift
+++ b/Sources/Lockman/Core/Strategies/ConcurrencyLimitedStrategy/ConcurrencyLimit.swift
@@ -1,0 +1,41 @@
+/// Represents the concurrency limit for an action.
+public enum ConcurrencyLimit: Sendable, Equatable {
+  /// No limit on concurrent executions.
+  case unlimited
+  /// Limited to a specific number of concurrent executions.
+  case limited(Int)
+
+  /// Returns the maximum number of concurrent executions allowed.
+  /// - Returns: `nil` for unlimited, or the specific limit value.
+  public var maxConcurrency: Int? {
+    switch self {
+    case .unlimited:
+      return nil
+    case .limited(let value):
+      return value
+    }
+  }
+
+  /// Checks if the current count exceeds the limit.
+  /// - Parameter currentCount: The current number of concurrent executions.
+  /// - Returns: `true` if the limit is exceeded, `false` otherwise.
+  public func isExceeded(currentCount: Int) -> Bool {
+    switch self {
+    case .unlimited:
+      return false
+    case .limited(let limit):
+      return currentCount >= limit
+    }
+  }
+}
+
+extension ConcurrencyLimit: CustomDebugStringConvertible {
+  public var debugDescription: String {
+    switch self {
+    case .unlimited:
+      return "unlimited"
+    case .limited(let value):
+      return "limited(\(value))"
+    }
+  }
+}

--- a/Sources/Lockman/Core/Strategies/ConcurrencyLimitedStrategy/LockmanConcurrencyLimitedAction.swift
+++ b/Sources/Lockman/Core/Strategies/ConcurrencyLimitedStrategy/LockmanConcurrencyLimitedAction.swift
@@ -1,0 +1,13 @@
+/// Protocol for actions that support concurrency limiting.
+public protocol LockmanConcurrencyLimitedAction: LockmanAction
+where I == LockmanConcurrencyLimitedInfo {
+  /// The name of the action (typically the case name).
+  var actionName: String { get }
+}
+
+extension LockmanConcurrencyLimitedAction {
+  /// The strategy identifier for concurrency-limited locking.
+  public var strategyId: LockmanStrategyId {
+    LockmanConcurrencyLimitedStrategy.makeStrategyId()
+  }
+}

--- a/Sources/Lockman/Core/Strategies/ConcurrencyLimitedStrategy/LockmanConcurrencyLimitedInfo.swift
+++ b/Sources/Lockman/Core/Strategies/ConcurrencyLimitedStrategy/LockmanConcurrencyLimitedInfo.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+/// Information for concurrency-limited locking.
+public struct LockmanConcurrencyLimitedInfo: LockmanInfo, Sendable, Equatable {
+  /// The action identifier.
+  public let actionId: LockmanActionId
+  /// The unique identifier for this lock info.
+  public let uniqueId: UUID
+  /// The concurrency group identifier.
+  public let concurrencyId: String
+  /// The concurrency limit.
+  public let limit: ConcurrencyLimit
+
+  /// Initialize with a predefined concurrency group.
+  /// - Parameters:
+  ///   - actionId: The action identifier.
+  ///   - group: The concurrency group containing id and limit.
+  public init(actionId: LockmanActionId, group: any ConcurrencyGroup) {
+    self.actionId = actionId
+    self.uniqueId = UUID()
+    self.concurrencyId = group.id
+    self.limit = group.limit
+  }
+
+  /// Initialize with a direct concurrency limit.
+  /// - Parameters:
+  ///   - actionId: The action identifier that also serves as the concurrency id.
+  ///   - limit: The concurrency limit.
+  public init(actionId: LockmanActionId, _ limit: ConcurrencyLimit) {
+    self.actionId = actionId
+    self.uniqueId = UUID()
+    self.concurrencyId = actionId
+    self.limit = limit
+  }
+}
+
+extension LockmanConcurrencyLimitedInfo: CustomDebugStringConvertible {
+  public var debugDescription: String {
+    "ConcurrencyLimitedInfo(actionId: \(actionId), concurrencyId: \(concurrencyId), limit: \(limit), uniqueId: \(uniqueId))"
+  }
+}

--- a/Sources/Lockman/Core/Strategies/ConcurrencyLimitedStrategy/LockmanConcurrencyLimitedStrategy.swift
+++ b/Sources/Lockman/Core/Strategies/ConcurrencyLimitedStrategy/LockmanConcurrencyLimitedStrategy.swift
@@ -1,0 +1,116 @@
+import Foundation
+
+/// Strategy that limits the number of concurrent executions per concurrency group.
+public final class LockmanConcurrencyLimitedStrategy: LockmanStrategy, @unchecked Sendable {
+  /// The type of lock info used by this strategy.
+  public typealias I = LockmanConcurrencyLimitedInfo
+
+  /// Shared instance of the strategy.
+  public static let shared = LockmanConcurrencyLimitedStrategy()
+
+  /// The strategy identifier.
+  public let strategyId: LockmanStrategyId
+
+  /// Creates the strategy identifier.
+  public static func makeStrategyId() -> LockmanStrategyId {
+    LockmanStrategyId(name: "concurrencyLimited")
+  }
+
+  /// Thread-safe state management.
+  private let state = LockmanState<LockmanConcurrencyLimitedInfo>()
+
+  /// Private initializer to ensure singleton usage.
+  private init() {
+    self.strategyId = Self.makeStrategyId()
+  }
+
+  /// Checks if a lock can be acquired based on concurrency limits.
+  public func canLock<B: LockmanBoundaryId>(
+    id: B,
+    info: LockmanConcurrencyLimitedInfo
+  ) -> LockmanResult {
+    let currentLocks = state.currents(id: id).filter { existingInfo in
+      existingInfo.concurrencyId == info.concurrencyId
+    }
+
+    let currentCount = currentLocks.count
+
+    let result: LockmanResult
+    var failureReason: String?
+
+    if info.limit.isExceeded(currentCount: currentCount) {
+      if case .limited(let limit) = info.limit {
+        result = .failure(
+          LockmanConcurrencyLimitedError.concurrencyLimitReached(
+            concurrencyId: info.concurrencyId,
+            limit: limit,
+            current: currentCount
+          )
+        )
+        failureReason =
+          "Concurrency limit exceeded for '\(info.concurrencyId)': \(currentCount)/\(limit)"
+      } else {
+        result = .success
+      }
+    } else {
+      result = .success
+    }
+
+    // Log the result
+    LockmanLogger.shared.logCanLock(
+      result: result,
+      strategy: "ConcurrencyLimited",
+      boundaryId: String(describing: id),
+      info: info,
+      reason: failureReason
+    )
+
+    return result
+  }
+
+  /// Adds the lock to the state.
+  public func lock<B: LockmanBoundaryId>(
+    id: B,
+    info: LockmanConcurrencyLimitedInfo
+  ) {
+    state.add(id: id, info: info)
+  }
+
+  /// Removes the lock from the state.
+  public func unlock<B: LockmanBoundaryId>(
+    id: B,
+    info: LockmanConcurrencyLimitedInfo
+  ) {
+    state.remove(id: id, info: info)
+  }
+
+  /// Removes all locks for a specific boundary.
+  public func cleanUp<B: LockmanBoundaryId>(
+    id: B
+  ) {
+    // Get all locks for this boundary and remove them one by one
+    let currentLocks = state.currents(id: id)
+    for info in currentLocks {
+      state.remove(id: id, info: info)
+    }
+  }
+
+  /// Removes all locks across all boundaries.
+  public func cleanUp() {
+    state.removeAll()
+  }
+
+  /// Returns current locks information for debugging purposes.
+  public func getCurrentLocks() -> [AnyLockmanBoundaryId: [any LockmanInfo]] {
+    var result: [AnyLockmanBoundaryId: [any LockmanInfo]] = [:]
+
+    // Get all boundaries and their locks from the state
+    let allLocks = state.getAllLocks()
+
+    for (boundaryId, lockInfos) in allLocks {
+      result[boundaryId] = lockInfos.map { $0 as any LockmanInfo }
+    }
+
+    return result
+  }
+}

--- a/Sources/LockmanMacros/LockmanConcurrencyLimitedMacro.swift
+++ b/Sources/LockmanMacros/LockmanConcurrencyLimitedMacro.swift
@@ -1,0 +1,98 @@
+import SwiftDiagnostics
+import SwiftSyntax
+import SwiftSyntaxBuilder
+import SwiftSyntaxMacros
+
+#if !canImport(SwiftSyntax600)
+  import SwiftSyntaxMacroExpansion
+#endif
+
+/// A macro that adds conformance to `LockmanConcurrencyLimitedAction` by generating
+/// an empty extension for the target type.
+///
+/// When this macro is attached to a type declaration, it produces:
+/// ```swift
+/// extension <TypeName>: LockmanConcurrencyLimitedAction {
+/// }
+/// ```
+///
+/// - Note: Member generation (such as `actionName` property) is provided by the
+///         corresponding `MemberMacro` implementation.
+public struct LockmanConcurrencyLimitedMacro: ExtensionMacro {
+  /// Generates an extension declaration that makes the given type conform to
+  /// `LockmanConcurrencyLimitedAction`.
+  ///
+  /// - Parameters:
+  ///   - _: The attribute syntax node (unused).
+  ///   - _: The declaration group syntax node to which the attribute is attached (unused).
+  ///   - type: The `TypeSyntax` node representing the type to extend.
+  ///   - _: An array of `TypeSyntax` representing inherited protocols (unused).
+  ///   - _: The macro expansion context (unused).
+  /// - Returns: An array containing a single `ExtensionDeclSyntax` that declares
+  ///            conformance to `LockmanConcurrencyLimitedAction`.
+  /// - Throws: An error if constructing the `ExtensionDeclSyntax` fails.
+  public static func expansion(
+    of _: AttributeSyntax,
+    attachedTo _: some DeclGroupSyntax,
+    providingExtensionsOf type: some TypeSyntaxProtocol,
+    conformingTo _: [TypeSyntax],
+    in _: some MacroExpansionContext
+  ) throws -> [ExtensionDeclSyntax] {
+    let extensionDecl = try makeConformanceExtensionDecl(
+      for: type,
+      conformingTo: "LockmanConcurrencyLimitedAction"
+    )
+    return [extensionDecl]
+  }
+}
+
+extension LockmanConcurrencyLimitedMacro: MemberMacro {
+  /// Generates member declarations (e.g., `actionName` property) for the enum to which
+  /// this macro is attached.
+  ///
+  /// - Parameters:
+  ///   - node: The `AttributeSyntax` node that triggered member generation.
+  ///   - declaration: The `DeclGroupSyntax` node representing the declaration (expected to be an enum).
+  ///   - context: The macro expansion context used for diagnostics.
+  /// - Returns: An array of `DeclSyntax` containing the generated members. If the
+  ///            declaration is not an enum or has no cases, returns an empty array.
+  /// - Throws: An error if member generation fails.
+  public static func expansion(
+    of node: AttributeSyntax,
+    providingMembersOf declaration: some DeclGroupSyntax,
+    in context: some MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    guard
+      let enumDecl = extractEnumDecl(
+        name: "LockmanConcurrencyLimited",
+        from: declaration,
+        attribute: node,
+        in: context
+      )
+    else {
+      return []
+    }
+
+    return generateConcurrencyLimitedMembers(for: enumDecl)
+  }
+}
+
+// MARK: - Concurrency Limited Specific Member Generation
+
+/// Generates member declarations specific to LockmanConcurrencyLimited actions.
+/// Currently generates only the `actionName` property. Users must implement
+/// `lockmanInfo` themselves to specify the concurrency group or limit.
+///
+/// - Parameter enumDecl: The `EnumDeclSyntax` representing the enum to process.
+/// - Returns: An array of `DeclSyntax` nodes containing the generated member declarations.
+private func generateConcurrencyLimitedMembers(for enumDecl: EnumDeclSyntax) -> [DeclSyntax] {
+  var members: [DeclSyntax] = []
+
+  // Generate standard actionName property
+  members.append(contentsOf: generateActionNameMembers(for: enumDecl))
+
+  // Do NOT generate lockmanInfo - users must implement it themselves
+  // to specify the concurrency group or limit using the overloaded initializers
+
+  return members
+}

--- a/Sources/LockmanMacros/MacroPlugin.swift
+++ b/Sources/LockmanMacros/MacroPlugin.swift
@@ -35,5 +35,8 @@ struct LockmanMacroPlugin: CompilerPlugin {
 
     // Dynamic condition strategy macro
     LockmanDynamicConditionMacro.self,
+
+    // Concurrency limited strategy macro
+    LockmanConcurrencyLimitedMacro.self,
   ]
 }

--- a/Tests/LockmanCoreTests/ConcurrencyLimitedTests/LockmanConcurrencyLimitedActionTests.swift
+++ b/Tests/LockmanCoreTests/ConcurrencyLimitedTests/LockmanConcurrencyLimitedActionTests.swift
@@ -1,0 +1,222 @@
+import Foundation
+import XCTest
+
+@testable import Lockman
+
+// MARK: - Test Boundary Id
+
+private struct TestBoundaryId: LockmanBoundaryId {
+  let value: String
+
+  init(_ value: String) {
+    self.value = value
+  }
+
+  func hash(into hasher: inout Hasher) {
+    hasher.combine(value)
+  }
+
+  static func == (lhs: TestBoundaryId, rhs: TestBoundaryId) -> Bool {
+    lhs.value == rhs.value
+  }
+}
+
+// MARK: - Test Concurrency Group
+
+private enum TestConcurrencyGroup: ConcurrencyGroup {
+  case apiRequests
+  case fileOperations
+
+  var id: String {
+    switch self {
+    case .apiRequests: return "api_requests"
+    case .fileOperations: return "file_operations"
+    }
+  }
+
+  var limit: ConcurrencyLimit {
+    switch self {
+    case .apiRequests: return .limited(3)
+    case .fileOperations: return .limited(2)
+    }
+  }
+}
+
+// MARK: - Test Action
+
+private enum TestAction: LockmanConcurrencyLimitedAction {
+  case fetchUser(id: String)
+  case uploadFile(name: String)
+  case processData
+
+  var actionName: String {
+    switch self {
+    case .fetchUser: return "fetchUser"
+    case .uploadFile: return "uploadFile"
+    case .processData: return "processData"
+    }
+  }
+
+  var lockmanInfo: LockmanConcurrencyLimitedInfo {
+    switch self {
+    case .fetchUser:
+      return .init(actionId: actionName, group: TestConcurrencyGroup.apiRequests)
+    case .uploadFile:
+      return .init(actionId: actionName, group: TestConcurrencyGroup.fileOperations)
+    case .processData:
+      return .init(actionId: actionName, .limited(1))
+    }
+  }
+}
+
+// MARK: - LockmanConcurrencyLimitedAction Tests
+
+final class LockmanConcurrencyLimitedActionTests: XCTestCase {
+  // MARK: - Protocol Conformance Tests
+
+  func testActionNameProperty() {
+    XCTAssertEqual(TestAction.fetchUser(id: "123").actionName, "fetchUser")
+    XCTAssertEqual(TestAction.uploadFile(name: "test.txt").actionName, "uploadFile")
+    XCTAssertEqual(TestAction.processData.actionName, "processData")
+  }
+
+  func testLockmanInfoPropertyWithGroup() {
+    let fetchUserInfo = TestAction.fetchUser(id: "123").lockmanInfo
+    XCTAssertEqual(fetchUserInfo.actionId, "fetchUser")
+    XCTAssertEqual(fetchUserInfo.concurrencyId, "api_requests")
+    XCTAssertEqual(fetchUserInfo.limit, .limited(3))
+
+    let uploadFileInfo = TestAction.uploadFile(name: "test.txt").lockmanInfo
+    XCTAssertEqual(uploadFileInfo.actionId, "uploadFile")
+    XCTAssertEqual(uploadFileInfo.concurrencyId, "file_operations")
+    XCTAssertEqual(uploadFileInfo.limit, .limited(2))
+  }
+
+  func testLockmanInfoPropertyWithDirectLimit() {
+    let processDataInfo = TestAction.processData.lockmanInfo
+    XCTAssertEqual(processDataInfo.actionId, "processData")
+    XCTAssertEqual(processDataInfo.concurrencyId, "processData")
+    XCTAssertEqual(processDataInfo.limit, .limited(1))
+  }
+
+  func testStrategyIdProperty() {
+    let action = TestAction.fetchUser(id: "123")
+    let expectedId = LockmanConcurrencyLimitedStrategy.makeStrategyId()
+    XCTAssertEqual(action.strategyId, expectedId)
+  }
+
+  // MARK: - Different Action Cases Tests
+
+  func testDifferentActionsHaveDifferentActionNames() {
+    let actions: [TestAction] = [
+      .fetchUser(id: "1"),
+      .uploadFile(name: "file"),
+      .processData,
+    ]
+
+    let actionNames = actions.map { $0.actionName }
+    let uniqueNames = Set(actionNames)
+
+    XCTAssertEqual(actionNames.count, uniqueNames.count)
+  }
+
+  func testSameActionWithDifferentAssociatedValues() {
+    let action1 = TestAction.fetchUser(id: "123")
+    let action2 = TestAction.fetchUser(id: "456")
+
+    XCTAssertEqual(action1.actionName, action2.actionName)
+    XCTAssertEqual(action1.lockmanInfo.concurrencyId, action2.lockmanInfo.concurrencyId)
+    XCTAssertEqual(action1.lockmanInfo.limit, action2.lockmanInfo.limit)
+  }
+
+  // MARK: - Integration Tests
+
+  func testActionCanBeUsedWithStrategy() {
+    let strategy = LockmanConcurrencyLimitedStrategy.shared
+    let boundary = TestBoundaryId("test")
+    let action = TestAction.fetchUser(id: "123")
+    let info = action.lockmanInfo
+
+    // First lock should succeed
+    let result = strategy.canLock(id: boundary, info: info)
+    XCTAssertEqual(result, .success)
+
+    // Clean up
+    strategy.cleanUp(id: boundary)
+  }
+
+  func testMultipleActionsRespectConcurrencyLimits() {
+    let strategy = LockmanConcurrencyLimitedStrategy.shared
+    let boundary = TestBoundaryId("test")
+
+    // Process data has limit of 1
+    let action1 = TestAction.processData
+    let action2 = TestAction.processData
+
+    strategy.lock(id: boundary, info: action1.lockmanInfo)
+
+    // Second should fail
+    let result = strategy.canLock(id: boundary, info: action2.lockmanInfo)
+    XCTAssertLockFailure(result)
+
+    // Clean up
+    strategy.cleanUp(id: boundary)
+  }
+
+  // MARK: - Type Safety Tests
+
+  func testActionIsLockmanAction() {
+    let action: any LockmanAction = TestAction.fetchUser(id: "123")
+    // Cast to concrete type to access actionName
+    if let testAction = action as? TestAction {
+      XCTAssertEqual(testAction.actionName, "fetchUser")
+    } else {
+      XCTFail("Action should be TestAction")
+    }
+    XCTAssertNotNil(action.lockmanInfo)
+  }
+
+  func testActionInfoType() {
+    let action = TestAction.fetchUser(id: "123")
+    let info = action.lockmanInfo
+
+    // Verify the info type is correct
+    XCTAssertTrue(type(of: info) == LockmanConcurrencyLimitedInfo.self)
+  }
+}
+
+// MARK: - Test Action with Unlimited
+
+private enum UnlimitedTestAction: LockmanConcurrencyLimitedAction {
+  case refreshUI
+  case updateCache
+
+  var actionName: String {
+    switch self {
+    case .refreshUI: return "refreshUI"
+    case .updateCache: return "updateCache"
+    }
+  }
+
+  var lockmanInfo: LockmanConcurrencyLimitedInfo {
+    .init(actionId: actionName, .unlimited)
+  }
+}
+
+extension LockmanConcurrencyLimitedActionTests {
+  func testUnlimitedActions() {
+    let strategy = LockmanConcurrencyLimitedStrategy.shared
+    let boundary = TestBoundaryId("test")
+
+    // Lock many unlimited actions
+    for i in 0..<100 {
+      let action = i % 2 == 0 ? UnlimitedTestAction.refreshUI : UnlimitedTestAction.updateCache
+      let result = strategy.canLock(id: boundary, info: action.lockmanInfo)
+      XCTAssertEqual(result, .success)
+      strategy.lock(id: boundary, info: action.lockmanInfo)
+    }
+
+    // Clean up
+    strategy.cleanUp(id: boundary)
+  }
+}

--- a/Tests/LockmanCoreTests/ConcurrencyLimitedTests/LockmanConcurrencyLimitedInfoTests.swift
+++ b/Tests/LockmanCoreTests/ConcurrencyLimitedTests/LockmanConcurrencyLimitedInfoTests.swift
@@ -1,0 +1,166 @@
+import Foundation
+import XCTest
+
+@testable import Lockman
+
+// MARK: - Test Concurrency Group
+
+private enum TestConcurrencyGroup: ConcurrencyGroup {
+  case apiRequests
+  case fileOperations
+
+  var id: String {
+    switch self {
+    case .apiRequests: return "api_requests"
+    case .fileOperations: return "file_operations"
+    }
+  }
+
+  var limit: ConcurrencyLimit {
+    switch self {
+    case .apiRequests: return .limited(3)
+    case .fileOperations: return .limited(2)
+    }
+  }
+}
+
+// MARK: - LockmanConcurrencyLimitedInfo Tests
+
+final class LockmanConcurrencyLimitedInfoTests: XCTestCase {
+  // MARK: - Initialization Tests with Group
+
+  func testInitializationWithGroup() {
+    let group = TestConcurrencyGroup.apiRequests
+    let info = LockmanConcurrencyLimitedInfo(actionId: "testAction", group: group)
+
+    XCTAssertEqual(info.actionId, "testAction")
+    XCTAssertEqual(info.concurrencyId, "api_requests")
+    XCTAssertEqual(info.limit, .limited(3))
+    XCTAssertNotNil(info.uniqueId)
+  }
+
+  func testInitializationWithDifferentGroups() {
+    let info1 = LockmanConcurrencyLimitedInfo(
+      actionId: "action1", group: TestConcurrencyGroup.apiRequests)
+    let info2 = LockmanConcurrencyLimitedInfo(
+      actionId: "action2", group: TestConcurrencyGroup.fileOperations)
+
+    XCTAssertEqual(info1.concurrencyId, "api_requests")
+    XCTAssertEqual(info1.limit, .limited(3))
+
+    XCTAssertEqual(info2.concurrencyId, "file_operations")
+    XCTAssertEqual(info2.limit, .limited(2))
+  }
+
+  // MARK: - Initialization Tests with Direct Limit
+
+  func testInitializationWithDirectLimit() {
+    let info = LockmanConcurrencyLimitedInfo(actionId: "testAction", .limited(5))
+
+    XCTAssertEqual(info.actionId, "testAction")
+    XCTAssertEqual(info.concurrencyId, "testAction")  // actionId becomes concurrencyId
+    XCTAssertEqual(info.limit, .limited(5))
+    XCTAssertNotNil(info.uniqueId)
+  }
+
+  func testInitializationWithUnlimited() {
+    let info = LockmanConcurrencyLimitedInfo(actionId: "unlimitedAction", .unlimited)
+
+    XCTAssertEqual(info.actionId, "unlimitedAction")
+    XCTAssertEqual(info.concurrencyId, "unlimitedAction")
+    XCTAssertEqual(info.limit, .unlimited)
+    XCTAssertNotNil(info.uniqueId)
+  }
+
+  // MARK: - Equatable Tests
+
+  func testEqualityWithSameValues() {
+    let group = TestConcurrencyGroup.apiRequests
+
+    // Create two instances with same values but different UUIDs
+    let info1 = LockmanConcurrencyLimitedInfo(actionId: "action", group: group)
+    let info2 = LockmanConcurrencyLimitedInfo(actionId: "action", group: group)
+
+    // They should NOT be equal because uniqueIds are different
+    XCTAssertNotEqual(info1, info2)
+  }
+
+  func testInequalityWithDifferentActionIds() {
+    let group = TestConcurrencyGroup.apiRequests
+    let info1 = LockmanConcurrencyLimitedInfo(actionId: "action1", group: group)
+    let info2 = LockmanConcurrencyLimitedInfo(actionId: "action2", group: group)
+
+    XCTAssertNotEqual(info1, info2)
+  }
+
+  func testInequalityWithDifferentConcurrencyIds() {
+    let info1 = LockmanConcurrencyLimitedInfo(
+      actionId: "action", group: TestConcurrencyGroup.apiRequests)
+    let info2 = LockmanConcurrencyLimitedInfo(
+      actionId: "action", group: TestConcurrencyGroup.fileOperations)
+
+    XCTAssertNotEqual(info1, info2)
+  }
+
+  func testInequalityWithDifferentLimits() {
+    let info1 = LockmanConcurrencyLimitedInfo(actionId: "action", .limited(3))
+    let info2 = LockmanConcurrencyLimitedInfo(actionId: "action", .limited(5))
+
+    XCTAssertNotEqual(info1, info2)
+  }
+
+  func testInequalityWithDifferentUniqueIds() {
+    let group = TestConcurrencyGroup.apiRequests
+    let info1 = LockmanConcurrencyLimitedInfo(actionId: "action", group: group)
+    let info2 = LockmanConcurrencyLimitedInfo(actionId: "action", group: group)
+
+    // Different UUIDs
+    XCTAssertNotEqual(info1.uniqueId, info2.uniqueId)
+    XCTAssertNotEqual(info1, info2)
+  }
+
+  // MARK: - Debug Description Tests
+
+  func testDebugDescriptionWithGroup() {
+    let info = LockmanConcurrencyLimitedInfo(
+      actionId: "testAction", group: TestConcurrencyGroup.apiRequests)
+    let description = info.debugDescription
+
+    XCTAssertTrue(description.contains("ConcurrencyLimitedInfo"))
+    XCTAssertTrue(description.contains("actionId: testAction"))
+    XCTAssertTrue(description.contains("concurrencyId: api_requests"))
+    XCTAssertTrue(description.contains("limit: limited(3)"))
+    XCTAssertTrue(description.contains("uniqueId:"))
+  }
+
+  func testDebugDescriptionWithUnlimited() {
+    let info = LockmanConcurrencyLimitedInfo(actionId: "unlimitedAction", .unlimited)
+    let description = info.debugDescription
+
+    XCTAssertTrue(description.contains("ConcurrencyLimitedInfo"))
+    XCTAssertTrue(description.contains("actionId: unlimitedAction"))
+    XCTAssertTrue(description.contains("concurrencyId: unlimitedAction"))
+    XCTAssertTrue(description.contains("limit: unlimited"))
+  }
+
+  // MARK: - LockmanInfo Protocol Tests
+
+  func testConformsToLockmanInfo() {
+    let info = LockmanConcurrencyLimitedInfo(actionId: "test", .limited(1))
+
+    // Verify it can be used as LockmanInfo
+    let lockmanInfo: any LockmanInfo = info
+    XCTAssertEqual(lockmanInfo.actionId, "test")
+    XCTAssertNotNil(lockmanInfo.uniqueId)
+  }
+
+  func testSendable() {
+    // This test ensures the type is Sendable by using it in a concurrent context
+    let info = LockmanConcurrencyLimitedInfo(actionId: "test", .limited(1))
+
+    Task {
+      let capturedInfo = info
+      XCTAssertEqual(capturedInfo.actionId, "test")
+    }
+  }
+}

--- a/Tests/LockmanCoreTests/ConcurrencyLimitedTests/LockmanConcurrencyLimitedStrategyTests.swift
+++ b/Tests/LockmanCoreTests/ConcurrencyLimitedTests/LockmanConcurrencyLimitedStrategyTests.swift
@@ -1,0 +1,301 @@
+import Foundation
+import XCTest
+
+@testable import Lockman
+
+// MARK: - Test Helpers
+
+private struct TestBoundaryId: LockmanBoundaryId {
+  let value: String
+
+  init(_ value: String) {
+    self.value = value
+  }
+
+  func hash(into hasher: inout Hasher) {
+    hasher.combine(value)
+  }
+
+  static func == (lhs: TestBoundaryId, rhs: TestBoundaryId) -> Bool {
+    lhs.value == rhs.value
+  }
+}
+
+private enum TestConcurrencyGroup: ConcurrencyGroup {
+  case apiRequests
+  case fileOperations
+  case uiUpdates
+
+  var id: String {
+    switch self {
+    case .apiRequests: return "api_requests"
+    case .fileOperations: return "file_operations"
+    case .uiUpdates: return "ui_updates"
+    }
+  }
+
+  var limit: ConcurrencyLimit {
+    switch self {
+    case .apiRequests: return .limited(3)
+    case .fileOperations: return .limited(2)
+    case .uiUpdates: return .unlimited
+    }
+  }
+}
+
+// MARK: - LockmanConcurrencyLimitedStrategy Tests
+
+final class LockmanConcurrencyLimitedStrategyTests: XCTestCase {
+  // MARK: - Initialization Tests
+
+  func testSharedInstanceIsSingleton() {
+    let instance1 = LockmanConcurrencyLimitedStrategy.shared
+    let instance2 = LockmanConcurrencyLimitedStrategy.shared
+
+    XCTAssertTrue(instance1 === instance2)
+  }
+
+  func testMakeStrategyIdReturnsConsistentIdentifier() {
+    let id1 = LockmanConcurrencyLimitedStrategy.makeStrategyId()
+    let id2 = LockmanConcurrencyLimitedStrategy.makeStrategyId()
+
+    XCTAssertEqual(id1, id2)
+  }
+
+  func testInstanceStrategyIdMatchesMakeStrategyId() {
+    let strategy = LockmanConcurrencyLimitedStrategy.shared
+    let staticId = LockmanConcurrencyLimitedStrategy.makeStrategyId()
+
+    XCTAssertEqual(strategy.strategyId, staticId)
+  }
+
+  // MARK: - Basic Lock Behavior Tests with Groups
+
+  func testFirstLockSucceedsWithGroup() {
+    let strategy = LockmanConcurrencyLimitedStrategy.shared
+    let boundary = TestBoundaryId("test")
+    let info = LockmanConcurrencyLimitedInfo(
+      actionId: "action", group: TestConcurrencyGroup.apiRequests)
+
+    let result = strategy.canLock(id: boundary, info: info)
+    XCTAssertEqual(result, .success)
+
+    strategy.cleanUp(id: boundary)
+  }
+
+  func testMultipleLocksWithinLimitSucceed() {
+    let strategy = LockmanConcurrencyLimitedStrategy.shared
+    let boundary = TestBoundaryId("test")
+
+    // API requests allow 3 concurrent
+    let info1 = LockmanConcurrencyLimitedInfo(
+      actionId: "action1", group: TestConcurrencyGroup.apiRequests)
+    let info2 = LockmanConcurrencyLimitedInfo(
+      actionId: "action2", group: TestConcurrencyGroup.apiRequests)
+    let info3 = LockmanConcurrencyLimitedInfo(
+      actionId: "action3", group: TestConcurrencyGroup.apiRequests)
+
+    // All three should succeed
+    XCTAssertEqual(strategy.canLock(id: boundary, info: info1), .success)
+    strategy.lock(id: boundary, info: info1)
+
+    XCTAssertEqual(strategy.canLock(id: boundary, info: info2), .success)
+    strategy.lock(id: boundary, info: info2)
+
+    XCTAssertEqual(strategy.canLock(id: boundary, info: info3), .success)
+    strategy.lock(id: boundary, info: info3)
+
+    strategy.cleanUp(id: boundary)
+  }
+
+  func testLockFailsWhenLimitExceeded() {
+    let strategy = LockmanConcurrencyLimitedStrategy.shared
+    let boundary = TestBoundaryId("test")
+
+    // File operations allow 2 concurrent
+    let info1 = LockmanConcurrencyLimitedInfo(
+      actionId: "upload1", group: TestConcurrencyGroup.fileOperations)
+    let info2 = LockmanConcurrencyLimitedInfo(
+      actionId: "upload2", group: TestConcurrencyGroup.fileOperations)
+    let info3 = LockmanConcurrencyLimitedInfo(
+      actionId: "upload3", group: TestConcurrencyGroup.fileOperations)
+
+    // First two should succeed
+    XCTAssertEqual(strategy.canLock(id: boundary, info: info1), .success)
+    strategy.lock(id: boundary, info: info1)
+
+    XCTAssertEqual(strategy.canLock(id: boundary, info: info2), .success)
+    strategy.lock(id: boundary, info: info2)
+
+    // Third should fail
+    let result = strategy.canLock(id: boundary, info: info3)
+    XCTAssertLockFailure(result)
+
+    if case .failure(let error) = result,
+      let concurrencyError = error as? LockmanConcurrencyLimitedError
+    {
+      switch concurrencyError {
+      case .concurrencyLimitReached(let concurrencyId, let limit, let current):
+        XCTAssertEqual(concurrencyId, "file_operations")
+        XCTAssertEqual(limit, 2)
+        XCTAssertEqual(current, 2)
+      }
+    } else {
+      XCTFail("Expected LockmanConcurrencyLimitedError")
+    }
+
+    strategy.cleanUp(id: boundary)
+  }
+
+  func testUnlimitedGroupAllowsManyLocks() {
+    let strategy = LockmanConcurrencyLimitedStrategy.shared
+    let boundary = TestBoundaryId("test")
+
+    // UI updates are unlimited
+    for i in 0..<100 {
+      let info = LockmanConcurrencyLimitedInfo(
+        actionId: "ui\(i)", group: TestConcurrencyGroup.uiUpdates)
+      XCTAssertEqual(strategy.canLock(id: boundary, info: info), .success)
+      strategy.lock(id: boundary, info: info)
+    }
+
+    strategy.cleanUp(id: boundary)
+  }
+
+  // MARK: - Direct Limit Tests
+
+  func testDirectLimitedConfiguration() {
+    let strategy = LockmanConcurrencyLimitedStrategy.shared
+    let boundary = TestBoundaryId("test")
+
+    let info1 = LockmanConcurrencyLimitedInfo(actionId: "special1", .limited(1))
+    let info2 = LockmanConcurrencyLimitedInfo(actionId: "special1", .limited(1))
+
+    // First should succeed
+    XCTAssertEqual(strategy.canLock(id: boundary, info: info1), .success)
+    strategy.lock(id: boundary, info: info1)
+
+    // Second with same actionId should fail (limit is 1)
+    XCTAssertLockFailure(strategy.canLock(id: boundary, info: info2))
+
+    strategy.cleanUp(id: boundary)
+  }
+
+  func testDirectUnlimitedConfiguration() {
+    let strategy = LockmanConcurrencyLimitedStrategy.shared
+    let boundary = TestBoundaryId("test")
+
+    // Multiple locks with same actionId and unlimited
+    for _ in 0..<50 {
+      let info = LockmanConcurrencyLimitedInfo(actionId: "unlimited-action", .unlimited)
+      XCTAssertEqual(strategy.canLock(id: boundary, info: info), .success)
+      strategy.lock(id: boundary, info: info)
+    }
+
+    strategy.cleanUp(id: boundary)
+  }
+
+  // MARK: - Cross-Boundary Tests
+
+  func testDifferentBoundariesHaveIndependentLimits() {
+    let strategy = LockmanConcurrencyLimitedStrategy.shared
+    let boundary1 = TestBoundaryId("boundary1")
+    let boundary2 = TestBoundaryId("boundary2")
+
+    // File operations allow 2 concurrent per boundary
+    let info1 = LockmanConcurrencyLimitedInfo(
+      actionId: "upload1", group: TestConcurrencyGroup.fileOperations)
+    let info2 = LockmanConcurrencyLimitedInfo(
+      actionId: "upload2", group: TestConcurrencyGroup.fileOperations)
+    let info3 = LockmanConcurrencyLimitedInfo(
+      actionId: "upload3", group: TestConcurrencyGroup.fileOperations)
+
+    // Fill boundary1 to limit
+    strategy.lock(id: boundary1, info: info1)
+    strategy.lock(id: boundary1, info: info2)
+    XCTAssertLockFailure(strategy.canLock(id: boundary1, info: info3))
+
+    // boundary2 should still allow locks
+    XCTAssertEqual(strategy.canLock(id: boundary2, info: info1), .success)
+    strategy.lock(id: boundary2, info: info1)
+    XCTAssertEqual(strategy.canLock(id: boundary2, info: info2), .success)
+
+    strategy.cleanUp(id: boundary1)
+    strategy.cleanUp(id: boundary2)
+  }
+
+  // MARK: - Unlock Behavior Tests
+
+  func testUnlockFreesSlot() {
+    let strategy = LockmanConcurrencyLimitedStrategy.shared
+    let boundary = TestBoundaryId("test")
+
+    // File operations allow 2 concurrent
+    let info1 = LockmanConcurrencyLimitedInfo(
+      actionId: "upload1", group: TestConcurrencyGroup.fileOperations)
+    let info2 = LockmanConcurrencyLimitedInfo(
+      actionId: "upload2", group: TestConcurrencyGroup.fileOperations)
+    let info3 = LockmanConcurrencyLimitedInfo(
+      actionId: "upload3", group: TestConcurrencyGroup.fileOperations)
+
+    // Fill to limit
+    strategy.lock(id: boundary, info: info1)
+    strategy.lock(id: boundary, info: info2)
+    XCTAssertLockFailure(strategy.canLock(id: boundary, info: info3))
+
+    // Unlock one
+    strategy.unlock(id: boundary, info: info1)
+
+    // Now third should succeed
+    XCTAssertEqual(strategy.canLock(id: boundary, info: info3), .success)
+
+    strategy.cleanUp(id: boundary)
+  }
+
+  // MARK: - CleanUp Tests
+
+  func testCleanUpRemovesAllLocksForBoundary() {
+    let strategy = LockmanConcurrencyLimitedStrategy.shared
+    let boundary = TestBoundaryId("test")
+
+    // Add multiple locks
+    let info1 = LockmanConcurrencyLimitedInfo(
+      actionId: "action1", group: TestConcurrencyGroup.apiRequests)
+    let info2 = LockmanConcurrencyLimitedInfo(
+      actionId: "action2", group: TestConcurrencyGroup.apiRequests)
+
+    strategy.lock(id: boundary, info: info1)
+    strategy.lock(id: boundary, info: info2)
+
+    // Clean up
+    strategy.cleanUp(id: boundary)
+
+    // Should be able to lock again
+    XCTAssertEqual(strategy.canLock(id: boundary, info: info1), .success)
+    XCTAssertEqual(strategy.canLock(id: boundary, info: info2), .success)
+  }
+
+  // MARK: - GetCurrentLocks Tests
+
+  func testGetCurrentLocksReturnsCorrectLocks() {
+    let strategy = LockmanConcurrencyLimitedStrategy.shared
+    let boundary = TestBoundaryId("test")
+
+    let info1 = LockmanConcurrencyLimitedInfo(
+      actionId: "action1", group: TestConcurrencyGroup.apiRequests)
+    let info2 = LockmanConcurrencyLimitedInfo(
+      actionId: "action2", group: TestConcurrencyGroup.fileOperations)
+
+    strategy.lock(id: boundary, info: info1)
+    strategy.lock(id: boundary, info: info2)
+
+    let allLocks = strategy.getCurrentLocks()
+    let locks = allLocks[AnyLockmanBoundaryId(boundary)] ?? []
+    XCTAssertEqual(locks.count, 2)
+
+    let actionIds = locks.compactMap { ($0 as? LockmanConcurrencyLimitedInfo)?.actionId }.sorted()
+    XCTAssertEqual(actionIds, ["action1", "action2"])
+
+    strategy.cleanUp(id: boundary)
+  }
+}

--- a/Tests/LockmanMacrosTests/LockmanConcurrencyLimitedMacroTests.swift
+++ b/Tests/LockmanMacrosTests/LockmanConcurrencyLimitedMacroTests.swift
@@ -1,10 +1,10 @@
+#if canImport(LockmanMacros)
+import LockmanMacros
 import MacroTesting
 import SwiftSyntax
 import SwiftSyntaxBuilder
 import SwiftSyntaxMacros
 import XCTest
-
-@testable import LockmanMacros
 
 // MARK: - LockmanConcurrencyLimitedMacro Tests
 
@@ -389,3 +389,4 @@ final class LockmanConcurrencyLimitedMacroTests: XCTestCase {
     }
   }
 }
+#endif

--- a/Tests/LockmanMacrosTests/LockmanConcurrencyLimitedMacroTests.swift
+++ b/Tests/LockmanMacrosTests/LockmanConcurrencyLimitedMacroTests.swift
@@ -1,0 +1,391 @@
+import MacroTesting
+import SwiftSyntax
+import SwiftSyntaxBuilder
+import SwiftSyntaxMacros
+import XCTest
+
+@testable import LockmanMacros
+
+// MARK: - LockmanConcurrencyLimitedMacro Tests
+
+final class LockmanConcurrencyLimitedMacroTests: XCTestCase {
+  override func invokeTest() {
+    // Configure macro testing to not record and to show diffs
+    withMacroTesting(
+      record: false,
+      macros: [
+        "LockmanConcurrencyLimited": LockmanConcurrencyLimitedMacro.self
+      ]
+    ) {
+      super.invokeTest()
+    }
+  }
+
+  // MARK: - Basic Expansion Tests
+
+  func testBasicEnumExpansion() {
+    assertMacro {
+      """
+      @LockmanConcurrencyLimited
+      enum ViewAction {
+        case fetchUserProfile
+        case uploadFile
+      }
+      """
+    } expansion: {
+      """
+      enum ViewAction {
+        case fetchUserProfile
+        case uploadFile
+
+        internal var actionName: String {
+          switch self {
+          case .fetchUserProfile:
+            return "fetchUserProfile"
+          case .uploadFile:
+            return "uploadFile"
+          }
+        }
+      }
+
+      extension ViewAction: LockmanConcurrencyLimitedAction {
+      }
+      """
+    }
+  }
+
+  func testEnumWithAssociatedValues() {
+    assertMacro {
+      """
+      @LockmanConcurrencyLimited
+      enum ViewAction {
+        case fetchUserProfile(userId: String)
+        case uploadFile(name: String, size: Int)
+        case processData
+      }
+      """
+    } expansion: {
+      """
+      enum ViewAction {
+        case fetchUserProfile(userId: String)
+        case uploadFile(name: String, size: Int)
+        case processData
+
+        internal var actionName: String {
+          switch self {
+          case .fetchUserProfile(_):
+            return "fetchUserProfile"
+          case .uploadFile(_, _):
+            return "uploadFile"
+          case .processData:
+            return "processData"
+          }
+        }
+      }
+
+      extension ViewAction: LockmanConcurrencyLimitedAction {
+      }
+      """
+    }
+  }
+
+  // MARK: - Access Level Tests
+
+  func testPublicEnumExpansion() {
+    assertMacro {
+      """
+      @LockmanConcurrencyLimited
+      public enum ViewAction {
+        case fetchData
+        case saveData
+      }
+      """
+    } expansion: {
+      """
+      public enum ViewAction {
+        case fetchData
+        case saveData
+
+        public var actionName: String {
+          switch self {
+          case .fetchData:
+            return "fetchData"
+          case .saveData:
+            return "saveData"
+          }
+        }
+      }
+
+      extension ViewAction: LockmanConcurrencyLimitedAction {
+      }
+      """
+    }
+  }
+
+  func testInternalEnumExpansion() {
+    assertMacro {
+      """
+      @LockmanConcurrencyLimited
+      internal enum ViewAction {
+        case action1
+        case action2
+      }
+      """
+    } expansion: {
+      """
+      internal enum ViewAction {
+        case action1
+        case action2
+
+        internal var actionName: String {
+          switch self {
+          case .action1:
+            return "action1"
+          case .action2:
+            return "action2"
+          }
+        }
+      }
+
+      extension ViewAction: LockmanConcurrencyLimitedAction {
+      }
+      """
+    }
+  }
+
+  // MARK: - Edge Case Tests
+
+  func testEmptyEnum() {
+    assertMacro {
+      """
+      @LockmanConcurrencyLimited
+      enum EmptyAction {
+      }
+      """
+    } expansion: {
+      """
+      enum EmptyAction {
+      }
+
+      extension EmptyAction: LockmanConcurrencyLimitedAction {
+      }
+      """
+    }
+  }
+
+  func testSingleCaseEnum() {
+    assertMacro {
+      """
+      @LockmanConcurrencyLimited
+      enum SingleAction {
+        case onlyAction
+      }
+      """
+    } expansion: {
+      """
+      enum SingleAction {
+        case onlyAction
+
+        internal var actionName: String {
+          switch self {
+          case .onlyAction:
+            return "onlyAction"
+          }
+        }
+      }
+
+      extension SingleAction: LockmanConcurrencyLimitedAction {
+      }
+      """
+    }
+  }
+
+  func testComplexAssociatedValues() {
+    assertMacro {
+      """
+      @LockmanConcurrencyLimited
+      enum ComplexAction {
+        case simple
+        case withTuple((Int, String))
+        case withClosure(() -> Void)
+        case withOptional(String?)
+        case withMultiple(a: Int, b: String, c: Bool)
+      }
+      """
+    } expansion: {
+      """
+      enum ComplexAction {
+        case simple
+        case withTuple((Int, String))
+        case withClosure(() -> Void)
+        case withOptional(String?)
+        case withMultiple(a: Int, b: String, c: Bool)
+
+        internal var actionName: String {
+          switch self {
+          case .simple:
+            return "simple"
+          case .withTuple(_):
+            return "withTuple"
+          case .withClosure(_):
+            return "withClosure"
+          case .withOptional(_):
+            return "withOptional"
+          case .withMultiple(_, _, _):
+            return "withMultiple"
+          }
+        }
+      }
+
+      extension ComplexAction: LockmanConcurrencyLimitedAction {
+      }
+      """
+    }
+  }
+
+  // MARK: - Error Cases
+
+  func testMacroOnStruct() {
+    assertMacro {
+      """
+      @LockmanConcurrencyLimited
+      struct ViewAction {
+        let name: String
+      }
+      """
+    } diagnostics: {
+      """
+      @LockmanConcurrencyLimited
+      ┬─────────────────────────
+      ╰─ 🛑 @LockmanConcurrencyLimited can only be attached to an enum declaration.
+      struct ViewAction {
+        let name: String
+      }
+      """
+    }
+  }
+
+  func testMacroOnClass() {
+    assertMacro {
+      """
+      @LockmanConcurrencyLimited
+      class ViewAction {
+        var name: String = ""
+      }
+      """
+    } diagnostics: {
+      """
+      @LockmanConcurrencyLimited
+      ┬─────────────────────────
+      ╰─ 🛑 @LockmanConcurrencyLimited can only be attached to an enum declaration.
+      class ViewAction {
+        var name: String = ""
+      }
+      """
+    }
+  }
+
+  func testMacroOnProtocol() {
+    assertMacro {
+      """
+      @LockmanConcurrencyLimited
+      protocol ViewAction {
+        var name: String { get }
+      }
+      """
+    } diagnostics: {
+      """
+      @LockmanConcurrencyLimited
+      ┬─────────────────────────
+      ╰─ 🛑 @LockmanConcurrencyLimited can only be attached to an enum declaration.
+      protocol ViewAction {
+        var name: String { get }
+      }
+      """
+    }
+  }
+
+  // MARK: - Integration Tests
+
+  func testRealWorldExample() {
+    assertMacro {
+      """
+      @LockmanConcurrencyLimited
+      public enum FeatureAction {
+        case fetchUserProfile(userId: String)
+        case fetchUserPosts(userId: String, page: Int)
+        case uploadImage(data: Data, metadata: [String: Any])
+        case deletePost(postId: String)
+        case refreshFeed
+      }
+      """
+    } expansion: {
+      """
+      public enum FeatureAction {
+        case fetchUserProfile(userId: String)
+        case fetchUserPosts(userId: String, page: Int)
+        case uploadImage(data: Data, metadata: [String: Any])
+        case deletePost(postId: String)
+        case refreshFeed
+
+        public var actionName: String {
+          switch self {
+          case .fetchUserProfile(_):
+            return "fetchUserProfile"
+          case .fetchUserPosts(_, _):
+            return "fetchUserPosts"
+          case .uploadImage(_, _):
+            return "uploadImage"
+          case .deletePost(_):
+            return "deletePost"
+          case .refreshFeed:
+            return "refreshFeed"
+          }
+        }
+      }
+
+      extension FeatureAction: LockmanConcurrencyLimitedAction {
+      }
+      """
+    }
+  }
+
+  // MARK: - Multi-case Declaration Tests
+
+  func testMultipleCasesInOneDeclaration() {
+    assertMacro {
+      """
+      @LockmanConcurrencyLimited
+      enum Action {
+        case a, b, c
+        case d(Int), e(String)
+      }
+      """
+    } expansion: {
+      """
+      enum Action {
+        case a, b, c
+        case d(Int), e(String)
+
+        internal var actionName: String {
+          switch self {
+          case .a:
+            return "a"
+          case .b:
+            return "b"
+          case .c:
+            return "c"
+          case .d(_):
+            return "d"
+          case .e(_):
+            return "e"
+          }
+        }
+      }
+
+      extension Action: LockmanConcurrencyLimitedAction {
+      }
+      """
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Implements a new Lockman strategy that limits concurrent executions per concurrency group
- Actions are cancelled (not queued) when the concurrency limit is reached
- Supports both predefined groups and direct limit specification

## Changes
- **ConcurrencyLimit enum**: Provides `.unlimited` and `.limited(Int)` cases for explicit concurrency control
- **ConcurrencyGroup protocol**: Allows users to define their own concurrency groups with id and limit
- **LockmanConcurrencyLimitedStrategy**: Core strategy implementation that tracks and limits concurrent executions
- **LockmanConcurrencyLimitedInfo**: Lock info with overloaded initializers for flexibility
- **@LockmanConcurrencyLimited macro**: Generates required boilerplate code
- **Comprehensive test suite**: All components are thoroughly tested

## API Design
The strategy supports two usage patterns:

### 1. Using predefined ConcurrencyGroup
```swift
enum MyConcurrencyGroup: ConcurrencyGroup {
    case apiRequests
    case fileOperations
    
    var id: String { /* ... */ }
    var limit: ConcurrencyLimit { /* ... */ }
}

let info = LockmanConcurrencyLimitedInfo(
    actionId: "fetchUser",
    group: MyConcurrencyGroup.apiRequests
)
```

### 2. Using direct limit (actionId becomes concurrencyId)
```swift
let info = LockmanConcurrencyLimitedInfo(
    actionId: "specialOperation",
    .limited(1)
)
```

## Test plan
- [x] All unit tests pass
- [x] Code formatted with `make format`
- [x] Strategy integrates correctly with existing Lockman infrastructure
- [x] Thread-safe implementation verified
- [x] Macro generates correct code for all test cases

🤖 Generated with [Claude Code](https://claude.ai/code)