### PR TITLE
feat: add error information to successWithPrecedingCancellation

### DIFF
--- a/Sources/Lockman/Composable/ReduceWithLock.swift
+++ b/Sources/Lockman/Composable/ReduceWithLock.swift
@@ -353,7 +353,10 @@ extension ReduceWithLock {
     switch result {
     case .failure(let error):
       return (false, error)
-    case .successWithPrecedingCancellation, .success:
+    case .successWithPrecedingCancellation(let error):
+      // Lock acquired but with preceding cancellation - return success with error
+      return (true, error)
+    case .success:
       return (true, nil)
     @unknown default:
       return (true, nil)

--- a/Sources/Lockman/Core/Debug/LockmanLogger.swift
+++ b/Sources/Lockman/Core/Debug/LockmanLogger.swift
@@ -68,11 +68,11 @@ public final class LockmanLogger: @unchecked Sendable {
         message =
           "❌ [Lockman] canLock failed - Strategy: \(strategy), BoundaryId: \(boundaryId), Info: \(info.debugDescription)\(reasonStr)"
 
-      case .successWithPrecedingCancellation:
+      case .successWithPrecedingCancellation(let error):
         let cancelledStr =
           cancelledInfo.map { ", Cancelled: '\($0.actionId)' (uniqueId: \($0.uniqueId))" } ?? ""
         message =
-          "⚠️ [Lockman] canLock succeeded with cancellation - Strategy: \(strategy), BoundaryId: \(boundaryId), Info: \(info.debugDescription)\(cancelledStr)"
+          "⚠️ [Lockman] canLock succeeded with cancellation - Strategy: \(strategy), BoundaryId: \(boundaryId), Info: \(info.debugDescription)\(cancelledStr), Error: \(error)"
       }
 
       // Use Logger from Internal/Logger.swift

--- a/Sources/Lockman/Core/Errors/LockmanPriorityBasedError.swift
+++ b/Sources/Lockman/Core/Errors/LockmanPriorityBasedError.swift
@@ -26,6 +26,13 @@ public enum LockmanPriorityBasedError: LockmanError {
   /// regardless of priority.
   case blockedBySameAction(actionId: String)
 
+  /// Indicates that a preceding action will be cancelled due to preemption.
+  ///
+  /// This occurs when a higher priority action preempts a lower priority action.
+  /// The lower priority action will be cancelled to allow the higher priority
+  /// action to proceed.
+  case precedingActionCancelled(actionId: String)
+
   public var errorDescription: String? {
     switch self {
     case let .higherPriorityExists(requested, currentHighest):
@@ -36,6 +43,9 @@ public enum LockmanPriorityBasedError: LockmanError {
     case let .blockedBySameAction(actionId):
       return
         "Cannot acquire lock: action '\(actionId)' is already running and duplicates are blocked."
+    case let .precedingActionCancelled(actionId):
+      return
+        "Lock acquired, preceding action '\(actionId)' will be cancelled."
     }
   }
 
@@ -48,6 +58,8 @@ public enum LockmanPriorityBasedError: LockmanError {
       return "Actions with the same priority and exclusive behavior cannot run concurrently."
     case .blockedBySameAction:
       return "The strategy is configured to prevent duplicate action execution."
+    case .precedingActionCancelled:
+      return "A lower priority action was preempted by a higher priority action."
     }
   }
 }

--- a/Sources/Lockman/Core/Protocols/LockmanStrategy.swift
+++ b/Sources/Lockman/Core/Protocols/LockmanStrategy.swift
@@ -20,7 +20,11 @@ public enum LockmanResult: Sendable {
   /// When this result is returned, the calling code should:
   /// 1. Cancel the existing operation (usually via Effect cancellation)
   /// 2. Proceed with the new operation
-  case successWithPrecedingCancellation
+  ///
+  /// - Parameter error: An error describing the failure state of the preceding
+  ///   action that will be canceled. This error should be handled appropriately,
+  ///   such as notifying error handlers before proceeding with cancellation.
+  case successWithPrecedingCancellation(error: any Error)
 
   /// Lock acquisition failed due to conflicts.
   ///

--- a/Sources/Lockman/Core/Strategies/CompositeStrategy/LockmanCompositeStrategy.swift
+++ b/Sources/Lockman/Core/Strategies/CompositeStrategy/LockmanCompositeStrategy.swift
@@ -165,11 +165,17 @@ where S1.I == I1, S2.I == I2 {
   ///   - results: Variable number of `LockmanResult` values from component strategies
   /// - Returns: The coordinated result following composite strategy rules
   private func coordinateResults(_ results: LockmanResult...) -> LockmanResult {
+    var cancellationError: (any Error)?
+
     // If any strategy failed, the entire operation fails
     // Return the first failure with its error
     for result in results {
       if case .failure(let error) = result {
         return .failure(error)
+      }
+      // Capture the first cancellation error we encounter
+      if case .successWithPrecedingCancellation(let error) = result, cancellationError == nil {
+        cancellationError = error
       }
     }
 
@@ -179,7 +185,13 @@ where S1.I == I1, S2.I == I2 {
     }
 
     // If any strategy requires cancellation, the operation requires cancellation
-    return .successWithPrecedingCancellation
+    // Use the first cancellation error we found
+    if let error = cancellationError {
+      return .successWithPrecedingCancellation(error: error)
+    }
+
+    // This shouldn't happen if the enum is properly handled
+    fatalError("Unexpected state: successWithPrecedingCancellation expected but no error found")
   }
 }
 
@@ -350,10 +362,16 @@ where S1.I == I1, S2.I == I2, S3.I == I3 {
   // MARK: - Private Helpers
 
   private func coordinateResults(_ results: LockmanResult...) -> LockmanResult {
+    var cancellationError: (any Error)?
+
     // If any strategy failed, return the first failure with its error
     for result in results {
       if case .failure(let error) = result {
         return .failure(error)
+      }
+      // Capture the first cancellation error we encounter
+      if case .successWithPrecedingCancellation(let error) = result, cancellationError == nil {
+        cancellationError = error
       }
     }
 
@@ -361,7 +379,10 @@ where S1.I == I1, S2.I == I2, S3.I == I3 {
       return .success
     }
 
-    return .successWithPrecedingCancellation
+    // If any strategy requires cancellation, use the first cancellation error
+    // At this point, we know at least one result is not .success, so it must be
+    // .successWithPrecedingCancellation, which means cancellationError is set
+    return .successWithPrecedingCancellation(error: cancellationError!)
   }
 }
 
@@ -547,10 +568,16 @@ where S1.I == I1, S2.I == I2, S3.I == I3, S4.I == I4 {
   // MARK: - Private Helpers
 
   private func coordinateResults(_ results: LockmanResult...) -> LockmanResult {
+    var cancellationError: (any Error)?
+
     // If any strategy failed, return the first failure with its error
     for result in results {
       if case .failure(let error) = result {
         return .failure(error)
+      }
+      // Capture the first cancellation error we encounter
+      if case .successWithPrecedingCancellation(let error) = result, cancellationError == nil {
+        cancellationError = error
       }
     }
 
@@ -558,7 +585,10 @@ where S1.I == I1, S2.I == I2, S3.I == I3, S4.I == I4 {
       return .success
     }
 
-    return .successWithPrecedingCancellation
+    // If any strategy requires cancellation, use the first cancellation error
+    // At this point, we know at least one result is not .success, so it must be
+    // .successWithPrecedingCancellation, which means cancellationError is set
+    return .successWithPrecedingCancellation(error: cancellationError!)
   }
 }
 
@@ -776,10 +806,16 @@ where S1.I == I1, S2.I == I2, S3.I == I3, S4.I == I4, S5.I == I5 {
   // MARK: - Private Helpers
 
   private func coordinateResults(_ results: LockmanResult...) -> LockmanResult {
+    var cancellationError: (any Error)?
+
     // If any strategy failed, return the first failure with its error
     for result in results {
       if case .failure(let error) = result {
         return .failure(error)
+      }
+      // Capture the first cancellation error we encounter
+      if case .successWithPrecedingCancellation(let error) = result, cancellationError == nil {
+        cancellationError = error
       }
     }
 
@@ -787,6 +823,9 @@ where S1.I == I1, S2.I == I2, S3.I == I3, S4.I == I4, S5.I == I5 {
       return .success
     }
 
-    return .successWithPrecedingCancellation
+    // If any strategy requires cancellation, use the first cancellation error
+    // At this point, we know at least one result is not .success, so it must be
+    // .successWithPrecedingCancellation, which means cancellationError is set
+    return .successWithPrecedingCancellation(error: cancellationError!)
   }
 }

--- a/Sources/Lockman/Core/Strategies/Core/LockmanState.swift
+++ b/Sources/Lockman/Core/Strategies/Core/LockmanState.swift
@@ -384,37 +384,37 @@ extension LockmanState where K == LockmanActionId {
   convenience init() {
     self.init(keyExtractor: { $0.actionId })
   }
-  
+
   // MARK: - ActionId-specific convenience methods
-  
+
   /// Checks if a specific actionId exists in the boundary.
   ///
   /// Convenience method that calls the generic key-based method.
   func contains<B: LockmanBoundaryId>(id: B, actionId: LockmanActionId) -> Bool {
     contains(id: id, key: actionId)
   }
-  
+
   /// Returns all locks with a specific actionId in the boundary.
   ///
   /// Convenience method that calls the generic key-based method.
   func currents<B: LockmanBoundaryId>(id: B, actionId: LockmanActionId) -> [I] {
     currents(id: id, key: actionId)
   }
-  
+
   /// Returns the count of locks with a specific actionId.
   ///
   /// Convenience method that calls the generic key-based method.
   func count<B: LockmanBoundaryId>(id: B, actionId: LockmanActionId) -> Int {
     count(id: id, key: actionId)
   }
-  
+
   /// Removes all locks with a specific actionId from the boundary.
   ///
   /// Convenience method that calls the generic key-based method.
   func removeAll<B: LockmanBoundaryId>(id: B, actionId: LockmanActionId) {
     removeAll(id: id, key: actionId)
   }
-  
+
   /// Returns all unique actionIds in the boundary.
   ///
   /// Convenience method that calls the generic key-based method.

--- a/Tests/LockmanComposableTests/EffectLockmanPrecedingCancellationTests.swift
+++ b/Tests/LockmanComposableTests/EffectLockmanPrecedingCancellationTests.swift
@@ -1,0 +1,226 @@
+import ComposableArchitecture
+import Foundation
+import XCTest
+
+@testable import Lockman
+
+// MARK: - Preceding Action Cancellation Error Tests
+
+final class EffectWithLockPrecedingCancellationTests: XCTestCase {
+  @Sendable func testPrecedingCancellationError_CallsLockFailureHandler() async {
+    let container = LockmanStrategyContainer()
+    let strategy = LockmanPriorityBasedStrategy()
+    try? container.register(strategy)
+
+    await LockmanManager.withTestContainer(container) {
+      let store = await TestStore(
+        initialState: TestPriorityFeature.State()
+      ) {
+        TestPriorityFeature()
+      }
+
+      // Start a low priority action
+      await store.send(.startLowPriority) {
+        $0.lowPriorityRunning = true
+      }
+
+      // Then start a high priority action that should cancel the low priority one
+      await store.send(.startHighPriority) {
+        $0.highPriorityRunning = true
+      }
+
+      // Should receive the failure handler notification for the cancelled action
+      await store.receive(.lockFailureOccurred("lowPriorityTask")) {
+        $0.lastCancelledActionId = "lowPriorityTask"
+        $0.lockFailureCallCount += 1
+      }
+
+      // High priority task completes
+      await store.receive(.taskCompleted(.high)) {
+        $0.highPriorityRunning = false
+      }
+
+      await store.finish()
+    }
+  }
+
+  @Sendable func testReplaceableBehavior_CallsLockFailureHandler() async {
+    let container = LockmanStrategyContainer()
+    let strategy = LockmanPriorityBasedStrategy()
+    try? container.register(strategy)
+
+    await LockmanManager.withTestContainer(container) {
+      let store = await TestStore(
+        initialState: TestPriorityFeature.State()
+      ) {
+        TestPriorityFeature()
+      }
+
+      // Start a replaceable medium priority action
+      await store.send(.startMediumReplaceable) {
+        $0.mediumPriorityRunning = true
+      }
+
+      // Start another medium priority action that should replace the first one
+      await store.send(.startMediumExclusive) {
+        $0.mediumPriorityRunning = true
+      }
+
+      // Should receive the failure handler notification for the replaced action
+      await store.receive(.lockFailureOccurred("mediumReplaceableTask")) {
+        $0.lastCancelledActionId = "mediumReplaceableTask"
+        $0.lockFailureCallCount += 1
+      }
+
+      // New medium priority task completes
+      await store.receive(.taskCompleted(.medium)) {
+        $0.mediumPriorityRunning = false
+      }
+
+      await store.finish()
+    }
+  }
+
+  // Test feature for priority-based cancellation
+  @Reducer
+  struct TestPriorityFeature {
+    struct State: Equatable {
+      var lowPriorityRunning = false
+      var mediumPriorityRunning = false
+      var highPriorityRunning = false
+      var lastCancelledActionId: String?
+      var lockFailureCallCount = 0
+    }
+
+    enum Action: Equatable {
+      case startLowPriority
+      case startMediumReplaceable
+      case startMediumExclusive
+      case startHighPriority
+      case taskCompleted(Priority)
+      case lockFailureOccurred(String)
+    }
+
+    enum Priority: Equatable {
+      case low, medium, high
+    }
+
+    enum CancelID: LockmanCancelId {
+      case task
+    }
+
+    var body: some ReducerOf<Self> {
+      Reduce { state, action in
+        switch action {
+        case .startLowPriority:
+          state.lowPriorityRunning = true
+          return Effect<Action>.run { send in
+            try? await Task.sleep(nanoseconds: 100_000_000)  // 0.1 second
+            await send(.taskCompleted(.low))
+          }
+          .withLock(
+            strategy: LockmanPriorityBasedStrategy.self,
+            info: LockmanPriorityBasedInfo(
+              actionId: "lowPriorityTask",
+              priority: .low(.exclusive)
+            ),
+            lockFailure: { error, send in
+              if let priorityError = error as? LockmanPriorityBasedError,
+                case .precedingActionCancelled(let actionId) = priorityError
+              {
+                await send(.lockFailureOccurred(actionId))
+              }
+            },
+            action: action,
+            cancelID: CancelID.task
+          )
+
+        case .startMediumReplaceable:
+          state.mediumPriorityRunning = true
+          return Effect<Action>.run { send in
+            try? await Task.sleep(nanoseconds: 100_000_000)  // 0.1 second
+            await send(.taskCompleted(.medium))
+          }
+          .withLock(
+            strategy: LockmanPriorityBasedStrategy.self,
+            info: LockmanPriorityBasedInfo(
+              actionId: "mediumReplaceableTask",
+              priority: .medium(.replaceable)
+            ),
+            lockFailure: { error, send in
+              if let priorityError = error as? LockmanPriorityBasedError,
+                case .precedingActionCancelled(let actionId) = priorityError
+              {
+                await send(.lockFailureOccurred(actionId))
+              }
+            },
+            action: action,
+            cancelID: CancelID.task
+          )
+
+        case .startMediumExclusive:
+          state.mediumPriorityRunning = true
+          return Effect<Action>.run { send in
+            try? await Task.sleep(nanoseconds: 50_000_000)  // 0.05 second
+            await send(.taskCompleted(.medium))
+          }
+          .withLock(
+            strategy: LockmanPriorityBasedStrategy.self,
+            info: LockmanPriorityBasedInfo(
+              actionId: "mediumExclusiveTask",
+              priority: .medium(.exclusive)
+            ),
+            lockFailure: { error, send in
+              if let priorityError = error as? LockmanPriorityBasedError,
+                case .precedingActionCancelled(let actionId) = priorityError
+              {
+                await send(.lockFailureOccurred(actionId))
+              }
+            },
+            action: action,
+            cancelID: CancelID.task
+          )
+
+        case .startHighPriority:
+          state.highPriorityRunning = true
+          return Effect<Action>.run { send in
+            try? await Task.sleep(nanoseconds: 50_000_000)  // 0.05 second
+            await send(.taskCompleted(.high))
+          }
+          .withLock(
+            strategy: LockmanPriorityBasedStrategy.self,
+            info: LockmanPriorityBasedInfo(
+              actionId: "highPriorityTask",
+              priority: .high(.exclusive)
+            ),
+            lockFailure: { error, send in
+              if let priorityError = error as? LockmanPriorityBasedError,
+                case .precedingActionCancelled(let actionId) = priorityError
+              {
+                await send(.lockFailureOccurred(actionId))
+              }
+            },
+            action: action,
+            cancelID: CancelID.task
+          )
+
+        case let .taskCompleted(priority):
+          switch priority {
+          case .low:
+            state.lowPriorityRunning = false
+          case .medium:
+            state.mediumPriorityRunning = false
+          case .high:
+            state.highPriorityRunning = false
+          }
+          return .none
+
+        case let .lockFailureOccurred(actionId):
+          state.lastCancelledActionId = actionId
+          state.lockFailureCallCount += 1
+          return .none
+        }
+      }
+    }
+  }
+}

--- a/Tests/LockmanCoreTests/CompositeTests/LockmanCompositeBasicTests.swift
+++ b/Tests/LockmanCoreTests/CompositeTests/LockmanCompositeBasicTests.swift
@@ -163,7 +163,11 @@ final class LockmanCompositeBasicTests: XCTestCase {
     )
 
     let result = composite.canLock(id: boundaryId, info: info)
-    XCTAssertEqual(result, .successWithPrecedingCancellation)
+    if case .successWithPrecedingCancellation = result {
+      // Success - precedingActionCancelled is expected
+    } else {
+      XCTFail("Expected successWithPrecedingCancellation but got \(result)")
+    }
 
     // Cleanup
     priority.cleanUp(id: boundaryId)

--- a/Tests/LockmanCoreTests/LockmanEdgeCaseTests.swift
+++ b/Tests/LockmanCoreTests/LockmanEdgeCaseTests.swift
@@ -135,7 +135,13 @@ final class LockmanEdgeCaseTests: XCTestCase {
 
     // High priority should succeed (may not cancel if none priority doesn't block)
     let result = strategy.canLock(id: boundaryId, info: highInfo)
-    XCTAssertTrue(result == .success || result == .successWithPrecedingCancellation)
+    switch result {
+    case .success, .successWithPrecedingCancellation:
+      // Success - either immediate success or with cancellation
+      break
+    case .failure(let error):
+      XCTFail("Expected success or successWithPrecedingCancellation but got failure: \(error)")
+    }
 
     strategy.cleanUp()
   }

--- a/Tests/LockmanCoreTests/LockmanMainTests.swift
+++ b/Tests/LockmanCoreTests/LockmanMainTests.swift
@@ -327,7 +327,11 @@ final class LockmanMainTests: XCTestCase {
 
         priorityStrategy.lock(id: priorityBoundary, info: lowPriorityInfo)
         let canLockHigh = priorityStrategy.canLock(id: priorityBoundary, info: highPriorityInfo)
-        XCTAssertEqual(canLockHigh, .successWithPrecedingCancellation)
+        if case .successWithPrecedingCancellation = canLockHigh {
+          // Success - precedingActionCancelled is expected
+        } else {
+          XCTFail("Expected successWithPrecedingCancellation but got \(canLockHigh)")
+        }
 
         // 4. Clean up
         LockmanManager.cleanup.all()

--- a/Tests/LockmanCoreTests/PriorityBasedTests/LockmanPriorityBasedInfoTests.swift
+++ b/Tests/LockmanCoreTests/PriorityBasedTests/LockmanPriorityBasedInfoTests.swift
@@ -473,8 +473,11 @@ final class LockmanPriorityBasedInfoIntegrationTests: XCTestCase {
       XCTAssertEqual(resolvedStrategy.canLock(id: boundaryId, info: info3), .success)
 
       // Higher priority preempts lower priority
-      XCTAssertEqual(
-        resolvedStrategy.canLock(id: boundaryId, info: info2), .successWithPrecedingCancellation)
+      if case .successWithPrecedingCancellation = resolvedStrategy.canLock(id: boundaryId, info: info2) {
+        // Success - expected behavior
+      } else {
+        XCTFail("Expected successWithPrecedingCancellation")
+      }
 
       resolvedStrategy.cleanUp()
     }
@@ -497,9 +500,11 @@ final class LockmanPriorityBasedInfoIntegrationTests: XCTestCase {
     strategy.lock(id: boundaryId, info: lowExclusiveInfo)
 
     // High priority preempts low priority
-    XCTAssertEqual(
-      strategy.canLock(id: boundaryId, info: highReplaceableInfo), .successWithPrecedingCancellation
-    )
+    if case .successWithPrecedingCancellation = strategy.canLock(id: boundaryId, info: highReplaceableInfo) {
+      // Success - expected behavior
+    } else {
+      XCTFail("Expected successWithPrecedingCancellation")
+    }
     strategy.lock(id: boundaryId, info: highReplaceableInfo)
 
     // Another low priority fails against high priority

--- a/Tests/LockmanMacrosTests/LockmanConcurrencyLimitedMacroTests.swift
+++ b/Tests/LockmanMacrosTests/LockmanConcurrencyLimitedMacroTests.swift
@@ -1,392 +1,392 @@
 #if canImport(LockmanMacros)
-import LockmanMacros
-import MacroTesting
-import SwiftSyntax
-import SwiftSyntaxBuilder
-import SwiftSyntaxMacros
-import XCTest
+  import LockmanMacros
+  import MacroTesting
+  import SwiftSyntax
+  import SwiftSyntaxBuilder
+  import SwiftSyntaxMacros
+  import XCTest
 
-// MARK: - LockmanConcurrencyLimitedMacro Tests
+  // MARK: - LockmanConcurrencyLimitedMacro Tests
 
-final class LockmanConcurrencyLimitedMacroTests: XCTestCase {
-  override func invokeTest() {
-    // Configure macro testing to not record and to show diffs
-    withMacroTesting(
-      record: false,
-      macros: [
-        "LockmanConcurrencyLimited": LockmanConcurrencyLimitedMacro.self
-      ]
-    ) {
-      super.invokeTest()
-    }
-  }
-
-  // MARK: - Basic Expansion Tests
-
-  func testBasicEnumExpansion() {
-    assertMacro {
-      """
-      @LockmanConcurrencyLimited
-      enum ViewAction {
-        case fetchUserProfile
-        case uploadFile
+  final class LockmanConcurrencyLimitedMacroTests: XCTestCase {
+    override func invokeTest() {
+      // Configure macro testing to not record and to show diffs
+      withMacroTesting(
+        record: false,
+        macros: [
+          "LockmanConcurrencyLimited": LockmanConcurrencyLimitedMacro.self
+        ]
+      ) {
+        super.invokeTest()
       }
-      """
-    } expansion: {
-      """
-      enum ViewAction {
-        case fetchUserProfile
-        case uploadFile
+    }
 
-        internal var actionName: String {
-          switch self {
-          case .fetchUserProfile:
-            return "fetchUserProfile"
-          case .uploadFile:
-            return "uploadFile"
+    // MARK: - Basic Expansion Tests
+
+    func testBasicEnumExpansion() {
+      assertMacro {
+        """
+        @LockmanConcurrencyLimited
+        enum ViewAction {
+          case fetchUserProfile
+          case uploadFile
+        }
+        """
+      } expansion: {
+        """
+        enum ViewAction {
+          case fetchUserProfile
+          case uploadFile
+
+          internal var actionName: String {
+            switch self {
+            case .fetchUserProfile:
+              return "fetchUserProfile"
+            case .uploadFile:
+              return "uploadFile"
+            }
           }
         }
-      }
 
-      extension ViewAction: LockmanConcurrencyLimitedAction {
+        extension ViewAction: LockmanConcurrencyLimitedAction {
+        }
+        """
       }
-      """
     }
-  }
 
-  func testEnumWithAssociatedValues() {
-    assertMacro {
-      """
-      @LockmanConcurrencyLimited
-      enum ViewAction {
-        case fetchUserProfile(userId: String)
-        case uploadFile(name: String, size: Int)
-        case processData
-      }
-      """
-    } expansion: {
-      """
-      enum ViewAction {
-        case fetchUserProfile(userId: String)
-        case uploadFile(name: String, size: Int)
-        case processData
+    func testEnumWithAssociatedValues() {
+      assertMacro {
+        """
+        @LockmanConcurrencyLimited
+        enum ViewAction {
+          case fetchUserProfile(userId: String)
+          case uploadFile(name: String, size: Int)
+          case processData
+        }
+        """
+      } expansion: {
+        """
+        enum ViewAction {
+          case fetchUserProfile(userId: String)
+          case uploadFile(name: String, size: Int)
+          case processData
 
-        internal var actionName: String {
-          switch self {
-          case .fetchUserProfile(_):
-            return "fetchUserProfile"
-          case .uploadFile(_, _):
-            return "uploadFile"
-          case .processData:
-            return "processData"
+          internal var actionName: String {
+            switch self {
+            case .fetchUserProfile(_):
+              return "fetchUserProfile"
+            case .uploadFile(_, _):
+              return "uploadFile"
+            case .processData:
+              return "processData"
+            }
           }
         }
-      }
 
-      extension ViewAction: LockmanConcurrencyLimitedAction {
+        extension ViewAction: LockmanConcurrencyLimitedAction {
+        }
+        """
       }
-      """
     }
-  }
 
-  // MARK: - Access Level Tests
+    // MARK: - Access Level Tests
 
-  func testPublicEnumExpansion() {
-    assertMacro {
-      """
-      @LockmanConcurrencyLimited
-      public enum ViewAction {
-        case fetchData
-        case saveData
-      }
-      """
-    } expansion: {
-      """
-      public enum ViewAction {
-        case fetchData
-        case saveData
+    func testPublicEnumExpansion() {
+      assertMacro {
+        """
+        @LockmanConcurrencyLimited
+        public enum ViewAction {
+          case fetchData
+          case saveData
+        }
+        """
+      } expansion: {
+        """
+        public enum ViewAction {
+          case fetchData
+          case saveData
 
-        public var actionName: String {
-          switch self {
-          case .fetchData:
-            return "fetchData"
-          case .saveData:
-            return "saveData"
+          public var actionName: String {
+            switch self {
+            case .fetchData:
+              return "fetchData"
+            case .saveData:
+              return "saveData"
+            }
           }
         }
-      }
 
-      extension ViewAction: LockmanConcurrencyLimitedAction {
+        extension ViewAction: LockmanConcurrencyLimitedAction {
+        }
+        """
       }
-      """
     }
-  }
 
-  func testInternalEnumExpansion() {
-    assertMacro {
-      """
-      @LockmanConcurrencyLimited
-      internal enum ViewAction {
-        case action1
-        case action2
-      }
-      """
-    } expansion: {
-      """
-      internal enum ViewAction {
-        case action1
-        case action2
+    func testInternalEnumExpansion() {
+      assertMacro {
+        """
+        @LockmanConcurrencyLimited
+        internal enum ViewAction {
+          case action1
+          case action2
+        }
+        """
+      } expansion: {
+        """
+        internal enum ViewAction {
+          case action1
+          case action2
 
-        internal var actionName: String {
-          switch self {
-          case .action1:
-            return "action1"
-          case .action2:
-            return "action2"
+          internal var actionName: String {
+            switch self {
+            case .action1:
+              return "action1"
+            case .action2:
+              return "action2"
+            }
           }
         }
-      }
 
-      extension ViewAction: LockmanConcurrencyLimitedAction {
+        extension ViewAction: LockmanConcurrencyLimitedAction {
+        }
+        """
       }
-      """
     }
-  }
 
-  // MARK: - Edge Case Tests
+    // MARK: - Edge Case Tests
 
-  func testEmptyEnum() {
-    assertMacro {
-      """
-      @LockmanConcurrencyLimited
-      enum EmptyAction {
-      }
-      """
-    } expansion: {
-      """
-      enum EmptyAction {
-      }
+    func testEmptyEnum() {
+      assertMacro {
+        """
+        @LockmanConcurrencyLimited
+        enum EmptyAction {
+        }
+        """
+      } expansion: {
+        """
+        enum EmptyAction {
+        }
 
-      extension EmptyAction: LockmanConcurrencyLimitedAction {
+        extension EmptyAction: LockmanConcurrencyLimitedAction {
+        }
+        """
       }
-      """
     }
-  }
 
-  func testSingleCaseEnum() {
-    assertMacro {
-      """
-      @LockmanConcurrencyLimited
-      enum SingleAction {
-        case onlyAction
-      }
-      """
-    } expansion: {
-      """
-      enum SingleAction {
-        case onlyAction
+    func testSingleCaseEnum() {
+      assertMacro {
+        """
+        @LockmanConcurrencyLimited
+        enum SingleAction {
+          case onlyAction
+        }
+        """
+      } expansion: {
+        """
+        enum SingleAction {
+          case onlyAction
 
-        internal var actionName: String {
-          switch self {
-          case .onlyAction:
-            return "onlyAction"
+          internal var actionName: String {
+            switch self {
+            case .onlyAction:
+              return "onlyAction"
+            }
           }
         }
-      }
 
-      extension SingleAction: LockmanConcurrencyLimitedAction {
+        extension SingleAction: LockmanConcurrencyLimitedAction {
+        }
+        """
       }
-      """
     }
-  }
 
-  func testComplexAssociatedValues() {
-    assertMacro {
-      """
-      @LockmanConcurrencyLimited
-      enum ComplexAction {
-        case simple
-        case withTuple((Int, String))
-        case withClosure(() -> Void)
-        case withOptional(String?)
-        case withMultiple(a: Int, b: String, c: Bool)
-      }
-      """
-    } expansion: {
-      """
-      enum ComplexAction {
-        case simple
-        case withTuple((Int, String))
-        case withClosure(() -> Void)
-        case withOptional(String?)
-        case withMultiple(a: Int, b: String, c: Bool)
+    func testComplexAssociatedValues() {
+      assertMacro {
+        """
+        @LockmanConcurrencyLimited
+        enum ComplexAction {
+          case simple
+          case withTuple((Int, String))
+          case withClosure(() -> Void)
+          case withOptional(String?)
+          case withMultiple(a: Int, b: String, c: Bool)
+        }
+        """
+      } expansion: {
+        """
+        enum ComplexAction {
+          case simple
+          case withTuple((Int, String))
+          case withClosure(() -> Void)
+          case withOptional(String?)
+          case withMultiple(a: Int, b: String, c: Bool)
 
-        internal var actionName: String {
-          switch self {
-          case .simple:
-            return "simple"
-          case .withTuple(_):
-            return "withTuple"
-          case .withClosure(_):
-            return "withClosure"
-          case .withOptional(_):
-            return "withOptional"
-          case .withMultiple(_, _, _):
-            return "withMultiple"
+          internal var actionName: String {
+            switch self {
+            case .simple:
+              return "simple"
+            case .withTuple(_):
+              return "withTuple"
+            case .withClosure(_):
+              return "withClosure"
+            case .withOptional(_):
+              return "withOptional"
+            case .withMultiple(_, _, _):
+              return "withMultiple"
+            }
           }
         }
-      }
 
-      extension ComplexAction: LockmanConcurrencyLimitedAction {
+        extension ComplexAction: LockmanConcurrencyLimitedAction {
+        }
+        """
       }
-      """
     }
-  }
 
-  // MARK: - Error Cases
+    // MARK: - Error Cases
 
-  func testMacroOnStruct() {
-    assertMacro {
-      """
-      @LockmanConcurrencyLimited
-      struct ViewAction {
-        let name: String
+    func testMacroOnStruct() {
+      assertMacro {
+        """
+        @LockmanConcurrencyLimited
+        struct ViewAction {
+          let name: String
+        }
+        """
+      } diagnostics: {
+        """
+        @LockmanConcurrencyLimited
+        ┬─────────────────────────
+        ╰─ 🛑 @LockmanConcurrencyLimited can only be attached to an enum declaration.
+        struct ViewAction {
+          let name: String
+        }
+        """
       }
-      """
-    } diagnostics: {
-      """
-      @LockmanConcurrencyLimited
-      ┬─────────────────────────
-      ╰─ 🛑 @LockmanConcurrencyLimited can only be attached to an enum declaration.
-      struct ViewAction {
-        let name: String
-      }
-      """
     }
-  }
 
-  func testMacroOnClass() {
-    assertMacro {
-      """
-      @LockmanConcurrencyLimited
-      class ViewAction {
-        var name: String = ""
+    func testMacroOnClass() {
+      assertMacro {
+        """
+        @LockmanConcurrencyLimited
+        class ViewAction {
+          var name: String = ""
+        }
+        """
+      } diagnostics: {
+        """
+        @LockmanConcurrencyLimited
+        ┬─────────────────────────
+        ╰─ 🛑 @LockmanConcurrencyLimited can only be attached to an enum declaration.
+        class ViewAction {
+          var name: String = ""
+        }
+        """
       }
-      """
-    } diagnostics: {
-      """
-      @LockmanConcurrencyLimited
-      ┬─────────────────────────
-      ╰─ 🛑 @LockmanConcurrencyLimited can only be attached to an enum declaration.
-      class ViewAction {
-        var name: String = ""
-      }
-      """
     }
-  }
 
-  func testMacroOnProtocol() {
-    assertMacro {
-      """
-      @LockmanConcurrencyLimited
-      protocol ViewAction {
-        var name: String { get }
+    func testMacroOnProtocol() {
+      assertMacro {
+        """
+        @LockmanConcurrencyLimited
+        protocol ViewAction {
+          var name: String { get }
+        }
+        """
+      } diagnostics: {
+        """
+        @LockmanConcurrencyLimited
+        ┬─────────────────────────
+        ╰─ 🛑 @LockmanConcurrencyLimited can only be attached to an enum declaration.
+        protocol ViewAction {
+          var name: String { get }
+        }
+        """
       }
-      """
-    } diagnostics: {
-      """
-      @LockmanConcurrencyLimited
-      ┬─────────────────────────
-      ╰─ 🛑 @LockmanConcurrencyLimited can only be attached to an enum declaration.
-      protocol ViewAction {
-        var name: String { get }
-      }
-      """
     }
-  }
 
-  // MARK: - Integration Tests
+    // MARK: - Integration Tests
 
-  func testRealWorldExample() {
-    assertMacro {
-      """
-      @LockmanConcurrencyLimited
-      public enum FeatureAction {
-        case fetchUserProfile(userId: String)
-        case fetchUserPosts(userId: String, page: Int)
-        case uploadImage(data: Data, metadata: [String: Any])
-        case deletePost(postId: String)
-        case refreshFeed
-      }
-      """
-    } expansion: {
-      """
-      public enum FeatureAction {
-        case fetchUserProfile(userId: String)
-        case fetchUserPosts(userId: String, page: Int)
-        case uploadImage(data: Data, metadata: [String: Any])
-        case deletePost(postId: String)
-        case refreshFeed
+    func testRealWorldExample() {
+      assertMacro {
+        """
+        @LockmanConcurrencyLimited
+        public enum FeatureAction {
+          case fetchUserProfile(userId: String)
+          case fetchUserPosts(userId: String, page: Int)
+          case uploadImage(data: Data, metadata: [String: Any])
+          case deletePost(postId: String)
+          case refreshFeed
+        }
+        """
+      } expansion: {
+        """
+        public enum FeatureAction {
+          case fetchUserProfile(userId: String)
+          case fetchUserPosts(userId: String, page: Int)
+          case uploadImage(data: Data, metadata: [String: Any])
+          case deletePost(postId: String)
+          case refreshFeed
 
-        public var actionName: String {
-          switch self {
-          case .fetchUserProfile(_):
-            return "fetchUserProfile"
-          case .fetchUserPosts(_, _):
-            return "fetchUserPosts"
-          case .uploadImage(_, _):
-            return "uploadImage"
-          case .deletePost(_):
-            return "deletePost"
-          case .refreshFeed:
-            return "refreshFeed"
+          public var actionName: String {
+            switch self {
+            case .fetchUserProfile(_):
+              return "fetchUserProfile"
+            case .fetchUserPosts(_, _):
+              return "fetchUserPosts"
+            case .uploadImage(_, _):
+              return "uploadImage"
+            case .deletePost(_):
+              return "deletePost"
+            case .refreshFeed:
+              return "refreshFeed"
+            }
           }
         }
-      }
 
-      extension FeatureAction: LockmanConcurrencyLimitedAction {
+        extension FeatureAction: LockmanConcurrencyLimitedAction {
+        }
+        """
       }
-      """
     }
-  }
 
-  // MARK: - Multi-case Declaration Tests
+    // MARK: - Multi-case Declaration Tests
 
-  func testMultipleCasesInOneDeclaration() {
-    assertMacro {
-      """
-      @LockmanConcurrencyLimited
-      enum Action {
-        case a, b, c
-        case d(Int), e(String)
-      }
-      """
-    } expansion: {
-      """
-      enum Action {
-        case a, b, c
-        case d(Int), e(String)
+    func testMultipleCasesInOneDeclaration() {
+      assertMacro {
+        """
+        @LockmanConcurrencyLimited
+        enum Action {
+          case a, b, c
+          case d(Int), e(String)
+        }
+        """
+      } expansion: {
+        """
+        enum Action {
+          case a, b, c
+          case d(Int), e(String)
 
-        internal var actionName: String {
-          switch self {
-          case .a:
-            return "a"
-          case .b:
-            return "b"
-          case .c:
-            return "c"
-          case .d(_):
-            return "d"
-          case .e(_):
-            return "e"
+          internal var actionName: String {
+            switch self {
+            case .a:
+              return "a"
+            case .b:
+              return "b"
+            case .c:
+              return "c"
+            case .d(_):
+              return "d"
+            case .e(_):
+              return "e"
+            }
           }
         }
-      }
 
-      extension Action: LockmanConcurrencyLimitedAction {
+        extension Action: LockmanConcurrencyLimitedAction {
+        }
+        """
       }
-      """
     }
   }
-}
 #endif


### PR DESCRIPTION
## Summary
- Add error information to `LockmanResult.successWithPrecedingCancellation` case
- Implement `lockFailure` handler calls when preceding actions are cancelled
- Add new error case `precedingActionCancelled` to track cancelled actions

## Changes

### Core Changes
1. **LockmanPriorityBasedError**
   - Added `precedingActionCancelled(actionId: String)` case
   - Removed unused `precedingActionFailed` case

2. **LockmanResult**
   - Updated `successWithPrecedingCancellation` to include `error: Error` parameter
   - Added documentation for the error parameter

3. **withLock Method**
   - Now calls `lockFailure` handler when preceding actions are cancelled
   - Provides error information about the cancelled action

### Strategy Updates
- **LockmanPriorityBasedStrategy**: Returns appropriate error when preempting actions
- **LockmanCompositeStrategy**: Properly propagates cancellation errors
- **LockmanLogger**: Updated to log error information

## Test plan
- [x] Added unit tests for error information in `LockmanPriorityBasedStrategyTests`
- [x] Added integration tests for `lockFailure` handler in `EffectLockmanPrecedingCancellationTests`
- [x] All existing tests pass
- [x] Code builds without warnings

🤖 Generated with [Claude Code](https://claude.ai/code)