### PR TITLE
feat: add generic key support to LockmanState

### DIFF
--- a/Sources/Lockman/Core/Strategies/ConcurrencyLimitedStrategy/LockmanConcurrencyLimitedStrategy.swift
+++ b/Sources/Lockman/Core/Strategies/ConcurrencyLimitedStrategy/LockmanConcurrencyLimitedStrategy.swift
@@ -17,7 +17,10 @@ public final class LockmanConcurrencyLimitedStrategy: LockmanStrategy, @unchecke
   }
 
   /// Thread-safe state management.
-  private let state = LockmanState<LockmanConcurrencyLimitedInfo>()
+  /// Uses concurrencyId as the key for indexing locks.
+  private let state = LockmanState<LockmanConcurrencyLimitedInfo, String>(
+    keyExtractor: { $0.concurrencyId }
+  )
 
   /// Private initializer to ensure singleton usage.
   private init() {
@@ -29,11 +32,8 @@ public final class LockmanConcurrencyLimitedStrategy: LockmanStrategy, @unchecke
     id: B,
     info: LockmanConcurrencyLimitedInfo
   ) -> LockmanResult {
-    let currentLocks = state.currents(id: id).filter { existingInfo in
-      existingInfo.concurrencyId == info.concurrencyId
-    }
-
-    let currentCount = currentLocks.count
+    // Use the key-based query for efficient lookup
+    let currentCount = state.count(id: id, key: info.concurrencyId)
 
     let result: LockmanResult
     var failureReason: String?

--- a/Sources/Lockman/Core/Strategies/Core/LockmanState.swift
+++ b/Sources/Lockman/Core/Strategies/Core/LockmanState.swift
@@ -9,6 +9,13 @@ import OrderedCollections
 /// - Both key-based and index-based access patterns
 /// - Efficient insertion and removal operations
 ///
+/// ## Generic Key Support
+/// The container now supports any hashable key type, allowing strategies to define
+/// their own indexing scheme. For example:
+/// - SingleExecutionStrategy can use actionId as the key
+/// - ConcurrencyLimitedStrategy can use concurrencyId as the key
+/// - Custom strategies can define composite keys for complex grouping
+///
 /// ## Dependencies
 /// Requires `swift-collections` package:
 /// ```swift
@@ -19,39 +26,47 @@ import OrderedCollections
 /// - **Add**: O(1) - Direct ordered insertion with dual index update
 /// - **Remove by UUID**: O(1) - Direct key removal with dual index update
 /// - **Query by UUID**: O(1) - Direct key access
-/// - **Query by ActionId**: O(1) - Hash table lookup via action index
-/// - **Contains ActionId**: O(1) - Direct hash table check
-/// - **Count by ActionId**: O(1) - Direct count access via action index
-/// - **Currents by ActionId**: O(k) - Where k is the number of matching locks
+/// - **Query by Key**: O(1) - Hash table lookup via key index
+/// - **Contains Key**: O(1) - Direct hash table check
+/// - **Count by Key**: O(1) - Direct count access via key index
+/// - **Currents by Key**: O(k) - Where k is the number of matching locks
 /// - **All Currents**: O(k) - Where k is the total number of locks
 /// - **Ordered iteration**: O(k) - Natural order preservation
 /// - **Latest/Earliest access**: O(1) - Index-based access
-final class LockmanState<I: LockmanInfo>: Sendable {
+final class LockmanState<I: LockmanInfo, K: Hashable & Sendable>: Sendable {
   // MARK: - Private Properties
 
   /// Storage using OrderedDictionary for optimal performance and ordering
   private let storage = ManagedCriticalState<[AnyLockmanBoundaryId: OrderedDictionary<UUID, I>]>([:]
   )
 
-  /// Secondary index for O(1) actionId-based lookups.
-  /// This index dramatically improves performance for action-based queries,
+  /// Secondary index for O(1) key-based lookups.
+  /// This index dramatically improves performance for key-based queries,
   /// enabling constant-time contains() and count() operations.
-  /// Maps: BoundaryId -> ActionId -> Set of UUIDs
-  private let actionIndex = ManagedCriticalState<
-    [AnyLockmanBoundaryId: [LockmanActionId: Set<UUID>]]
+  /// Maps: BoundaryId -> Key -> Set of UUIDs
+  private let index = ManagedCriticalState<
+    [AnyLockmanBoundaryId: [K: Set<UUID>]]
   >([:])
+
+  /// Function to extract the key from lock info
+  private let keyExtractor: @Sendable (I) -> K
 
   // MARK: - Initialization
 
-  init() {}
+  /// Creates a new LockmanState with the specified key extraction function.
+  ///
+  /// - Parameter keyExtractor: Function that extracts the indexing key from lock info
+  init(keyExtractor: @escaping @Sendable (I) -> K) {
+    self.keyExtractor = keyExtractor
+  }
 
   // MARK: - Lock Management
 
   /// Adds new lock info with automatic ordering preservation.
   ///
   /// OrderedDictionary automatically maintains insertion order while providing
-  /// O(1) key-based access performance. This method also updates the action index
-  /// for efficient actionId-based lookups.
+  /// O(1) key-based access performance. This method also updates the key index
+  /// for efficient key-based lookups.
   ///
   /// - Parameters:
   ///   - id: The boundary identifier
@@ -61,35 +76,36 @@ final class LockmanState<I: LockmanInfo>: Sendable {
   /// O(1) - Direct ordered dictionary insertion and dual index update
   func add<B: LockmanBoundaryId>(id: B, info: I) {
     let boundaryKey = AnyLockmanBoundaryId(id)
+    let indexKey = keyExtractor(info)
 
     storage.withCriticalRegion { storage in
       storage[boundaryKey, default: OrderedDictionary<UUID, I>()][info.uniqueId] = info
     }
 
-    actionIndex.withCriticalRegion { index in
-      index[boundaryKey, default: [:]][info.actionId, default: []].insert(info.uniqueId)
+    index.withCriticalRegion { index in
+      index[boundaryKey, default: [:]][indexKey, default: []].insert(info.uniqueId)
     }
   }
 
-  /// Removes all locks with a specific actionId from the boundary.
+  /// Removes all locks with a specific key from the boundary.
   ///
-  /// This method removes all locks that have the specified actionId,
-  /// maintaining consistency between both the primary storage and action index.
+  /// This method removes all locks that match the specified key,
+  /// maintaining consistency between both the primary storage and key index.
   ///
   /// - Parameters:
   ///   - id: The boundary identifier
-  ///   - actionId: The action ID whose locks should be removed
+  ///   - key: The key whose locks should be removed
   ///
   /// ## Complexity
   /// O(n) - Where n is the total number of locks in the boundary
   /// However, if k (locks to remove) << n (total locks), this is still efficient
   /// due to O(1) Set lookup for each item
-  func removeAll<B: LockmanBoundaryId>(id: B, actionId: LockmanActionId) {
+  func removeAll<B: LockmanBoundaryId>(id: B, key: K) {
     let boundaryKey = AnyLockmanBoundaryId(id)
 
-    // Get all UUIDs for this actionId
-    let uuidsToRemove = actionIndex.withCriticalRegion { index in
-      index[boundaryKey]?[actionId] ?? []
+    // Get all UUIDs for this key
+    let uuidsToRemove = index.withCriticalRegion { index in
+      index[boundaryKey]?[key] ?? []
     }
 
     guard !uuidsToRemove.isEmpty else { return }
@@ -108,11 +124,11 @@ final class LockmanState<I: LockmanInfo>: Sendable {
       }
     }
 
-    // Remove from action index
-    actionIndex.withCriticalRegion { index in
+    // Remove from key index
+    index.withCriticalRegion { index in
       guard var boundaryIndex = index[boundaryKey] else { return }
 
-      boundaryIndex.removeValue(forKey: actionId)
+      boundaryIndex.removeValue(forKey: key)
 
       if boundaryIndex.isEmpty {
         index.removeValue(forKey: boundaryKey)
@@ -125,7 +141,7 @@ final class LockmanState<I: LockmanInfo>: Sendable {
   /// Removes a specific lock by UUID - True O(1) operation.
   ///
   /// This method maintains consistency between both the primary storage and
-  /// the action index by removing the lock from both data structures.
+  /// the key index by removing the lock from both data structures.
   ///
   /// - Parameters:
   ///   - id: The boundary identifier
@@ -136,7 +152,7 @@ final class LockmanState<I: LockmanInfo>: Sendable {
   func remove<B: LockmanBoundaryId>(id: B, info: any LockmanInfo) {
     let boundaryKey = AnyLockmanBoundaryId(id)
 
-    // First, get the info to access actionId for index cleanup
+    // First, get the info to access key for index cleanup
     let removedInfo = storage.withCriticalRegion { storage -> I? in
       guard let boundaryDict = storage[boundaryKey],
         let info = boundaryDict[info.uniqueId]
@@ -149,6 +165,8 @@ final class LockmanState<I: LockmanInfo>: Sendable {
     guard let removedInfo = removedInfo else {
       return
     }
+
+    let indexKey = keyExtractor(removedInfo)
 
     storage.withCriticalRegion { storage in
       guard var boundaryDict = storage[boundaryKey] else {
@@ -165,20 +183,20 @@ final class LockmanState<I: LockmanInfo>: Sendable {
       }
     }
 
-    // Update action index
-    actionIndex.withCriticalRegion { index in
+    // Update key index
+    index.withCriticalRegion { index in
       guard var boundaryIndex = index[boundaryKey],
-        var actionSet = boundaryIndex[removedInfo.actionId]
+        var keySet = boundaryIndex[indexKey]
       else {
         return
       }
 
-      actionSet.remove(info.uniqueId)
+      keySet.remove(info.uniqueId)
 
-      if actionSet.isEmpty {
-        boundaryIndex.removeValue(forKey: removedInfo.actionId)
+      if keySet.isEmpty {
+        boundaryIndex.removeValue(forKey: indexKey)
       } else {
-        boundaryIndex[removedInfo.actionId] = actionSet
+        boundaryIndex[indexKey] = keySet
       }
 
       if boundaryIndex.isEmpty {
@@ -208,41 +226,41 @@ final class LockmanState<I: LockmanInfo>: Sendable {
     }
   }
 
-  // MARK: - ActionId-based Query Operations
+  // MARK: - Key-based Query Operations
 
-  /// Checks if a specific actionId exists in the boundary - O(1) operation.
+  /// Checks if a specific key exists in the boundary - O(1) operation.
   ///
-  /// This method provides constant-time lookup for action existence,
-  /// making it ideal for strategies that need to check action conflicts.
+  /// This method provides constant-time lookup for key existence,
+  /// making it ideal for strategies that need to check conflicts.
   ///
   /// - Parameters:
   ///   - id: The boundary identifier
-  ///   - actionId: The action ID to check
-  /// - Returns: true if the action exists in the boundary
+  ///   - key: The key to check
+  /// - Returns: true if the key exists in the boundary
   ///
   /// ## Complexity
   /// O(1) - Direct hash table lookup
-  func contains<B: LockmanBoundaryId>(id: B, actionId: LockmanActionId) -> Bool {
+  func contains<B: LockmanBoundaryId>(id: B, key: K) -> Bool {
     let boundaryKey = AnyLockmanBoundaryId(id)
-    return actionIndex.withCriticalRegion { index in
-      index[boundaryKey]?[actionId] != nil
+    return index.withCriticalRegion { index in
+      index[boundaryKey]?[key] != nil
     }
   }
 
-  /// Returns all locks with a specific actionId in the boundary.
+  /// Returns all locks with a specific key in the boundary.
   ///
-  /// This method efficiently retrieves all locks matching the given actionId,
+  /// This method efficiently retrieves all locks matching the given key,
   /// maintaining the original insertion order.
   ///
   /// - Parameters:
   ///   - id: The boundary identifier
-  ///   - actionId: The action ID to filter by
-  /// - Returns: Array of locks with the specified actionId in insertion order
-  func currents<B: LockmanBoundaryId>(id: B, actionId: LockmanActionId) -> [I] {
+  ///   - key: The key to filter by
+  /// - Returns: Array of locks with the specified key in insertion order
+  func currents<B: LockmanBoundaryId>(id: B, key: K) -> [I] {
     let boundaryKey = AnyLockmanBoundaryId(id)
 
-    let uuids = actionIndex.withCriticalRegion { index in
-      index[boundaryKey]?[actionId] ?? []
+    let uuids = index.withCriticalRegion { index in
+      index[boundaryKey]?[key] ?? []
     }
 
     guard !uuids.isEmpty else {
@@ -267,26 +285,26 @@ final class LockmanState<I: LockmanInfo>: Sendable {
     }
   }
 
-  /// Returns the count of locks with a specific actionId - O(1) operation.
+  /// Returns the count of locks with a specific key - O(1) operation.
   ///
   /// - Parameters:
   ///   - id: The boundary identifier
-  ///   - actionId: The action ID to count
-  /// - Returns: Number of locks with the specified actionId
-  func count<B: LockmanBoundaryId>(id: B, actionId: LockmanActionId) -> Int {
+  ///   - key: The key to count
+  /// - Returns: Number of locks with the specified key
+  func count<B: LockmanBoundaryId>(id: B, key: K) -> Int {
     let boundaryKey = AnyLockmanBoundaryId(id)
-    return actionIndex.withCriticalRegion { index in
-      index[boundaryKey]?[actionId]?.count ?? 0
+    return index.withCriticalRegion { index in
+      index[boundaryKey]?[key]?.count ?? 0
     }
   }
 
-  /// Returns all unique actionIds in the boundary - O(1) operation.
+  /// Returns all unique keys in the boundary - O(1) operation.
   ///
   /// - Parameter id: The boundary identifier
-  /// - Returns: Set of all unique actionIds in the boundary
-  func actionIds<B: LockmanBoundaryId>(id: B) -> Set<LockmanActionId> {
+  /// - Returns: Set of all unique keys in the boundary
+  func keys<B: LockmanBoundaryId>(id: B) -> Set<K> {
     let boundaryKey = AnyLockmanBoundaryId(id)
-    return actionIndex.withCriticalRegion { index in
+    return index.withCriticalRegion { index in
       if let boundaryIndex = index[boundaryKey] {
         return Set(boundaryIndex.keys)
       }
@@ -301,7 +319,7 @@ final class LockmanState<I: LockmanInfo>: Sendable {
     storage.withCriticalRegion { storage in
       storage.removeAll(keepingCapacity: true)
     }
-    actionIndex.withCriticalRegion { index in
+    index.withCriticalRegion { index in
       index.removeAll(keepingCapacity: true)
     }
   }
@@ -312,7 +330,7 @@ final class LockmanState<I: LockmanInfo>: Sendable {
     storage.withCriticalRegion { storage in
       storage.removeValue(forKey: boundaryKey)
     }
-    actionIndex.withCriticalRegion { index in
+    index.withCriticalRegion { index in
       index.removeValue(forKey: boundaryKey)
     }
   }
@@ -347,5 +365,60 @@ final class LockmanState<I: LockmanInfo>: Sendable {
       }
       return result
     }
+  }
+}
+
+// MARK: - Type Alias for ActionId-based State
+
+/// Type alias for LockmanState that uses actionId as the key.
+/// This is provided for backward compatibility.
+typealias ActionIdLockmanState<I: LockmanInfo> = LockmanState<I, LockmanActionId>
+
+// MARK: - Convenience for ActionId-based State
+
+extension LockmanState where K == LockmanActionId {
+  /// Creates a new LockmanState that uses actionId as the key.
+  ///
+  /// This convenience initializer is provided for backward compatibility
+  /// and for the common use case where actions are indexed by their actionId.
+  convenience init() {
+    self.init(keyExtractor: { $0.actionId })
+  }
+  
+  // MARK: - ActionId-specific convenience methods
+  
+  /// Checks if a specific actionId exists in the boundary.
+  ///
+  /// Convenience method that calls the generic key-based method.
+  func contains<B: LockmanBoundaryId>(id: B, actionId: LockmanActionId) -> Bool {
+    contains(id: id, key: actionId)
+  }
+  
+  /// Returns all locks with a specific actionId in the boundary.
+  ///
+  /// Convenience method that calls the generic key-based method.
+  func currents<B: LockmanBoundaryId>(id: B, actionId: LockmanActionId) -> [I] {
+    currents(id: id, key: actionId)
+  }
+  
+  /// Returns the count of locks with a specific actionId.
+  ///
+  /// Convenience method that calls the generic key-based method.
+  func count<B: LockmanBoundaryId>(id: B, actionId: LockmanActionId) -> Int {
+    count(id: id, key: actionId)
+  }
+  
+  /// Removes all locks with a specific actionId from the boundary.
+  ///
+  /// Convenience method that calls the generic key-based method.
+  func removeAll<B: LockmanBoundaryId>(id: B, actionId: LockmanActionId) {
+    removeAll(id: id, key: actionId)
+  }
+  
+  /// Returns all unique actionIds in the boundary.
+  ///
+  /// Convenience method that calls the generic key-based method.
+  func actionIds<B: LockmanBoundaryId>(id: B) -> Set<LockmanActionId> {
+    keys(id: id)
   }
 }

--- a/Sources/Lockman/Core/Strategies/DynamicConditionStrategy/LockmanDynamicConditionStrategy.swift
+++ b/Sources/Lockman/Core/Strategies/DynamicConditionStrategy/LockmanDynamicConditionStrategy.swift
@@ -34,7 +34,10 @@ public final class LockmanDynamicConditionStrategy: LockmanStrategy, @unchecked 
   public static let shared = LockmanDynamicConditionStrategy()
 
   /// Thread-safe state container that tracks active locks per boundary.
-  private let state = LockmanState<LockmanDynamicConditionInfo>()
+  /// Uses actionId as the key for indexing locks.
+  private let state = LockmanState<LockmanDynamicConditionInfo, LockmanActionId>(
+    keyExtractor: { $0.actionId }
+  )
 
   /// The unique identifier for this strategy instance.
   public let strategyId: LockmanStrategyId
@@ -114,7 +117,7 @@ public final class LockmanDynamicConditionStrategy: LockmanStrategy, @unchecked 
     info: LockmanDynamicConditionInfo
   ) {
     // Remove all locks with the same actionId
-    state.removeAll(id: id, actionId: info.actionId)
+    state.removeAll(id: id, key: info.actionId)
   }
 
   /// Removes all active locks across all boundaries.

--- a/Sources/Lockman/Core/Strategies/PriorityBasedStrategy/LockmanPriorityBasedStrategy.swift
+++ b/Sources/Lockman/Core/Strategies/PriorityBasedStrategy/LockmanPriorityBasedStrategy.swift
@@ -63,8 +63,10 @@ public final class LockmanPriorityBasedStrategy: LockmanStrategy, @unchecked Sen
   ///
   /// Each boundary maintains an ordered collection of active lock infos, allowing
   /// the strategy to evaluate priority conflicts and determine the highest-priority
-  /// active action for each boundary.
-  private let state = LockmanState<LockmanPriorityBasedInfo>()
+  /// active action for each boundary. Uses actionId as the key for indexing locks.
+  private let state = LockmanState<LockmanPriorityBasedInfo, LockmanActionId>(
+    keyExtractor: { $0.actionId }
+  )
 
   /// The unique identifier for this strategy instance.
   public let strategyId: LockmanStrategyId

--- a/Sources/Lockman/Core/Strategies/SingleExecutionStrategy/LockmanSingleExecutionStrategy.swift
+++ b/Sources/Lockman/Core/Strategies/SingleExecutionStrategy/LockmanSingleExecutionStrategy.swift
@@ -35,7 +35,10 @@ public final class LockmanSingleExecutionStrategy: LockmanStrategy, @unchecked S
   public static let shared = LockmanSingleExecutionStrategy()
 
   /// Thread-safe state container that tracks active locks per boundary ID.
-  private let state = LockmanState<LockmanSingleExecutionInfo>()
+  /// Uses actionId as the key for indexing locks.
+  private let state = LockmanState<LockmanSingleExecutionInfo, LockmanActionId>(
+    keyExtractor: { $0.actionId }
+  )
 
   /// The unique identifier for this strategy instance.
   public let strategyId: LockmanStrategyId
@@ -105,7 +108,7 @@ public final class LockmanSingleExecutionStrategy: LockmanStrategy, @unchecked S
 
     case .action:
       // Exclusive per action - check if same actionId exists
-      if state.contains(id: id, actionId: info.actionId) {
+      if state.contains(id: id, key: info.actionId) {
         result = .failure(LockmanSingleExecutionError.actionAlreadyRunning(actionId: info.actionId))
         failureReason = "Action '\(info.actionId)' is already locked"
       } else {

--- a/Tests/LockmanCoreTests/LockmanStateActionIndexTests.swift
+++ b/Tests/LockmanCoreTests/LockmanStateActionIndexTests.swift
@@ -46,7 +46,7 @@ final class LockmanStateActionIndexTests: XCTestCase {
   }
 
   func testContainsReturnsFalseAfterRemovingAction() async throws {
-    let state = LockmanState<TestInfo>()
+    let state = LockmanState<TestInfo, LockmanActionId>()
     let boundary = TestBoundaryId(value: "test")
     let info = TestInfo(actionId: "action1")
 
@@ -60,7 +60,7 @@ final class LockmanStateActionIndexTests: XCTestCase {
   // MARK: - currents(id:actionId:) Tests
 
   func testCurrentsByActionIdReturnsEmptyForNonExistent() async throws {
-    let state = LockmanState<TestInfo>()
+    let state = LockmanState<TestInfo, LockmanActionId>()
     let boundary = TestBoundaryId(value: "test")
 
     let results = state.currents(id: boundary, actionId: "nonexistent")
@@ -68,7 +68,7 @@ final class LockmanStateActionIndexTests: XCTestCase {
   }
 
   func testCurrentsByActionIdReturnsMatchingLocks() async throws {
-    let state = LockmanState<TestInfo>()
+    let state = LockmanState<TestInfo, LockmanActionId>()
     let boundary = TestBoundaryId(value: "test")
 
     let info1 = TestInfo(actionId: "action1")
@@ -91,7 +91,7 @@ final class LockmanStateActionIndexTests: XCTestCase {
   }
 
   func testCurrentsByActionIdPreservesInsertionOrder() async throws {
-    let state = LockmanState<TestInfo>()
+    let state = LockmanState<TestInfo, LockmanActionId>()
     let boundary = TestBoundaryId(value: "test")
 
     let info1 = TestInfo(actionId: "action1")
@@ -113,14 +113,14 @@ final class LockmanStateActionIndexTests: XCTestCase {
   // MARK: - Count Tests
 
   func testCountReturnsZeroForNonExistent() async throws {
-    let state = LockmanState<TestInfo>()
+    let state = LockmanState<TestInfo, LockmanActionId>()
     let boundary = TestBoundaryId(value: "test")
 
     XCTAssertEqual(state.count(id: boundary, actionId: "nonexistent"), 0)
   }
 
   func testCountReturnsCorrectNumber() async throws {
-    let state = LockmanState<TestInfo>()
+    let state = LockmanState<TestInfo, LockmanActionId>()
     let boundary = TestBoundaryId(value: "test")
 
     let info1 = TestInfo(actionId: "action1")
@@ -139,7 +139,7 @@ final class LockmanStateActionIndexTests: XCTestCase {
   // MARK: - ActionIds Tests
 
   func testActionIdsReturnsEmptyForEmptyBoundary() async throws {
-    let state = LockmanState<TestInfo>()
+    let state = LockmanState<TestInfo, LockmanActionId>()
     let boundary = TestBoundaryId(value: "test")
 
     let actionIds = state.actionIds(id: boundary)
@@ -147,7 +147,7 @@ final class LockmanStateActionIndexTests: XCTestCase {
   }
 
   func testActionIdsReturnsAllUnique() async throws {
-    let state = LockmanState<TestInfo>()
+    let state = LockmanState<TestInfo, LockmanActionId>()
     let boundary = TestBoundaryId(value: "test")
 
     state.add(id: boundary, info: TestInfo(actionId: "action1"))
@@ -166,7 +166,7 @@ final class LockmanStateActionIndexTests: XCTestCase {
   // MARK: - Boundary Isolation Tests
 
   func testActionsAreIsolatedBetweenBoundaries() async throws {
-    let state = LockmanState<TestInfo>()
+    let state = LockmanState<TestInfo, LockmanActionId>()
     let boundary1 = TestBoundaryId(value: "boundary1")
     let boundary2 = TestBoundaryId(value: "boundary2")
 
@@ -185,7 +185,7 @@ final class LockmanStateActionIndexTests: XCTestCase {
   // MARK: - Performance Tests
 
   func testContainsPerformanceTest() {
-    let state = LockmanState<TestInfo>()
+    let state = LockmanState<TestInfo, LockmanActionId>()
     let boundary = TestBoundaryId(value: "test")
 
     // Add many different actions
@@ -210,7 +210,7 @@ final class LockmanStateActionIndexTests: XCTestCase {
   // MARK: - Edge Cases
 
   func testHandlesEmptyActionIds() async throws {
-    let state = LockmanState<TestInfo>()
+    let state = LockmanState<TestInfo, LockmanActionId>()
     let boundary = TestBoundaryId(value: "test")
 
     let info = TestInfo(actionId: "")
@@ -221,7 +221,7 @@ final class LockmanStateActionIndexTests: XCTestCase {
   }
 
   func testHandlesUnicodeActionIds() async throws {
-    let state = LockmanState<TestInfo>()
+    let state = LockmanState<TestInfo, LockmanActionId>()
     let boundary = TestBoundaryId(value: "test")
 
     let actionId = "🚀アクション💻"
@@ -235,7 +235,7 @@ final class LockmanStateActionIndexTests: XCTestCase {
   // MARK: - Cleanup Tests
 
   func testRemoveAllClearsActionIndex() async throws {
-    let state = LockmanState<TestInfo>()
+    let state = LockmanState<TestInfo, LockmanActionId>()
     let boundary = TestBoundaryId(value: "test")
 
     state.add(id: boundary, info: TestInfo(actionId: "action1"))
@@ -249,7 +249,7 @@ final class LockmanStateActionIndexTests: XCTestCase {
   }
 
   func testRemoveAllWithBoundaryClearsBoundaryActionIndex() async throws {
-    let state = LockmanState<TestInfo>()
+    let state = LockmanState<TestInfo, LockmanActionId>()
     let boundary1 = TestBoundaryId(value: "boundary1")
     let boundary2 = TestBoundaryId(value: "boundary2")
 
@@ -265,7 +265,7 @@ final class LockmanStateActionIndexTests: XCTestCase {
   // MARK: - removeAll(id:actionId:) Tests
 
   func testRemoveAllByActionId() async throws {
-    let state = LockmanState<TestInfo>()
+    let state = LockmanState<TestInfo, LockmanActionId>()
     let boundary = TestBoundaryId(value: "test")
 
     // Add multiple locks with same actionId
@@ -292,7 +292,7 @@ final class LockmanStateActionIndexTests: XCTestCase {
   }
 
   func testRemoveAllByActionIdEmptyCase() async throws {
-    let state = LockmanState<TestInfo>()
+    let state = LockmanState<TestInfo, LockmanActionId>()
     let boundary = TestBoundaryId(value: "test")
 
     // Try to remove non-existent actionId
@@ -303,7 +303,7 @@ final class LockmanStateActionIndexTests: XCTestCase {
   }
 
   func testRemoveAllByActionIdPreservesOtherActions() async throws {
-    let state = LockmanState<TestInfo>()
+    let state = LockmanState<TestInfo, LockmanActionId>()
     let boundary = TestBoundaryId(value: "test")
 
     // Add locks with different actionIds
@@ -322,7 +322,7 @@ final class LockmanStateActionIndexTests: XCTestCase {
   }
 
   func testRemoveAllByActionIdMultipleBoundaries() async throws {
-    let state = LockmanState<TestInfo>()
+    let state = LockmanState<TestInfo, LockmanActionId>()
     let boundary1 = TestBoundaryId(value: "boundary1")
     let boundary2 = TestBoundaryId(value: "boundary2")
 
@@ -339,7 +339,7 @@ final class LockmanStateActionIndexTests: XCTestCase {
   }
 
   func testRemoveAllByActionIdConcurrent() async throws {
-    let state = LockmanState<TestInfo>()
+    let state = LockmanState<TestInfo, LockmanActionId>()
     let boundary = TestBoundaryId(value: "test")
     let iterations = 100
 

--- a/Tests/LockmanCoreTests/LockmanStateActionIndexTests.swift
+++ b/Tests/LockmanCoreTests/LockmanStateActionIndexTests.swift
@@ -28,14 +28,14 @@ final class LockmanStateActionIndexTests: XCTestCase {
   // MARK: - Basic Functionality Tests
 
   func testContainsReturnsFalseForNonExistentAction() async throws {
-    let state = LockmanState<TestInfo>()
+    let state = LockmanState<TestInfo, LockmanActionId>()
     let boundary = TestBoundaryId(value: "test")
 
     XCTAssertFalse(state.contains(id: boundary, actionId: "nonexistent"))
   }
 
   func testContainsReturnsTrueAfterAddingAction() async throws {
-    let state = LockmanState<TestInfo>()
+    let state = LockmanState<TestInfo, LockmanActionId>()
     let boundary = TestBoundaryId(value: "test")
     let info = TestInfo(actionId: "action1")
 

--- a/Tests/LockmanCoreTests/SingleExecutionTests/LockmanSingleExecutionInfoTests.swift
+++ b/Tests/LockmanCoreTests/SingleExecutionTests/LockmanSingleExecutionInfoTests.swift
@@ -231,7 +231,7 @@ final class LockmanSingleExecutionInfoTests: XCTestCase {
 
 final class LockmanSingleExecutionInfoIntegrationTests: XCTestCase {
   func testWorksWithLockmanState() {
-    let state = LockmanState<LockmanSingleExecutionInfo>()
+    let state = LockmanState<LockmanSingleExecutionInfo, LockmanActionId>()
     let boundaryId = StringBoundaryId(value: "boundary")
 
     let info1 = LockmanSingleExecutionInfo(actionId: "action1", mode: .boundary)

--- a/Tests/LockmanCoreTests/StrategyTests/LockmanStateTests.swift
+++ b/Tests/LockmanCoreTests/StrategyTests/LockmanStateTests.swift
@@ -61,7 +61,7 @@ final class LockmanStateTests: XCTestCase {
   // MARK: - Basic Operations
 
   func testAddSingleEntry() {
-    let state = LockmanState<TestLockmanInfo>()
+    let state = LockmanState<TestLockmanInfo, LockmanActionId>()
     let boundaryId = TestBoundaryId(value: "test")
     let info = TestLockmanInfo(id: "1")
 
@@ -73,7 +73,7 @@ final class LockmanStateTests: XCTestCase {
   }
 
   func testAddMultipleEntriesToSameBoundary() {
-    let state = LockmanState<TestLockmanInfo>()
+    let state = LockmanState<TestLockmanInfo, LockmanActionId>()
     let boundaryId = TestBoundaryId(value: "test")
     let info1 = TestLockmanInfo(id: "1")
     let info2 = TestLockmanInfo(id: "2")
@@ -89,7 +89,7 @@ final class LockmanStateTests: XCTestCase {
   }
 
   func testAddEntriesToDifferentBoundaries() {
-    let state = LockmanState<TestLockmanInfo>()
+    let state = LockmanState<TestLockmanInfo, LockmanActionId>()
     let boundary1 = TestBoundaryId(value: "boundary1")
     let boundary2 = TestBoundaryId(value: "boundary2")
     let info1 = TestLockmanInfo(id: "1")
@@ -108,7 +108,7 @@ final class LockmanStateTests: XCTestCase {
   }
 
   func testRemoveLastFromSingleEntry() {
-    let state = LockmanState<TestLockmanInfo>()
+    let state = LockmanState<TestLockmanInfo, LockmanActionId>()
     let boundaryId = TestBoundaryId(value: "test")
     let info = TestLockmanInfo(id: "1")
 
@@ -120,7 +120,7 @@ final class LockmanStateTests: XCTestCase {
   }
 
   func testRemoveLastFromMultipleEntries() {
-    let state = LockmanState<TestLockmanInfo>()
+    let state = LockmanState<TestLockmanInfo, LockmanActionId>()
     let boundaryId = TestBoundaryId(value: "test")
     let info1 = TestLockmanInfo(id: "1")
     let info2 = TestLockmanInfo(id: "2")
@@ -138,7 +138,7 @@ final class LockmanStateTests: XCTestCase {
   }
 
   func testRemoveLastFromNonExistentBoundary() {
-    let state = LockmanState<TestLockmanInfo>()
+    let state = LockmanState<TestLockmanInfo, LockmanActionId>()
     let boundaryId = TestBoundaryId(value: "non-existent")
 
     // Should not crash
@@ -149,7 +149,7 @@ final class LockmanStateTests: XCTestCase {
   }
 
   func testGetCurrentsFromEmptyState() {
-    let state = LockmanState<TestLockmanInfo>()
+    let state = LockmanState<TestLockmanInfo, LockmanActionId>()
     let boundaryId = TestBoundaryId(value: "test")
 
     let currents = state.currents(id: boundaryId)
@@ -157,7 +157,7 @@ final class LockmanStateTests: XCTestCase {
   }
 
   func testCleanUpAllEntries() {
-    let state = LockmanState<TestLockmanInfo>()
+    let state = LockmanState<TestLockmanInfo, LockmanActionId>()
     let boundary1 = TestBoundaryId(value: "boundary1")
     let boundary2 = TestBoundaryId(value: "boundary2")
     let info1 = TestLockmanInfo(id: "1")
@@ -176,7 +176,7 @@ final class LockmanStateTests: XCTestCase {
   }
 
   func testCleanUpSpecificBoundary() {
-    let state = LockmanState<TestLockmanInfo>()
+    let state = LockmanState<TestLockmanInfo, LockmanActionId>()
     let boundary1 = TestBoundaryId(value: "boundary1")
     let boundary2 = TestBoundaryId(value: "boundary2")
     let info1 = TestLockmanInfo(id: "1")
@@ -198,7 +198,7 @@ final class LockmanStateTests: XCTestCase {
   // MARK: - Concurrent Access Tests
 
   func testConcurrentAddsToSameBoundary() async {
-    let state = LockmanState<TestLockmanInfo>()
+    let state = LockmanState<TestLockmanInfo, LockmanActionId>()
     let boundaryId = TestBoundaryId("test")
     let iterations = 100
 
@@ -216,7 +216,7 @@ final class LockmanStateTests: XCTestCase {
   }
 
   func testConcurrentAddsToDifferentBoundaries() async {
-    let state = LockmanState<TestLockmanInfo>()
+    let state = LockmanState<TestLockmanInfo, LockmanActionId>()
     let iterations = 50
     let boundaryCount = 5
 
@@ -240,7 +240,7 @@ final class LockmanStateTests: XCTestCase {
   }
 
   func testConcurrentAddAndRemoveOperations() async {
-    let state = LockmanState<TestLockmanInfo>()
+    let state = LockmanState<TestLockmanInfo, LockmanActionId>()
     let boundaryId = TestBoundaryId(value: "test")
     let iterations = 100
 
@@ -271,7 +271,7 @@ final class LockmanStateTests: XCTestCase {
   }
 
   func testConcurrentReadOperations() async {
-    let state = LockmanState<TestLockmanInfo>()
+    let state = LockmanState<TestLockmanInfo, LockmanActionId>()
     let boundaryId = TestBoundaryId(value: "test")
 
     // Add some initial data
@@ -299,7 +299,7 @@ final class LockmanStateTests: XCTestCase {
   // MARK: - Edge Cases
 
   func testStackLikeBehavior() {
-    let state = LockmanState<TestLockmanInfo>()
+    let state = LockmanState<TestLockmanInfo, LockmanActionId>()
     let boundaryId = TestBoundaryId(value: "test")
 
     let infoList = (1...5).map { TestLockmanInfo(id: "\($0)") }
@@ -319,7 +319,7 @@ final class LockmanStateTests: XCTestCase {
   }
 
   func testLargeNumberOfEntries() {
-    let state = LockmanState<TestLockmanInfo>()
+    let state = LockmanState<TestLockmanInfo, LockmanActionId>()
     let boundaryId = TestBoundaryId(value: "test")
     let count = 1000  // Reduced from 10000 for reasonable test time
 
@@ -337,7 +337,7 @@ final class LockmanStateTests: XCTestCase {
   }
 
   func testMultipleCleanUpOperations() {
-    let state = LockmanState<TestLockmanInfo>()
+    let state = LockmanState<TestLockmanInfo, LockmanActionId>()
     let boundaryId = TestBoundaryId(value: "test")
 
     state.add(id: boundaryId, info: TestLockmanInfo(id: "1"))
@@ -353,7 +353,7 @@ final class LockmanStateTests: XCTestCase {
   // MARK: - Data Integrity Tests
 
   func testOrderPreservation() {
-    let state = LockmanState<TestLockmanInfo>()
+    let state = LockmanState<TestLockmanInfo, LockmanActionId>()
     let boundaryId = TestBoundaryId(value: "order_test")
     let testData = ["first", "second", "third", "fourth", "fifth"]
 
@@ -366,7 +366,7 @@ final class LockmanStateTests: XCTestCase {
   }
 
   func testBoundaryIsolation() {
-    let state = LockmanState<TestLockmanInfo>()
+    let state = LockmanState<TestLockmanInfo, LockmanActionId>()
     let boundary1 = TestBoundaryId(value: "isolated1")
     let boundary2 = TestBoundaryId(value: "isolated2")
     let boundary3 = TestBoundaryId(value: "isolated3")
@@ -387,7 +387,7 @@ final class LockmanStateTests: XCTestCase {
   }
 
   func testComplexSequenceOperations() {
-    let state = LockmanState<TestLockmanInfo>()
+    let state = LockmanState<TestLockmanInfo, LockmanActionId>()
     let boundaryId = TestBoundaryId(value: "complex")
 
     // Complex sequence: add, add, remove, add, remove, remove
@@ -404,7 +404,7 @@ final class LockmanStateTests: XCTestCase {
   // MARK: - Memory Management Tests
 
   func testMemoryCleanupAfterRemovals() {
-    let state = LockmanState<TestLockmanInfo>()
+    let state = LockmanState<TestLockmanInfo, LockmanActionId>()
     let boundaryId = TestBoundaryId(value: "memory_test")
 
     // Add many entries
@@ -426,7 +426,7 @@ final class LockmanStateTests: XCTestCase {
   }
 
   func testCleanupWithMixedBoundaryStates() {
-    let state = LockmanState<TestLockmanInfo>()
+    let state = LockmanState<TestLockmanInfo, LockmanActionId>()
     let emptyBoundary = TestBoundaryId(value: "empty")
     let fullBoundary = TestBoundaryId(value: "full")
     let partialBoundary = TestBoundaryId(value: "partial")
@@ -564,7 +564,7 @@ final class AnyLockmanBoundaryIdTests: XCTestCase {
 
 final class LockmanStatePerformanceTests: XCTestCase {
   func testPerformanceWithFrequentAddsAndRemoves() async throws {
-    let state = LockmanState<TestLockmanInfo>()
+    let state = LockmanState<TestLockmanInfo, LockmanActionId>()
     let boundaryId = TestBoundaryId(value: "test")
     let iterations = 1000
 
@@ -590,7 +590,7 @@ final class LockmanStatePerformanceTests: XCTestCase {
   }
 
   func testPerformanceWithManyBoundaries() {
-    let state = LockmanState<TestLockmanInfo>()
+    let state = LockmanState<TestLockmanInfo, LockmanActionId>()
     let boundaryCount = 100
     let entriesPerBoundary = 10
 
@@ -616,7 +616,7 @@ final class LockmanStatePerformanceTests: XCTestCase {
   }
 
   func testConcurrentPerformance() async {
-    let state = LockmanState<TestLockmanInfo>()
+    let state = LockmanState<TestLockmanInfo, LockmanActionId>()
     let taskCount = 1
     let operationsPerTask = 100
 


### PR DESCRIPTION
## Summary
- Add generic key type parameter to LockmanState for flexible indexing
- Optimize ConcurrencyLimitedStrategy from O(n) filtering to O(1) count operations
- Maintain backward compatibility with convenience methods for actionId-based indexing

## Changes

### Core Changes
- **LockmanState**: Now accepts generic key type `K` with `keyExtractor` function
- **Index optimization**: Added secondary index for O(1) key-based lookups
- **Strategy updates**: Each strategy now uses the most appropriate key:
  - SingleExecutionStrategy: `actionId`
  - PriorityBasedStrategy: `actionId`
  - DynamicConditionStrategy: `actionId`
  - ConcurrencyLimitedStrategy: `concurrencyId` (main optimization benefit)
  - GroupCoordinationStrategy: continues using custom storage

### API Changes
```swift
// New generic API
LockmanState<I: LockmanInfo, K: Hashable & Sendable>(
  keyExtractor: @escaping @Sendable (I) -> K
)

// Convenience for actionId (backward compatible)
LockmanState<I: LockmanInfo, LockmanActionId>()
```

### Performance Improvements
- ConcurrencyLimitedStrategy: Checking concurrent count reduced from O(n) to O(1)
- Key-based queries (`contains`, `count`, `currents`): All now O(1) or O(k) where k is result size

## Test plan
- [x] All existing tests pass (620 tests)
- [x] Updated test files to use generic API
- [x] Verified backward compatibility through convenience methods
- [x] Performance improvement verified in ConcurrencyLimitedStrategy

🤖 Generated with [Claude Code](https://claude.ai/code)