### PR TITLE
feat: add Info objects to LockmanError

### DIFF
--- a/Sources/Lockman/Core/Debug/LockmanDebugFormatters.swift
+++ b/Sources/Lockman/Core/Debug/LockmanDebugFormatters.swift
@@ -59,6 +59,8 @@ extension LockmanManager.debug {
       return "DynamicCondition"
     case "LockmanGroupCoordinatedStrategy":
       return "GroupCoordinated"
+    case "LockmanConcurrencyLimitedStrategy":
+      return "ConcurrencyLimited"
     default:
       // For other strategies, remove "Lockman" prefix and "Strategy" suffix
       var result = withoutModule
@@ -341,6 +343,9 @@ extension LockmanManager.debug {
     case let groupCoordinated as LockmanGroupCoordinatedInfo:
       let groupsStr = groupCoordinated.groupIds.map { "\($0)" }.sorted().joined(separator: ",")
       return "groups: \(groupsStr) r: \(groupCoordinated.coordinationRole)"
+      
+    case let concurrencyLimited as LockmanConcurrencyLimitedInfo:
+      return "concurrency: \(concurrencyLimited.concurrencyId) limit: \(concurrencyLimited.limit)"
 
     case is any LockmanCompositeInfo:
       return "Composite"
@@ -361,6 +366,8 @@ extension LockmanManager.debug {
       return "DynamicCondition"
     case is LockmanGroupCoordinatedInfo:
       return "GroupCoordination"
+    case is LockmanConcurrencyLimitedInfo:
+      return "ConcurrencyLimited"
     default:
       return "Unknown"
     }

--- a/Sources/Lockman/Core/Debug/LockmanDebugFormatters.swift
+++ b/Sources/Lockman/Core/Debug/LockmanDebugFormatters.swift
@@ -324,35 +324,8 @@ extension LockmanManager.debug {
 
   /// Extracts additional information from lock info based on its type.
   private static func extractAdditionalInfo(from info: any LockmanInfo) -> String {
-    switch info {
-    case let singleExecution as LockmanSingleExecutionInfo:
-      return "mode: \(singleExecution.mode)"
-
-    case let priorityBased as LockmanPriorityBasedInfo:
-      let priority = priorityBased.priority
-      var result = "priority: \(priority)"
-      if let behavior = priority.behavior {
-        let behaviorStr = behavior == .exclusive ? ".exclusive" : ".replaceable"
-        result = String(result.prefix(20 - 13)) + " b: " + behaviorStr
-      }
-      return result
-
-    case is LockmanDynamicConditionInfo:
-      return "condition: <closure>"
-
-    case let groupCoordinated as LockmanGroupCoordinatedInfo:
-      let groupsStr = groupCoordinated.groupIds.map { "\($0)" }.sorted().joined(separator: ",")
-      return "groups: \(groupsStr) r: \(groupCoordinated.coordinationRole)"
-      
-    case let concurrencyLimited as LockmanConcurrencyLimitedInfo:
-      return "concurrency: \(concurrencyLimited.concurrencyId) limit: \(concurrencyLimited.limit)"
-
-    case is any LockmanCompositeInfo:
-      return "Composite"
-
-    default:
-      return ""
-    }
+    // Use the debugAdditionalInfo property defined by each info type
+    return info.debugAdditionalInfo
   }
 
   /// Gets the strategy name for a given lock info type.

--- a/Sources/Lockman/Core/Errors/LockmanConcurrencyLimitedError.swift
+++ b/Sources/Lockman/Core/Errors/LockmanConcurrencyLimitedError.swift
@@ -3,12 +3,16 @@ import Foundation
 /// Errors specific to concurrency-limited locking.
 public enum LockmanConcurrencyLimitedError: LockmanError {
   /// The concurrency limit has been reached.
-  case concurrencyLimitReached(concurrencyId: String, limit: Int, current: Int)
+  /// - Parameters:
+  ///   - requestedInfo: The info of the action that was blocked
+  ///   - existingInfos: Array of currently active infos in the same concurrency group
+  ///   - current: Current number of active concurrent executions
+  case concurrencyLimitReached(requestedInfo: LockmanConcurrencyLimitedInfo, existingInfos: [LockmanConcurrencyLimitedInfo], current: Int)
 
   public var errorDescription: String? {
     switch self {
-    case let .concurrencyLimitReached(concurrencyId, limit, current):
-      return "Concurrency limit reached for '\(concurrencyId)': \(current)/\(limit)"
+    case let .concurrencyLimitReached(requestedInfo, _, current):
+      return "Concurrency limit reached for '\(requestedInfo.concurrencyId)': \(current)/\(requestedInfo.limit)"
     }
   }
 

--- a/Sources/Lockman/Core/Errors/LockmanGroupCoordinationError.swift
+++ b/Sources/Lockman/Core/Errors/LockmanGroupCoordinationError.swift
@@ -20,13 +20,13 @@ public enum LockmanGroupCoordinationError: LockmanError {
   /// Indicates that an action with the same ID is already in the group.
   ///
   /// Each action ID must be unique within a coordination group.
-  case actionAlreadyInGroup(actionId: String, groupIds: Set<AnyLockmanGroupId>)
+  case actionAlreadyInGroup(existingInfo: LockmanGroupCoordinatedInfo, groupIds: Set<AnyLockmanGroupId>)
 
   /// Indicates that an action is blocked by an exclusive leader.
   ///
   /// Exclusive leaders can prevent other actions from executing based on their entry policy.
   case blockedByExclusiveLeader(
-    leaderActionId: String, groupId: AnyLockmanGroupId,
+    leaderInfo: LockmanGroupCoordinatedInfo, groupId: AnyLockmanGroupId,
     entryPolicy: GroupCoordinationRole.LeaderEntryPolicy)
 
   public var errorDescription: String? {
@@ -37,12 +37,12 @@ public enum LockmanGroupCoordinationError: LockmanError {
     case let .memberCannotJoinEmptyGroup(groupIds):
       return
         "Cannot acquire lock: member cannot join empty groups \(groupIds.map { "\($0)" }.sorted())."
-    case let .actionAlreadyInGroup(actionId, groupIds):
+    case let .actionAlreadyInGroup(existingInfo, groupIds):
       return
-        "Cannot acquire lock: action '\(actionId)' is already in groups \(groupIds.map { "\($0)" }.sorted())."
-    case let .blockedByExclusiveLeader(leaderActionId, groupId, entryPolicy):
+        "Cannot acquire lock: action '\(existingInfo.actionId)' is already in groups \(groupIds.map { "\($0)" }.sorted())."
+    case let .blockedByExclusiveLeader(leaderInfo, groupId, entryPolicy):
       return
-        "Cannot acquire lock: blocked by exclusive leader '\(leaderActionId)' in group '\(groupId)' (policy: \(entryPolicy))."
+        "Cannot acquire lock: blocked by exclusive leader '\(leaderInfo.actionId)' in group '\(groupId)' (policy: \(entryPolicy))."
     }
   }
 

--- a/Sources/Lockman/Core/Errors/LockmanPriorityBasedError.swift
+++ b/Sources/Lockman/Core/Errors/LockmanPriorityBasedError.swift
@@ -24,14 +24,14 @@ public enum LockmanPriorityBasedError: LockmanError {
   ///
   /// This occurs when the strategy is configured to block duplicate actions
   /// regardless of priority.
-  case blockedBySameAction(actionId: String)
+  case blockedBySameAction(existingInfo: LockmanPriorityBasedInfo)
 
   /// Indicates that a preceding action will be cancelled due to preemption.
   ///
   /// This occurs when a higher priority action preempts a lower priority action.
   /// The lower priority action will be cancelled to allow the higher priority
   /// action to proceed.
-  case precedingActionCancelled(actionId: String)
+  case precedingActionCancelled(cancelledInfo: LockmanPriorityBasedInfo)
 
   public var errorDescription: String? {
     switch self {
@@ -40,12 +40,12 @@ public enum LockmanPriorityBasedError: LockmanError {
         "Cannot acquire lock: requested priority \(requested) is lower than current highest priority \(currentHighest)."
     case let .samePriorityConflict(priority):
       return "Cannot acquire lock: another action with priority \(priority) is already running."
-    case let .blockedBySameAction(actionId):
+    case let .blockedBySameAction(existingInfo):
       return
-        "Cannot acquire lock: action '\(actionId)' is already running and duplicates are blocked."
-    case let .precedingActionCancelled(actionId):
+        "Cannot acquire lock: action '\(existingInfo.actionId)' is already running and duplicates are blocked."
+    case let .precedingActionCancelled(cancelledInfo):
       return
-        "Lock acquired, preceding action '\(actionId)' will be cancelled."
+        "Lock acquired, preceding action '\(cancelledInfo.actionId)' will be cancelled."
     }
   }
 

--- a/Sources/Lockman/Core/Errors/LockmanSingleExecutionError.swift
+++ b/Sources/Lockman/Core/Errors/LockmanSingleExecutionError.swift
@@ -11,20 +11,20 @@ public enum LockmanSingleExecutionError: LockmanError {
   ///
   /// This occurs when attempting to acquire a boundary-scoped lock while
   /// another operation is already holding a lock in the same boundary.
-  case boundaryAlreadyLocked(boundaryId: String)
+  case boundaryAlreadyLocked(boundaryId: String, existingInfo: LockmanSingleExecutionInfo)
 
   /// Indicates that an action with the same ID is already running.
   ///
   /// This occurs when attempting to execute an action while another instance
   /// of the same action is already in progress.
-  case actionAlreadyRunning(actionId: String)
+  case actionAlreadyRunning(existingInfo: LockmanSingleExecutionInfo)
 
   public var errorDescription: String? {
     switch self {
-    case let .boundaryAlreadyLocked(boundaryId):
-      return "Cannot acquire lock: boundary '\(boundaryId)' already has an active lock."
-    case let .actionAlreadyRunning(actionId):
-      return "Cannot acquire lock: action '\(actionId)' is already running."
+    case let .boundaryAlreadyLocked(boundaryId, existingInfo):
+      return "Cannot acquire lock: boundary '\(boundaryId)' already has an active lock for action '\(existingInfo.actionId)'."
+    case let .actionAlreadyRunning(existingInfo):
+      return "Cannot acquire lock: action '\(existingInfo.actionId)' is already running."
     }
   }
 

--- a/Sources/Lockman/Core/Protocols/LockmanInfo.swift
+++ b/Sources/Lockman/Core/Protocols/LockmanInfo.swift
@@ -56,4 +56,34 @@ public protocol LockmanInfo: Sendable, CustomDebugStringConvertible {
   /// This is typically a `UUID` that is automatically generated during
   /// initialization to ensure uniqueness across all instances.
   var uniqueId: UUID { get }
+  
+  /// Returns additional debug information specific to this lock info type.
+  ///
+  /// This method provides a formatted string containing strategy-specific
+  /// information that is useful for debugging. The returned string should
+  /// be concise and suitable for display in debug output tables.
+  ///
+  /// ## Default Implementation
+  /// Returns an empty string by default. Concrete types should override
+  /// this to provide meaningful debug information.
+  ///
+  /// ## Examples
+  /// ```swift
+  /// // SingleExecutionInfo
+  /// "mode: boundary"
+  ///
+  /// // PriorityBasedInfo
+  /// "priority: high b: .exclusive"
+  ///
+  /// // ConcurrencyLimitedInfo
+  /// "concurrency: api_requests limit: limited(3)"
+  /// ```
+  var debugAdditionalInfo: String { get }
+}
+
+// MARK: - Default Implementation
+
+extension LockmanInfo {
+  /// Default implementation returns an empty string.
+  public var debugAdditionalInfo: String { "" }
 }

--- a/Sources/Lockman/Core/Strategies/CompositeStrategy/LockmanCompositeInfo.swift
+++ b/Sources/Lockman/Core/Strategies/CompositeStrategy/LockmanCompositeInfo.swift
@@ -80,6 +80,10 @@ extension LockmanCompositeInfo2: CustomDebugStringConvertible {
   public var debugDescription: String {
     "LockmanCompositeInfo2(actionId: '\(actionId)', uniqueId: \(uniqueId), info1: \(lockmanInfoForStrategy1.debugDescription), info2: \(lockmanInfoForStrategy2.debugDescription))"
   }
+  
+  public var debugAdditionalInfo: String {
+    "Composite"
+  }
 }
 
 // MARK: - LockmanCompositeInfo3
@@ -139,6 +143,10 @@ public struct LockmanCompositeInfo3<I1: LockmanInfo, I2: LockmanInfo, I3: Lockma
 extension LockmanCompositeInfo3: CustomDebugStringConvertible {
   public var debugDescription: String {
     "LockmanCompositeInfo3(actionId: '\(actionId)', uniqueId: \(uniqueId), info1: \(lockmanInfoForStrategy1.debugDescription), info2: \(lockmanInfoForStrategy2.debugDescription), info3: \(lockmanInfoForStrategy3.debugDescription))"
+  }
+  
+  public var debugAdditionalInfo: String {
+    "Composite"
   }
 }
 
@@ -205,6 +213,10 @@ public struct LockmanCompositeInfo4<
 extension LockmanCompositeInfo4: CustomDebugStringConvertible {
   public var debugDescription: String {
     "LockmanCompositeInfo4(actionId: '\(actionId)', uniqueId: \(uniqueId), info1: \(lockmanInfoForStrategy1.debugDescription), info2: \(lockmanInfoForStrategy2.debugDescription), info3: \(lockmanInfoForStrategy3.debugDescription), info4: \(lockmanInfoForStrategy4.debugDescription))"
+  }
+  
+  public var debugAdditionalInfo: String {
+    "Composite"
   }
 }
 
@@ -277,5 +289,9 @@ public struct LockmanCompositeInfo5<
 extension LockmanCompositeInfo5: CustomDebugStringConvertible {
   public var debugDescription: String {
     "LockmanCompositeInfo5(actionId: '\(actionId)', uniqueId: \(uniqueId), info1: \(lockmanInfoForStrategy1.debugDescription), info2: \(lockmanInfoForStrategy2.debugDescription), info3: \(lockmanInfoForStrategy3.debugDescription), info4: \(lockmanInfoForStrategy4.debugDescription), info5: \(lockmanInfoForStrategy5.debugDescription))"
+  }
+  
+  public var debugAdditionalInfo: String {
+    "Composite"
   }
 }

--- a/Sources/Lockman/Core/Strategies/ConcurrencyLimitedStrategy/LockmanConcurrencyLimitedInfo.swift
+++ b/Sources/Lockman/Core/Strategies/ConcurrencyLimitedStrategy/LockmanConcurrencyLimitedInfo.swift
@@ -38,4 +38,8 @@ extension LockmanConcurrencyLimitedInfo: CustomDebugStringConvertible {
   public var debugDescription: String {
     "ConcurrencyLimitedInfo(actionId: \(actionId), concurrencyId: \(concurrencyId), limit: \(limit), uniqueId: \(uniqueId))"
   }
+  
+  public var debugAdditionalInfo: String {
+    "concurrency: \(concurrencyId) limit: \(limit)"
+  }
 }

--- a/Sources/Lockman/Core/Strategies/ConcurrencyLimitedStrategy/LockmanConcurrencyLimitedStrategy.swift
+++ b/Sources/Lockman/Core/Strategies/ConcurrencyLimitedStrategy/LockmanConcurrencyLimitedStrategy.swift
@@ -40,10 +40,13 @@ public final class LockmanConcurrencyLimitedStrategy: LockmanStrategy, @unchecke
 
     if info.limit.isExceeded(currentCount: currentCount) {
       if case .limited(let limit) = info.limit {
+        // Get existing infos in the same concurrency group
+        let existingInfos = state.currents(id: id, key: info.concurrencyId)
+        
         result = .failure(
           LockmanConcurrencyLimitedError.concurrencyLimitReached(
-            concurrencyId: info.concurrencyId,
-            limit: limit,
+            requestedInfo: info,
+            existingInfos: existingInfos,
             current: currentCount
           )
         )

--- a/Sources/Lockman/Core/Strategies/DynamicConditionStrategy/LockmanDynamicConditionInfo.swift
+++ b/Sources/Lockman/Core/Strategies/DynamicConditionStrategy/LockmanDynamicConditionInfo.swift
@@ -78,4 +78,10 @@ public struct LockmanDynamicConditionInfo: LockmanInfo, Sendable {
   public var debugDescription: String {
     "LockmanDynamicConditionInfo(actionId: '\(actionId)', uniqueId: \(uniqueId), condition: <closure>)"
   }
+  
+  // MARK: - Debug Additional Info
+  
+  public var debugAdditionalInfo: String {
+    "condition: <closure>"
+  }
 }

--- a/Sources/Lockman/Core/Strategies/GroupCoordinationStrategy/LockmanGroupCoordinatedInfo.swift
+++ b/Sources/Lockman/Core/Strategies/GroupCoordinationStrategy/LockmanGroupCoordinatedInfo.swift
@@ -151,4 +151,11 @@ extension LockmanGroupCoordinatedInfo: CustomDebugStringConvertible {
     return
       "LockmanGroupCoordinatedInfo(actionId: '\(actionId)', uniqueId: \(uniqueId), groupIds: [\(groupIdsStr)], coordinationRole: .\(coordinationRole))"
   }
+  
+  // MARK: - Debug Additional Info
+  
+  public var debugAdditionalInfo: String {
+    let groupsStr = groupIds.map { "\($0)" }.sorted().joined(separator: ",")
+    return "groups: \(groupsStr) r: \(coordinationRole)"
+  }
 }

--- a/Sources/Lockman/Core/Strategies/GroupCoordinationStrategy/LockmanGroupCoordinationStrategy.swift
+++ b/Sources/Lockman/Core/Strategies/GroupCoordinationStrategy/LockmanGroupCoordinationStrategy.swift
@@ -127,12 +127,12 @@ public final class LockmanGroupCoordinationStrategy: LockmanStrategy, @unchecked
         let groupState = boundaryState?.groups[groupId]
 
         // Check if this specific action is already active in this group
-        if groupState?.activeMembers[info.actionId] != nil {
+        if let existingMember = groupState?.activeMembers[info.actionId] {
           // Same action ID cannot be executed twice in the same group
           failureReason = "Action '\(info.actionId)' is already active in group '\(groupId)'"
           return .failure(
             LockmanGroupCoordinationError.actionAlreadyInGroup(
-              actionId: info.actionId, groupIds: Set([groupId])))
+              existingInfo: existingMember.info, groupIds: Set([groupId])))
         }
 
         // No additional blocking logic needed here

--- a/Sources/Lockman/Core/Strategies/PriorityBasedStrategy/LockmanPriorityBasedInfo.swift
+++ b/Sources/Lockman/Core/Strategies/PriorityBasedStrategy/LockmanPriorityBasedInfo.swift
@@ -153,6 +153,18 @@ public struct LockmanPriorityBasedInfo: LockmanInfo, Sendable, Equatable {
     return
       "LockmanPriorityBasedInfo(actionId: '\(actionId)', uniqueId: \(uniqueId), priority: \(priorityStr), blocksSameAction: \(blocksSameAction))"
   }
+  
+  // MARK: - Debug Additional Info
+  
+  public var debugAdditionalInfo: String {
+    var result = "priority: \(priority)"
+    if let behavior = priority.behavior {
+      let behaviorStr = behavior == .exclusive ? ".exclusive" : ".replaceable"
+      result = String(result.prefix(20 - 13)) + " b: " + behaviorStr
+    }
+    result += " blocksSameAction: \(blocksSameAction)"
+    return result
+  }
 }
 
 // MARK: - Priority Definition

--- a/Sources/Lockman/Core/Strategies/PriorityBasedStrategy/LockmanPriorityBasedStrategy.swift
+++ b/Sources/Lockman/Core/Strategies/PriorityBasedStrategy/LockmanPriorityBasedStrategy.swift
@@ -152,8 +152,10 @@ public final class LockmanPriorityBasedStrategy: LockmanStrategy, @unchecked Sen
         $0.actionId == requestedInfo.actionId
       }
       if hasSameActionConflict {
+        // Find the existing info with the same actionId
+        let existingInfo = currentLocks.first { $0.actionId == requestedInfo.actionId }!
         result = .failure(
-          LockmanPriorityBasedError.blockedBySameAction(actionId: requestedInfo.actionId))
+          LockmanPriorityBasedError.blockedBySameAction(existingInfo: existingInfo))
         failureReason = "Same action '\(requestedInfo.actionId)' is blocked by policy"
 
         LockmanLogger.shared.logCanLock(
@@ -212,7 +214,7 @@ public final class LockmanPriorityBasedStrategy: LockmanStrategy, @unchecked Sen
       // Requested action has higher priority - can preempt current
       result = .successWithPrecedingCancellation(
         error: LockmanPriorityBasedError.precedingActionCancelled(
-          actionId: currentHighestPriorityInfo.actionId
+          cancelledInfo: currentHighestPriorityInfo
         )
       )
       cancelledInfo = (currentHighestPriorityInfo.actionId, currentHighestPriorityInfo.uniqueId)
@@ -378,7 +380,7 @@ extension LockmanPriorityBasedStrategy {
       // Existing action: "I am replaceable, allow new same-priority actions to take over"
       // → Existing action gets canceled, new action succeeds
       return .successWithPrecedingCancellation(
-        error: LockmanPriorityBasedError.precedingActionCancelled(actionId: current.actionId)
+        error: LockmanPriorityBasedError.precedingActionCancelled(cancelledInfo: current)
       )
     }
   }

--- a/Sources/Lockman/Core/Strategies/SingleExecutionStrategy/LockmanSingleExecutionInfo.swift
+++ b/Sources/Lockman/Core/Strategies/SingleExecutionStrategy/LockmanSingleExecutionInfo.swift
@@ -104,4 +104,10 @@ public struct LockmanSingleExecutionInfo: LockmanInfo, Sendable, Equatable {
   public var debugDescription: String {
     "LockmanSingleExecutionInfo(actionId: '\(actionId)', uniqueId: \(uniqueId), mode: \(mode))"
   }
+  
+  // MARK: - Debug Additional Info
+  
+  public var debugAdditionalInfo: String {
+    "mode: \(mode)"
+  }
 }

--- a/Sources/Lockman/Core/Strategies/SingleExecutionStrategy/LockmanSingleExecutionStrategy.swift
+++ b/Sources/Lockman/Core/Strategies/SingleExecutionStrategy/LockmanSingleExecutionStrategy.swift
@@ -101,15 +101,17 @@ public final class LockmanSingleExecutionStrategy: LockmanStrategy, @unchecked S
       if currentLocks.isEmpty {
         result = .success
       } else {
+        let existingInfo = currentLocks.first!
         result = .failure(
-          LockmanSingleExecutionError.boundaryAlreadyLocked(boundaryId: String(describing: id)))
+          LockmanSingleExecutionError.boundaryAlreadyLocked(boundaryId: String(describing: id), existingInfo: existingInfo))
         failureReason = "Boundary '\(id)' already has an active lock"
       }
 
     case .action:
       // Exclusive per action - check if same actionId exists
       if state.contains(id: id, key: info.actionId) {
-        result = .failure(LockmanSingleExecutionError.actionAlreadyRunning(actionId: info.actionId))
+        let existingInfo = state.currents(id: id, key: info.actionId).first!
+        result = .failure(LockmanSingleExecutionError.actionAlreadyRunning(existingInfo: existingInfo))
         failureReason = "Action '\(info.actionId)' is already locked"
       } else {
         result = .success

--- a/Tests/LockmanComposableTests/EffectLockmanPrecedingCancellationTests.swift
+++ b/Tests/LockmanComposableTests/EffectLockmanPrecedingCancellationTests.swift
@@ -148,9 +148,9 @@ final class EffectWithLockPrecedingCancellationTests: XCTestCase {
             },
             lockFailure: { error, send in
               if let priorityError = error as? LockmanPriorityBasedError,
-                case .precedingActionCancelled(let actionId) = priorityError
+                case .precedingActionCancelled(let cancelledInfo) = priorityError
               {
-                await send(.lockFailureOccurred(actionId))
+                await send(.lockFailureOccurred(cancelledInfo.actionId))
               }
             },
             action: PriorityBasedAction.lowPriority,
@@ -166,9 +166,9 @@ final class EffectWithLockPrecedingCancellationTests: XCTestCase {
             },
             lockFailure: { error, send in
               if let priorityError = error as? LockmanPriorityBasedError,
-                case .precedingActionCancelled(let actionId) = priorityError
+                case .precedingActionCancelled(let cancelledInfo) = priorityError
               {
-                await send(.lockFailureOccurred(actionId))
+                await send(.lockFailureOccurred(cancelledInfo.actionId))
               }
             },
             action: PriorityBasedAction.highExclusive,

--- a/Tests/LockmanComposableTests/EffectWithLockLockFailureTests.swift
+++ b/Tests/LockmanComposableTests/EffectWithLockLockFailureTests.swift
@@ -140,10 +140,10 @@ final class EffectWithLockLockFailureTests: XCTestCase {
 
     await store.receive(
       .lockFailureOccurred(
-        "Cannot acquire lock: boundary 'testBoundary' already has an active lock.")
+        "Cannot acquire lock: boundary 'testBoundary' already has an active lock for action 'test-action'.")
     ) {
       $0.lockFailureErrorMessage =
-        "Cannot acquire lock: boundary 'testBoundary' already has an active lock."
+        "Cannot acquire lock: boundary 'testBoundary' already has an active lock for action 'test-action'."
     }
 
     // Verify operation was not called

--- a/Tests/LockmanCoreTests/ConcurrencyLimitedTests/LockmanConcurrencyLimitedStrategyTests.swift
+++ b/Tests/LockmanCoreTests/ConcurrencyLimitedTests/LockmanConcurrencyLimitedStrategyTests.swift
@@ -135,9 +135,12 @@ final class LockmanConcurrencyLimitedStrategyTests: XCTestCase {
       let concurrencyError = error as? LockmanConcurrencyLimitedError
     {
       switch concurrencyError {
-      case .concurrencyLimitReached(let concurrencyId, let limit, let current):
-        XCTAssertEqual(concurrencyId, "file_operations")
-        XCTAssertEqual(limit, 2)
+      case .concurrencyLimitReached(let requestedInfo, let existingInfos, let current):
+        XCTAssertEqual(requestedInfo.concurrencyId, "file_operations")
+        XCTAssertEqual(requestedInfo.actionId, "upload3")
+        XCTAssertEqual(existingInfos.count, 2)
+        XCTAssertTrue(existingInfos.contains { $0.actionId == "upload1" })
+        XCTAssertTrue(existingInfos.contains { $0.actionId == "upload2" })
         XCTAssertEqual(current, 2)
       }
     } else {

--- a/Tests/LockmanCoreTests/ErrorTests/LockmanErrorCoverageTests.swift
+++ b/Tests/LockmanCoreTests/ErrorTests/LockmanErrorCoverageTests.swift
@@ -8,11 +8,13 @@ final class LockmanErrorCoverageTests: XCTestCase {
   // MARK: - LockmanSingleExecutionError Tests
 
   func testSingleExecutionErrorFailureReason() {
-    let error1 = LockmanSingleExecutionError.boundaryAlreadyLocked(boundaryId: "test-boundary")
+    let existingInfo = LockmanSingleExecutionInfo(actionId: "existing-action", mode: .boundary)
+    let error1 = LockmanSingleExecutionError.boundaryAlreadyLocked(boundaryId: "test-boundary", existingInfo: existingInfo)
     XCTAssertNotNil(error1.failureReason)
     XCTAssertTrue(error1.failureReason!.contains("boundary"))
 
-    let error2 = LockmanSingleExecutionError.actionAlreadyRunning(actionId: "test-action")
+    let existingInfo2 = LockmanSingleExecutionInfo(actionId: "test-action", mode: .action)
+    let error2 = LockmanSingleExecutionError.actionAlreadyRunning(existingInfo: existingInfo2)
     XCTAssertNotNil(error2.failureReason)
     XCTAssertTrue(error2.failureReason!.contains("action"))
   }
@@ -31,7 +33,8 @@ final class LockmanErrorCoverageTests: XCTestCase {
     XCTAssertNotNil(error2.failureReason)
     XCTAssertTrue(error2.failureReason!.contains("priority"))
 
-    let error3 = LockmanPriorityBasedError.blockedBySameAction(actionId: "test-action")
+    let existingInfo3 = LockmanPriorityBasedInfo(actionId: "test-action", priority: .high(.exclusive))
+    let error3 = LockmanPriorityBasedError.blockedBySameAction(existingInfo: existingInfo3)
     XCTAssertNotNil(error3.failureReason)
     XCTAssertTrue(error3.failureReason!.contains("action"))
   }
@@ -69,8 +72,10 @@ final class LockmanErrorCoverageTests: XCTestCase {
     XCTAssertNotNil(error2.failureReason)
     XCTAssertTrue(error2.failureReason!.contains("Member"))
 
+    let existingInfo3 = LockmanGroupCoordinatedInfo(
+      actionId: "action1", groupId: "group1", coordinationRole: .member)
     let error3 = LockmanGroupCoordinationError.actionAlreadyInGroup(
-      actionId: "action1", groupIds: [AnyLockmanGroupId("group1"), AnyLockmanGroupId("group2")])
+      existingInfo: existingInfo3, groupIds: [AnyLockmanGroupId("group1"), AnyLockmanGroupId("group2")])
     XCTAssertNotNil(error3.errorDescription)
     XCTAssertTrue(error3.errorDescription!.contains("action1"))
     XCTAssertNotNil(error3.failureReason)
@@ -82,11 +87,13 @@ final class LockmanErrorCoverageTests: XCTestCase {
   func testErrorDescriptionsWithSpecialCharacters() {
     let specialId = "test-<>&\"'123"
 
-    let error1 = LockmanSingleExecutionError.boundaryAlreadyLocked(boundaryId: specialId)
+    let existingInfo1 = LockmanSingleExecutionInfo(actionId: "existing", mode: .boundary)
+    let error1 = LockmanSingleExecutionError.boundaryAlreadyLocked(boundaryId: specialId, existingInfo: existingInfo1)
     XCTAssertNotNil(error1.errorDescription)
     XCTAssertTrue(error1.errorDescription!.contains(specialId))
 
-    let error2 = LockmanPriorityBasedError.blockedBySameAction(actionId: specialId)
+    let existingInfo2 = LockmanPriorityBasedInfo(actionId: specialId, priority: .high(.exclusive))
+    let error2 = LockmanPriorityBasedError.blockedBySameAction(existingInfo: existingInfo2)
     XCTAssertNotNil(error2.errorDescription)
     XCTAssertTrue(error2.errorDescription!.contains(specialId))
 
@@ -98,12 +105,15 @@ final class LockmanErrorCoverageTests: XCTestCase {
   func testErrorDescriptionsWithEmptyStrings() {
     let emptyId = ""
 
-    let error1 = LockmanSingleExecutionError.actionAlreadyRunning(actionId: emptyId)
+    let existingInfo1 = LockmanSingleExecutionInfo(actionId: emptyId, mode: .action)
+    let error1 = LockmanSingleExecutionError.actionAlreadyRunning(existingInfo: existingInfo1)
     XCTAssertNotNil(error1.errorDescription)
     XCTAssertNotNil(error1.failureReason)
 
+    let existingInfo2 = LockmanGroupCoordinatedInfo(
+      actionId: emptyId, groupId: "group1", coordinationRole: .member)
     let error2 = LockmanGroupCoordinationError.actionAlreadyInGroup(
-      actionId: emptyId, groupIds: Set<AnyLockmanGroupId>())
+      existingInfo: existingInfo2, groupIds: Set<AnyLockmanGroupId>())
     XCTAssertNotNil(error2.errorDescription)
     XCTAssertNotNil(error2.failureReason)
   }

--- a/Tests/LockmanCoreTests/PriorityBasedTests/LockmanPriorityBasedStrategyTests.swift
+++ b/Tests/LockmanCoreTests/PriorityBasedTests/LockmanPriorityBasedStrategyTests.swift
@@ -656,8 +656,8 @@ final class LockmanPriorityBasedStrategyTests: XCTestCase {
       }
 
       // Verify the error contains correct information
-      if case .precedingActionCancelled(let actionId) = priorityError {
-        XCTAssertEqual(actionId, "lowAction", "Error should contain the cancelled action ID")
+      if case .precedingActionCancelled(let cancelledInfo) = priorityError {
+        XCTAssertEqual(cancelledInfo.actionId, "lowAction", "Error should contain the cancelled action ID")
       } else {
         XCTFail("Expected precedingActionCancelled error but got \(priorityError)")
       }
@@ -689,9 +689,9 @@ final class LockmanPriorityBasedStrategyTests: XCTestCase {
         return
       }
 
-      if case .precedingActionCancelled(let actionId) = priorityError {
+      if case .precedingActionCancelled(let cancelledInfo) = priorityError {
         XCTAssertEqual(
-          actionId, "replaceableAction", "Error should contain the cancelled action ID")
+          cancelledInfo.actionId, "replaceableAction", "Error should contain the cancelled action ID")
       } else {
         XCTFail("Expected precedingActionCancelled error but got \(priorityError)")
       }


### PR DESCRIPTION
## Summary
- Updated `LockmanConcurrencyLimitedError` to include full Info objects instead of just actionId strings
- This completes the unified error specification where all applicable error types include Info objects
- Improved error handling and debugging capabilities

## Changes
- Modified `LockmanConcurrencyLimitedError.concurrencyLimitReached` case to include:
  - `requestedInfo`: The Info of the action that was blocked
  - `existingInfos`: Array of currently active Infos in the same concurrency group
  - `current`: Current number of active concurrent executions
- Updated `LockmanConcurrencyLimitedStrategy` to pass Info objects when creating errors
- Updated test expectations to validate the new error structure
- Added debug output support for ConcurrencyLimited strategy in `LockmanDebugFormatters`

## Test Plan
- [x] All existing tests pass
- [x] Updated `LockmanConcurrencyLimitedStrategyTests` to validate new error structure
- [x] Verified that error messages now include actionId from the Info objects
- [x] Build succeeds on all platforms

🤖 Generated with [Claude Code](https://claude.ai/code)