### PR TITLE
docs: fix comment accuracy and consistency issues

### DIFF
--- a/Sources/Lockman/Composable/Effect+Lockman.swift
+++ b/Sources/Lockman/Composable/Effect+Lockman.swift
@@ -128,8 +128,8 @@ extension Effect {
   ///
   /// ## Error Handling
   /// This method supports two types of error handlers:
-  /// - `catch handler`: For errors that occur during operation execution (has unlock token)
-  /// - `lockFailure`: For lock acquisition failures (no unlock token needed)
+  /// - `catch handler`: For errors that occur during operation execution (receives unlock token)
+  /// - `lockFailure`: For lock acquisition failures (no unlock token available)
   public static func withLock<B: LockmanBoundaryId, A: LockmanAction>(
     priority: TaskPriority? = nil,
     unlockOption: UnlockOption? = nil,
@@ -333,7 +333,8 @@ extension Effect {
   /// ## Error Handling Strategy
   /// This method uses a do-catch pattern to handle strategy resolution errors.
   /// If strategy resolution fails, it calls `handleError` to provide detailed
-  /// diagnostic information and returns `.none` to prevent effect execution.
+  /// diagnostic information and optionally calls the provided handler before
+  /// returning `.none` to prevent effect execution.
   ///
   /// ## Type Safety
   /// The method maintains type safety through generic constraints:

--- a/Sources/Lockman/Composable/ReduceWithLock.swift
+++ b/Sources/Lockman/Composable/ReduceWithLock.swift
@@ -472,7 +472,7 @@ extension ReduceWithLock {
   ///   - unlockOption: Controls when the unlock operation is executed
   ///   - handleCancellationErrors: Whether to pass CancellationError to catch handler
   ///   - operation: Async closure receiving `send` and `unlock` functions
-  ///   - handler: Optional error handler receiving error, send, and unlock functions
+  ///   - handler: Optional error handler (`catch` parameter) receiving error, send, and unlock functions
   ///   - lockFailure: Optional handler for lock acquisition failures (no unlock token)
   ///   - lockAction: LockmanAction providing lock information and strategy type
   ///   - cancelID: Unique identifier for effect cancellation and lock boundary

--- a/Sources/Lockman/Core/Protocols/LockmanStrategy.swift
+++ b/Sources/Lockman/Core/Protocols/LockmanStrategy.swift
@@ -107,8 +107,8 @@ public protocol LockmanStrategy<I>: Sendable {
   /// Checks if a lock can be acquired without actually acquiring it.
   ///
   /// This method allows the strategy to evaluate whether a lock acquisition
-  /// would succeed without modifying the strategy's internal state. This is
-  /// useful for pre-flight checks and decision making in the Effect system.
+  /// would succeed without modifying the strategy's internal state. The actual
+  /// lock acquisition happens in the subsequent `lock` method call.
   ///
   /// ## Implementation Guidelines
   /// - Should not modify internal state

--- a/Sources/Lockman/Core/Strategies/Core/LockmanStrategyContainer.swift
+++ b/Sources/Lockman/Core/Strategies/Core/LockmanStrategyContainer.swift
@@ -97,7 +97,7 @@ public final class LockmanStrategyContainer: @unchecked Sendable {
   /// - Parameters:
   ///   - id: The unique identifier for this strategy configuration
   ///   - strategy: A concrete strategy conforming to `LockmanStrategy<I>`
-  /// - Throws: `LockmanError.strategyAlreadyRegistered` if this ID is already registered
+  /// - Throws: `LockmanRegistrationError.strategyAlreadyRegistered` if this ID is already registered
   ///
   /// ## Complexity
   /// O(1) - Direct hash map insertion with conflict detection
@@ -130,7 +130,7 @@ public final class LockmanStrategyContainer: @unchecked Sendable {
   /// consistency between the strategy's identity and its registration.
   ///
   /// - Parameter strategy: A concrete strategy conforming to `LockmanStrategy<I>`
-  /// - Throws: `LockmanError.strategyAlreadyRegistered` if this ID is already registered
+  /// - Throws: `LockmanRegistrationError.strategyAlreadyRegistered` if this ID is already registered
   ///
   /// ## Example
   /// ```swift
@@ -227,7 +227,7 @@ public final class LockmanStrategyContainer: @unchecked Sendable {
   ///   - id: The strategy identifier to look up
   ///   - expecting: The expected `LockmanInfo` type (for type inference)
   /// - Returns: An `AnyLockmanStrategy<I>` wrapping the registered strategy instance
-  /// - Throws: `LockmanError.strategyNotRegistered` if no strategy with this ID is registered
+  /// - Throws: `LockmanRegistrationError.strategyNotRegistered` if no strategy with this ID is registered
   ///
   /// ## Complexity
   /// O(1) - Direct hash map lookup by ID
@@ -262,7 +262,7 @@ public final class LockmanStrategyContainer: @unchecked Sendable {
   ///
   /// - Parameter strategyType: The concrete strategy type to look up
   /// - Returns: An `AnyLockmanStrategy<I>` wrapping the registered strategy instance
-  /// - Throws: `LockmanError.strategyNotRegistered` if no strategy of this type is registered
+  /// - Throws: `LockmanRegistrationError.strategyNotRegistered` if no strategy of this type is registered
   ///
   /// ## Example
   /// ```swift

--- a/Sources/Lockman/Core/Strategies/GroupCoordinationStrategy/LockmanGroupCoordinationStrategy.swift
+++ b/Sources/Lockman/Core/Strategies/GroupCoordinationStrategy/LockmanGroupCoordinationStrategy.swift
@@ -3,7 +3,10 @@ import Foundation
 /// A strategy that coordinates actions within groups based on their roles.
 ///
 /// This strategy manages group-based locking where:
-/// - **Leaders** can only execute when their group is empty (no other members)
+/// - **Leaders** can execute based on their entry policy:
+///   - `.emptyGroup`: Only when the group is completely empty
+///   - `.withoutMembers`: When there are no members (other leaders allowed)
+///   - `.withoutLeader`: When there is no other leader (members allowed)
 /// - **Members** can only execute when their group has active participants
 ///
 /// This creates a coordination pattern where leaders start group activities

--- a/Sources/Lockman/Core/Strategies/PriorityBasedStrategy/LockmanPriorityBasedStrategy.swift
+++ b/Sources/Lockman/Core/Strategies/PriorityBasedStrategy/LockmanPriorityBasedStrategy.swift
@@ -341,11 +341,11 @@ extension LockmanPriorityBasedStrategy {
   ///
   /// ## Examples
   /// ```swift
-  /// // Existing payment (.exclusive) blocks new search
-  /// existing(.exclusive) + new(.replaceable) → .failure
+  /// // Existing action with exclusive behavior blocks new action
+  /// current: .high(.exclusive), requested: .high(.replaceable) → .failure
   ///
-  /// // Existing search (.replaceable) yields to new search
-  /// existing(.replaceable) + new(.exclusive) → .successWithPrecedingCancellation
+  /// // Existing action with replaceable behavior yields to new action
+  /// current: .high(.replaceable), requested: .high(.exclusive) → .successWithPrecedingCancellation
   /// ```
   ///
   /// ## Design Rationale

--- a/Sources/Lockman/Core/Strategies/SingleExecutionStrategy/LockmanSingleExecutionStrategy.swift
+++ b/Sources/Lockman/Core/Strategies/SingleExecutionStrategy/LockmanSingleExecutionStrategy.swift
@@ -92,7 +92,7 @@ public final class LockmanSingleExecutionStrategy: LockmanStrategy, @unchecked S
 
     switch info.mode {
     case .none:
-      // No exclusive execution - always allow
+      // No exclusive execution - bypasses lock checking and always returns success
       result = .success
 
     case .boundary:


### PR DESCRIPTION
## Summary
- Fixed incorrect error type references in documentation comments
- Clarified ambiguous descriptions and improved technical accuracy
- Updated code examples to use correct syntax

## Changes
- **LockmanStrategyContainer**: Fixed error type references from `LockmanError` to `LockmanRegistrationError`
- **LockmanStrategy**: Clarified `canLock` method description to better explain its purpose
- **Effect+Lockman**: Enhanced error handling documentation to distinguish between handler types
- **LockmanGroupCoordinationStrategy**: Updated leader execution conditions to include all entry policies
- **LockmanPriorityBasedStrategy**: Fixed code examples to use proper syntax
- **ReduceWithLock**: Clarified parameter name reference for consistency
- **LockmanSingleExecutionStrategy**: Improved ExecutionMode.none description

## Test plan
- [x] Verified all Swift files build successfully
- [x] Documentation comments are now accurate and consistent with implementation
- [x] No functional changes, only documentation improvements

🤖 Generated with [Claude Code](https://claude.ai/code)