### PR TITLE
docs: add expandable sections for older versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,14 @@ The documentation for releases and `main` are available here:
 * [`main`](https://takeshishimada.github.io/Lockman/main/documentation/lockman/)
 * [0.5.0](https://takeshishimada.github.io/Lockman/0.5.0/documentation/lockman/)
 
+<details>
+<summary>Other versions</summary>
+
+* [0.4.0](https://takeshishimada.github.io/Lockman/0.4.0/documentation/lockman/)
+* [0.3.0](https://takeshishimada.github.io/Lockman/0.3.0/documentation/lockman/)
+
+</details>
+
 ## Installation
 
 Lockman can be installed using [Swift Package Manager](https://swift.org/package-manager/).
@@ -121,11 +129,19 @@ Add the dependency to your target:
 | Lockman | The Composable Architecture |
 |---------|----------------------------|
 | 0.5.0   | 1.17.1                     |
+
+<details>
+<summary>Other versions</summary>
+
+| Lockman | The Composable Architecture |
+|---------|----------------------------|
 | 0.4.0   | 1.17.1                     |
 | 0.3.0   | 1.17.1                     |
 | 0.2.1   | 1.17.1                     |
 | 0.2.0   | 1.17.1                     |
 | 0.1.0   | 1.17.1                     |
+
+</details>
 
 ## Community
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -74,6 +74,14 @@ Lockmanは以下の制御戦略を提供し、実際のアプリ開発で頻繁�
 * [`main`](https://takeshishimada.github.io/Lockman/main/documentation/lockman/)
 * [0.5.0](https://takeshishimada.github.io/Lockman/0.5.0/documentation/lockman/)
 
+<details>
+<summary>その他のバージョン</summary>
+
+* [0.4.0](https://takeshishimada.github.io/Lockman/0.4.0/documentation/lockman/)
+* [0.3.0](https://takeshishimada.github.io/Lockman/0.3.0/documentation/lockman/)
+
+</details>
+
 ## インストール
 
 Lockmanは[Swift Package Manager](https://swift.org/package-manager/)でインストールできます。
@@ -121,11 +129,19 @@ dependencies: [
 | Lockman | The Composable Architecture |
 |---------|----------------------------|
 | 0.5.0   | 1.17.1                     |
+
+<details>
+<summary>その他のバージョン</summary>
+
+| Lockman | The Composable Architecture |
+|---------|----------------------------|
 | 0.4.0   | 1.17.1                     |
 | 0.3.0   | 1.17.1                     |
 | 0.2.1   | 1.17.1                     |
 | 0.2.0   | 1.17.1                     |
 | 0.1.0   | 1.17.1                     |
+
+</details>
 
 ## コミュニティ
 


### PR DESCRIPTION
## Summary
Add expandable sections in README files for older versions to keep documentation cleaner while still providing access to historical information.

## Changes
- **Documentation section**: Added expandable "Other versions" section with links to 0.4.0 and 0.3.0
- **Version Compatibility section**: Made older versions expandable, keeping only the latest version (0.5.0) visible by default
- Applied changes to both `README.md` and `README_ja.md` for consistency

## Motivation
This improves the README readability by:
1. Focusing on the current/latest version information
2. Reducing visual clutter from older version information
3. Still providing easy access to historical data when needed

## Test Plan
- [x] Verified markdown renders correctly with expandable sections
- [x] Confirmed documentation links follow the same pattern as existing links
- [x] Ensured consistency between English and Japanese versions

🤖 Generated with [Claude Code](https://claude.ai/code)