### PR TITLE
feat: update default configuration values

### DIFF
--- a/Examples/Strategies/Strategies/03-CompositeStrategy.swift
+++ b/Examples/Strategies/Strategies/03-CompositeStrategy.swift
@@ -5,11 +5,11 @@ import SwiftUI
 // Custom error for authentication
 struct AuthenticationError: Error, LocalizedError {
   let actionId: String
-  
+
   var errorDescription: String? {
     "Cannot acquire lock for action '\(actionId)': User is not logged in."
   }
-  
+
   var failureReason: String? {
     "The user must be logged in to perform this action."
   }

--- a/Sources/Lockman/Core/LockmanError.swift
+++ b/Sources/Lockman/Core/LockmanError.swift
@@ -13,7 +13,7 @@ import Foundation
 /// - `LockmanPriorityBasedError`: Errors from priority-based strategy
 /// - `LockmanGroupCoordinationError`: Errors from group coordination strategy
 /// - `LockmanRegistrationError`: Errors from strategy registration and resolution
-/// 
+///
 /// For dynamic condition strategy, users define their own error types.
 ///
 /// ## Usage

--- a/Sources/Lockman/Core/LockmanManager.swift
+++ b/Sources/Lockman/Core/LockmanManager.swift
@@ -16,16 +16,16 @@ public enum LockmanManager {
     /// This value is used by all `withLock` and `concatenateWithLock` methods
     /// when the `unlockOption` parameter is not provided.
     ///
-    /// Default value is `.transition` to ensure safe coordination with UI transitions.
-    var defaultUnlockOption: LockmanUnlockOption = .transition
+    /// Default value is `.immediate` for immediate unlock behavior.
+    var defaultUnlockOption: LockmanUnlockOption = .immediate
 
     /// Controls whether CancellationError should be passed to error handlers in withLock operations.
     ///
-    /// When `true` (default), CancellationError is passed to the catch handler if provided.
+    /// When `true`, CancellationError is passed to the catch handler if provided.
     /// When `false`, CancellationError is silently ignored and not passed to handlers.
     ///
-    /// Default value is `true` to maintain backward compatibility.
-    var handleCancellationErrors: Bool = true
+    /// Default value is `false` to silently ignore cancellation errors.
+    var handleCancellationErrors: Bool = false
 
     /// Creates a new configuration with default values.
     init() {}
@@ -43,7 +43,7 @@ public enum LockmanManager {
     /// This value is used by all `withLock` and `concatenateWithLock` methods
     /// when the `unlockOption` parameter is not provided.
     ///
-    /// Default value is `.transition` to ensure safe coordination with UI transitions.
+    /// Default value is `.immediate` for immediate unlock behavior.
     ///
     /// ```swift
     /// // In AppDelegate or App initialization
@@ -59,7 +59,7 @@ public enum LockmanManager {
 
     /// Controls whether CancellationError should be passed to error handlers in withLock operations.
     ///
-    /// When `true` (default), CancellationError is passed to the catch handler if provided.
+    /// When `true`, CancellationError is passed to the catch handler if provided.
     /// When `false`, CancellationError is silently ignored and not passed to handlers.
     ///
     /// ```swift

--- a/Sources/Lockman/Core/Strategies/DynamicConditionStrategy/LockmanDynamicConditionAction.swift
+++ b/Sources/Lockman/Core/Strategies/DynamicConditionStrategy/LockmanDynamicConditionAction.swift
@@ -11,7 +11,7 @@ import Foundation
 ///     case priorityTooLow(priority: Int)
 ///     case taskTooBig(size: Int)
 /// }
-/// 
+///
 /// @LockmanDynamicCondition
 /// enum MyAction {
 ///     case fetchData(userId: String, priority: Int)

--- a/Sources/Lockman/Core/Strategies/DynamicConditionStrategy/LockmanDynamicConditionInfo.swift
+++ b/Sources/Lockman/Core/Strategies/DynamicConditionStrategy/LockmanDynamicConditionInfo.swift
@@ -12,7 +12,7 @@ import Foundation
 ///     let currentUsers: Int
 ///     let maxUsers: Int
 /// }
-/// 
+///
 /// let info = LockmanDynamicConditionInfo(
 ///     actionId: "fetchData",
 ///     condition: {

--- a/Sources/Lockman/Core/Strategies/DynamicConditionStrategy/LockmanDynamicConditionStrategy.swift
+++ b/Sources/Lockman/Core/Strategies/DynamicConditionStrategy/LockmanDynamicConditionStrategy.swift
@@ -12,7 +12,7 @@ import Foundation
 /// struct PriorityTooLowError: Error {
 ///     let priority: Int
 /// }
-/// 
+///
 /// let action = MyAction.fetchData(userId: "123", priority: 5)
 /// let conditionalAction = action.with {
 ///     guard priority > 3 else {

--- a/Tests/LockmanComposableTests/ReduceWithLockIntegrationTests.swift
+++ b/Tests/LockmanComposableTests/ReduceWithLockIntegrationTests.swift
@@ -8,16 +8,18 @@ import XCTest
 private struct ComposableTestDynamicConditionError: Error, LocalizedError {
   let actionId: String
   let hint: String?
-  
+
   var errorDescription: String? {
     "Dynamic condition not met for action '\(actionId)'" + (hint.map { ". Hint: \($0)" } ?? "")
   }
-  
+
   var failureReason: String? {
     "The condition for action '\(actionId)' was not met" + (hint.map { ": \($0)" } ?? "")
   }
-  
-  static func conditionNotMet(actionId: String, hint: String?) -> ComposableTestDynamicConditionError {
+
+  static func conditionNotMet(actionId: String, hint: String?)
+    -> ComposableTestDynamicConditionError
+  {
     ComposableTestDynamicConditionError(actionId: actionId, hint: hint)
   }
 }

--- a/Tests/LockmanCoreTests/DynamicConditionStrategy/LockmanDynamicConditionStrategyTests.swift
+++ b/Tests/LockmanCoreTests/DynamicConditionStrategy/LockmanDynamicConditionStrategyTests.swift
@@ -7,15 +7,15 @@ import XCTest
 private struct MockDynamicConditionError: Error, LocalizedError {
   let actionId: String
   let hint: String?
-  
+
   var errorDescription: String? {
     "Dynamic condition not met for action '\(actionId)'" + (hint.map { ". Hint: \($0)" } ?? "")
   }
-  
+
   var failureReason: String? {
     "The condition for action '\(actionId)' was not met" + (hint.map { ": \($0)" } ?? "")
   }
-  
+
   static func conditionNotMet(actionId: String, hint: String?) -> MockDynamicConditionError {
     MockDynamicConditionError(actionId: actionId, hint: hint)
   }

--- a/Tests/LockmanCoreTests/ErrorTests/LockmanErrorCoverageTests.swift
+++ b/Tests/LockmanCoreTests/ErrorTests/LockmanErrorCoverageTests.swift
@@ -6,15 +6,15 @@ import XCTest
 struct TestDynamicConditionError: Error, LocalizedError {
   let actionId: String
   let hint: String?
-  
+
   var errorDescription: String? {
     "Dynamic condition not met for action '\(actionId)'" + (hint.map { ". Hint: \($0)" } ?? "")
   }
-  
+
   var failureReason: String? {
     "The condition for action '\(actionId)' was not met" + (hint.map { ": \($0)" } ?? "")
   }
-  
+
   static func conditionNotMet(actionId: String, hint: String?) -> TestDynamicConditionError {
     TestDynamicConditionError(actionId: actionId, hint: hint)
   }

--- a/Tests/LockmanCoreTests/LockmanConfigurationTests.swift
+++ b/Tests/LockmanCoreTests/LockmanConfigurationTests.swift
@@ -60,7 +60,9 @@ final class LockmanConfigurationTests: XCTestCase {
       // Multiple writers
       for i in 0..<iterations {
         group.addTask {
-          let options: [LockmanUnlockOption] = [.immediate, .mainRunLoop, .transition, .delayed(0.1)]
+          let options: [LockmanUnlockOption] = [
+            .immediate, .mainRunLoop, .transition, .delayed(0.1),
+          ]
           LockmanManager.config.defaultUnlockOption = options[i % options.count]
         }
       }

--- a/Tests/LockmanCoreTests/LockmanConfigurationTests.swift
+++ b/Tests/LockmanCoreTests/LockmanConfigurationTests.swift
@@ -13,9 +13,9 @@ final class LockmanConfigurationTests: XCTestCase {
 
   // MARK: - Configuration Tests
 
-  func testDefaultConfigurationHasTransitionUnlockOption() async throws {
-    // Default configuration should use .transition
-    XCTAssertEqual(LockmanManager.config.defaultUnlockOption, .transition)
+  func testDefaultConfigurationHasImmediateUnlockOption() async throws {
+    // Default configuration should use .immediate
+    XCTAssertEqual(LockmanManager.config.defaultUnlockOption, .immediate)
   }
 
   func testConfigurationCanBeModified() async throws {
@@ -43,7 +43,7 @@ final class LockmanConfigurationTests: XCTestCase {
 
     // Reset to default
     LockmanManager.config.reset()
-    XCTAssertEqual(LockmanManager.config.defaultUnlockOption, .transition)
+    XCTAssertEqual(LockmanManager.config.defaultUnlockOption, .immediate)
   }
 
   func testConfigurationIsThreadSafe() async throws {
@@ -106,28 +106,28 @@ final class LockmanConfigurationTests: XCTestCase {
 
   // MARK: - Handle Cancellation Errors Tests
 
-  func testDefaultHandleCancellationErrorsIsTrue() async throws {
-    XCTAssertTrue(LockmanManager.config.handleCancellationErrors)
+  func testDefaultHandleCancellationErrorsIsFalse() async throws {
+    XCTAssertFalse(LockmanManager.config.handleCancellationErrors)
   }
 
   func testHandleCancellationErrorsCanBeModified() async throws {
+    // Enable (default is false)
+    LockmanManager.config.handleCancellationErrors = true
+    XCTAssertTrue(LockmanManager.config.handleCancellationErrors)
+
     // Disable
     LockmanManager.config.handleCancellationErrors = false
     XCTAssertFalse(LockmanManager.config.handleCancellationErrors)
-
-    // Enable
-    LockmanManager.config.handleCancellationErrors = true
-    XCTAssertTrue(LockmanManager.config.handleCancellationErrors)
   }
 
   func testHandleCancellationErrorsResetRestoresDefault() async throws {
     // Modify configuration
-    LockmanManager.config.handleCancellationErrors = false
-    XCTAssertFalse(LockmanManager.config.handleCancellationErrors)
+    LockmanManager.config.handleCancellationErrors = true
+    XCTAssertTrue(LockmanManager.config.handleCancellationErrors)
 
     // Reset to default
     LockmanManager.config.reset()
-    XCTAssertTrue(LockmanManager.config.handleCancellationErrors)
+    XCTAssertFalse(LockmanManager.config.handleCancellationErrors)
   }
 
   func testHandleCancellationErrorsThreadSafe() async throws {

--- a/Tests/LockmanTests/Composable/LockmanComposableIssueReporterTests.swift
+++ b/Tests/LockmanTests/Composable/LockmanComposableIssueReporterTests.swift
@@ -83,4 +83,3 @@ final class ComposableIssueReporterTests: XCTestCase {
     XCTAssertEqual(reportedMessage, "Integration test message")
   }
 }
-

--- a/Tests/LockmanTests/Core/Debug/LockmanDebugTests.swift
+++ b/Tests/LockmanTests/Core/Debug/LockmanDebugTests.swift
@@ -1,67 +1,69 @@
 import XCTest
+
 @testable import Lockman
 
 final class LockmanDebugTests: XCTestCase {
-  
+
   override func setUp() {
     super.setUp()
     // Reset debug settings
     LockmanManager.debug.isLoggingEnabled = false
   }
-  
+
   override func tearDown() {
     super.tearDown()
     // Reset debug settings
     LockmanManager.debug.isLoggingEnabled = false
   }
-  
+
   func testIsLoggingEnabled() {
     // Initially should be false
     XCTAssertFalse(LockmanManager.debug.isLoggingEnabled)
-    
+
     // Enable logging
     LockmanManager.debug.isLoggingEnabled = true
     XCTAssertTrue(LockmanManager.debug.isLoggingEnabled)
-    
+
     // Disable logging
     LockmanManager.debug.isLoggingEnabled = false
     XCTAssertFalse(LockmanManager.debug.isLoggingEnabled)
   }
-  
+
   func testPrintCurrentLocksWithNoLocks() {
     // Capture console output
     let pipe = Pipe()
     let originalStdout = dup(STDOUT_FILENO)
     dup2(pipe.fileHandleForWriting.fileDescriptor, STDOUT_FILENO)
-    
+
     // Print current locks when no locks exist
     LockmanManager.debug.printCurrentLocks()
-    
+
     // Restore stdout
     fflush(stdout)
     dup2(originalStdout, STDOUT_FILENO)
     close(originalStdout)
     pipe.fileHandleForWriting.closeFile()
-    
+
     // Read captured output
     let data = pipe.fileHandleForReading.readDataToEndOfFile()
     let output = String(data: data, encoding: .utf8) ?? ""
-    
+
     // Should contain table headers or "No active locks" message
-    XCTAssertTrue(output.contains("Strategy") || output.contains("No active locks") || output.isEmpty)
+    XCTAssertTrue(
+      output.contains("Strategy") || output.contains("No active locks") || output.isEmpty)
   }
-  
+
   func testPrintCurrentLocksWithOptions() {
     // Test that method accepts options parameter
     // We can't easily test the output differences, but we can verify it doesn't crash
     LockmanManager.debug.printCurrentLocks(options: .default)
     LockmanManager.debug.printCurrentLocks(options: .compact)
     LockmanManager.debug.printCurrentLocks(options: .detailed)
-    
+
     // If we get here without crashing, the test passes
     XCTAssertTrue(true)
   }
-  
+
   func testCompositeInfoProtocol() {
     // Test LockmanCompositeInfo2
     let info1 = LockmanSingleExecutionInfo(actionId: "action1")
@@ -70,13 +72,13 @@ final class LockmanDebugTests: XCTestCase {
       lockmanInfoForStrategy1: info1,
       lockmanInfoForStrategy2: info2
     )
-    
+
     let allInfos2 = compositeInfo2.allInfos()
     XCTAssertEqual(allInfos2.count, 2)
     XCTAssertTrue(allInfos2[0] is LockmanSingleExecutionInfo)
     XCTAssertTrue(allInfos2[1] is LockmanSingleExecutionInfo)
   }
-  
+
   func testCompositeInfo3Protocol() {
     // Test LockmanCompositeInfo3
     let info1 = LockmanSingleExecutionInfo(actionId: "action1")
@@ -87,14 +89,14 @@ final class LockmanDebugTests: XCTestCase {
       lockmanInfoForStrategy2: info2,
       lockmanInfoForStrategy3: info3
     )
-    
+
     let allInfos3 = compositeInfo3.allInfos()
     XCTAssertEqual(allInfos3.count, 3)
     XCTAssertEqual((allInfos3[0] as? LockmanSingleExecutionInfo)?.actionId, "action1")
     XCTAssertEqual((allInfos3[1] as? LockmanSingleExecutionInfo)?.actionId, "action2")
     XCTAssertEqual((allInfos3[2] as? LockmanSingleExecutionInfo)?.actionId, "action3")
   }
-  
+
   func testCompositeInfo4Protocol() {
     // Test LockmanCompositeInfo4
     let info1 = LockmanSingleExecutionInfo(actionId: "action1")
@@ -107,14 +109,14 @@ final class LockmanDebugTests: XCTestCase {
       lockmanInfoForStrategy3: info3,
       lockmanInfoForStrategy4: info4
     )
-    
+
     let allInfos4 = compositeInfo4.allInfos()
     XCTAssertEqual(allInfos4.count, 4)
     for (index, info) in allInfos4.enumerated() {
       XCTAssertEqual((info as? LockmanSingleExecutionInfo)?.actionId, "action\(index + 1)")
     }
   }
-  
+
   func testCompositeInfo5Protocol() {
     // Test LockmanCompositeInfo5
     let infos = (1...5).map { LockmanSingleExecutionInfo(actionId: "action\($0)") }
@@ -125,81 +127,82 @@ final class LockmanDebugTests: XCTestCase {
       lockmanInfoForStrategy4: infos[3],
       lockmanInfoForStrategy5: infos[4]
     )
-    
+
     let allInfos5 = compositeInfo5.allInfos()
     XCTAssertEqual(allInfos5.count, 5)
     for (index, info) in allInfos5.enumerated() {
       XCTAssertEqual((info as? LockmanSingleExecutionInfo)?.actionId, "action\(index + 1)")
     }
   }
-  
+
   func testLoggingIntegration() {
     // Enable logging
     LockmanManager.debug.isLoggingEnabled = true
-    
+
     // Create a strategy and perform operations
     let strategy = LockmanSingleExecutionStrategy()
     let boundaryId = AnyLockmanBoundaryId("test-boundary")
     let info = LockmanSingleExecutionInfo(actionId: "test-action")
-    
+
     // Capture console output
     let pipe = Pipe()
     let originalStdout = dup(STDOUT_FILENO)
     dup2(pipe.fileHandleForWriting.fileDescriptor, STDOUT_FILENO)
-    
+
     // Perform canLock operation (should trigger logging)
     _ = strategy.canLock(id: boundaryId, info: info)
-    
+
     // Restore stdout
     fflush(stdout)
     dup2(originalStdout, STDOUT_FILENO)
     close(originalStdout)
     pipe.fileHandleForWriting.closeFile()
-    
+
     // Read captured output
     let data = pipe.fileHandleForReading.readDataToEndOfFile()
     let output = String(data: data, encoding: .utf8) ?? ""
-    
+
     #if DEBUG
-    // In debug builds, logging should produce output
-    XCTAssertTrue(output.contains("canLock") || output.contains("Lockman"))
+      // In debug builds, logging should produce output
+      XCTAssertTrue(output.contains("canLock") || output.contains("Lockman"))
     #else
-    // In release builds, logging might be disabled
-    _ = output
+      // In release builds, logging might be disabled
+      _ = output
     #endif
   }
-  
+
   func testDebugWithActiveLocks() {
     // Create strategies and lock some resources
     let strategy = LockmanSingleExecutionStrategy()
     let boundaryId = AnyLockmanBoundaryId("test-boundary")
     let info = LockmanSingleExecutionInfo(actionId: "test-action")
-    
+
     // Lock a resource
     strategy.lockAcquired(id: boundaryId, info: info)
-    
+
     // Capture console output
     let pipe = Pipe()
     let originalStdout = dup(STDOUT_FILENO)
     dup2(pipe.fileHandleForWriting.fileDescriptor, STDOUT_FILENO)
-    
+
     // Print current locks
     LockmanManager.debug.printCurrentLocks()
-    
+
     // Restore stdout
     fflush(stdout)
     dup2(originalStdout, STDOUT_FILENO)
     close(originalStdout)
     pipe.fileHandleForWriting.closeFile()
-    
+
     // Clean up
     strategy.lockReleased(id: boundaryId, info: info)
-    
+
     // Read captured output
     let data = pipe.fileHandleForReading.readDataToEndOfFile()
     let output = String(data: data, encoding: .utf8) ?? ""
-    
+
     // Should contain information about the lock
-    XCTAssertTrue(output.contains("test-action") || output.contains("test-boundary") || output.isEmpty)
+    XCTAssertTrue(
+      output.contains("test-action") || output.contains("test-boundary") || output.isEmpty)
   }
 }

--- a/Tests/LockmanTests/Core/LockmanIssueReporterTests.swift
+++ b/Tests/LockmanTests/Core/LockmanIssueReporterTests.swift
@@ -156,4 +156,3 @@ final class LockmanIssueReporterBackwardCompatibilityTests: XCTestCase {
     XCTAssertTrue(DefaultIssueReporter.self == LockmanDefaultIssueReporter.self)
   }
 }
-

--- a/Tests/LockmanTests/Core/Protocols/LockmanInfoTests.swift
+++ b/Tests/LockmanTests/Core/Protocols/LockmanInfoTests.swift
@@ -152,4 +152,3 @@ final class LockmanInfoTests: XCTestCase {
     XCTAssertTrue(debugString.contains("debug data"))
   }
 }
-

--- a/Tests/LockmanTests/Core/Strategies/CompositeStrategy/LockmanCompositeStrategy2Tests.swift
+++ b/Tests/LockmanTests/Core/Strategies/CompositeStrategy/LockmanCompositeStrategy2Tests.swift
@@ -1,50 +1,51 @@
 import XCTest
+
 @testable import Lockman
 
 final class LockmanCompositeStrategy2Tests: XCTestCase {
-  
+
   // MARK: - Test Types
-  
+
   private struct TestBoundaryId: LockmanBoundaryId {
     let value: String
-    
+
     init(_ value: String) {
       self.value = value
     }
   }
-  
+
   // MARK: - Basic Tests
-  
+
   func testInitialization() {
     let strategy1 = LockmanSingleExecutionStrategy()
     let strategy2 = LockmanPriorityBasedStrategy()
-    
+
     let composite = LockmanCompositeStrategy2(
       strategy1: strategy1,
       strategy2: strategy2
     )
-    
+
     XCTAssertEqual(composite.strategyId.name, "CompositeStrategy2")
     XCTAssertNotNil(composite.strategyId.configuration)
     XCTAssertTrue(composite.strategyId.configuration?.contains("+") ?? false)
   }
-  
+
   func testMakeStrategyIdWithStrategies() {
     let strategy1 = LockmanSingleExecutionStrategy()
     let strategy2 = LockmanPriorityBasedStrategy()
-    
+
     let strategyId = LockmanCompositeStrategy2.makeStrategyId(
       strategy1: strategy1,
       strategy2: strategy2
     )
-    
+
     XCTAssertEqual(strategyId.name, "CompositeStrategy2")
     XCTAssertEqual(
       strategyId.configuration,
       "\(strategy1.strategyId.value)+\(strategy2.strategyId.value)"
     )
   }
-  
+
   func testMakeStrategyIdWithoutParameters() {
     let strategyId = LockmanCompositeStrategy2<
       LockmanSingleExecutionInfo,
@@ -52,13 +53,13 @@ final class LockmanCompositeStrategy2Tests: XCTestCase {
       LockmanPriorityBasedInfo,
       LockmanPriorityBasedStrategy
     >.makeStrategyId()
-    
+
     XCTAssertEqual(strategyId.name, "CompositeStrategy2")
     XCTAssertNil(strategyId.configuration)
   }
-  
+
   // MARK: - CanLock Tests
-  
+
   func testCanLockBothSuccess() {
     let strategy1 = LockmanSingleExecutionStrategy()
     let strategy2 = LockmanPriorityBasedStrategy()
@@ -66,17 +67,17 @@ final class LockmanCompositeStrategy2Tests: XCTestCase {
       strategy1: strategy1,
       strategy2: strategy2
     )
-    
+
     let boundaryId = TestBoundaryId("test")
     let info = LockmanCompositeInfo2(
       lockmanInfoForStrategy1: LockmanSingleExecutionInfo(actionId: "action1"),
       lockmanInfoForStrategy2: LockmanPriorityBasedInfo(actionId: "action2", priority: .medium)
     )
-    
+
     let result = composite.canLock(id: boundaryId, info: info)
     XCTAssertEqual(result, .success)
   }
-  
+
   func testCanLockFirstStrategyFails() {
     let strategy1 = LockmanSingleExecutionStrategy()
     let strategy2 = LockmanPriorityBasedStrategy()
@@ -84,31 +85,31 @@ final class LockmanCompositeStrategy2Tests: XCTestCase {
       strategy1: strategy1,
       strategy2: strategy2
     )
-    
+
     let boundaryId = TestBoundaryId("test")
     let info1 = LockmanSingleExecutionInfo(actionId: "action1")
-    
+
     // Lock strategy1 first to make it fail
     strategy1.lockAcquired(id: boundaryId, info: info1)
-    
+
     let compositeInfo = LockmanCompositeInfo2(
       lockmanInfoForStrategy1: info1,
       lockmanInfoForStrategy2: LockmanPriorityBasedInfo(actionId: "action2", priority: .medium)
     )
-    
+
     let result = composite.canLock(id: boundaryId, info: compositeInfo)
-    
+
     switch result {
     case .failure(let error):
       XCTAssertTrue(error is LockmanSingleExecutionError)
     default:
       XCTFail("Expected failure but got \(result)")
     }
-    
+
     // Cleanup
     strategy1.lockReleased(id: boundaryId, info: info1)
   }
-  
+
   func testCanLockSecondStrategyFails() {
     let strategy1 = LockmanSingleExecutionStrategy()
     let strategy2 = LockmanPriorityBasedStrategy()
@@ -116,54 +117,54 @@ final class LockmanCompositeStrategy2Tests: XCTestCase {
       strategy1: strategy1,
       strategy2: strategy2
     )
-    
+
     let boundaryId = TestBoundaryId("test")
     let blockingInfo = LockmanPriorityBasedInfo(
       actionId: "blocking",
       priority: .high(.preferLater)
     )
-    
+
     // Lock strategy2 with high priority
     strategy2.lockAcquired(id: boundaryId, info: blockingInfo)
-    
+
     let compositeInfo = LockmanCompositeInfo2(
       lockmanInfoForStrategy1: LockmanSingleExecutionInfo(actionId: "action1"),
       lockmanInfoForStrategy2: LockmanPriorityBasedInfo(actionId: "action2", priority: .low)
     )
-    
+
     let result = composite.canLock(id: boundaryId, info: compositeInfo)
-    
+
     switch result {
     case .failure(let error):
       XCTAssertTrue(error is LockmanPriorityBasedError)
     default:
       XCTFail("Expected failure but got \(result)")
     }
-    
+
     // Cleanup
     strategy2.lockReleased(id: boundaryId, info: blockingInfo)
   }
-  
+
   func testCanLockWithSuccessWithPrecedingCancellation() {
     // Create mock strategies
     let strategy1 = MockLockmanStrategy(
       canLockResult: .successWithPrecedingCancellation(error: TestError.cancellationError)
     )
     let strategy2 = MockLockmanStrategy(canLockResult: .success)
-    
+
     let composite = LockmanCompositeStrategy2(
       strategy1: strategy1,
       strategy2: strategy2
     )
-    
+
     let boundaryId = TestBoundaryId("test")
     let info = LockmanCompositeInfo2(
       lockmanInfoForStrategy1: MockLockmanInfo(actionId: "action1"),
       lockmanInfoForStrategy2: MockLockmanInfo(actionId: "action2")
     )
-    
+
     let result = composite.canLock(id: boundaryId, info: info)
-    
+
     switch result {
     case .successWithPrecedingCancellation(let error):
       XCTAssertTrue(error is TestError)
@@ -171,7 +172,7 @@ final class LockmanCompositeStrategy2Tests: XCTestCase {
       XCTFail("Expected successWithPrecedingCancellation but got \(result)")
     }
   }
-  
+
   func testCanLockMultipleCancellations() {
     // Both strategies return cancellation, should use first error
     let strategy1 = MockLockmanStrategy(
@@ -180,20 +181,20 @@ final class LockmanCompositeStrategy2Tests: XCTestCase {
     let strategy2 = MockLockmanStrategy(
       canLockResult: .successWithPrecedingCancellation(error: TestError.secondCancellation)
     )
-    
+
     let composite = LockmanCompositeStrategy2(
       strategy1: strategy1,
       strategy2: strategy2
     )
-    
+
     let boundaryId = TestBoundaryId("test")
     let info = LockmanCompositeInfo2(
       lockmanInfoForStrategy1: MockLockmanInfo(actionId: "action1"),
       lockmanInfoForStrategy2: MockLockmanInfo(actionId: "action2")
     )
-    
+
     let result = composite.canLock(id: boundaryId, info: info)
-    
+
     switch result {
     case .successWithPrecedingCancellation(let error):
       // Should use the first cancellation error
@@ -202,13 +203,13 @@ final class LockmanCompositeStrategy2Tests: XCTestCase {
       XCTFail("Expected successWithPrecedingCancellation but got \(result)")
     }
   }
-  
+
   // MARK: - Lock/Unlock Tests
-  
+
   func testLockUnlockOrder() {
     var lockOrder: [String] = []
     var unlockOrder: [String] = []
-    
+
     let strategy1 = MockOrderTrackingStrategy(
       id: "1",
       lockOrder: &lockOrder,
@@ -219,27 +220,27 @@ final class LockmanCompositeStrategy2Tests: XCTestCase {
       lockOrder: &lockOrder,
       unlockOrder: &unlockOrder
     )
-    
+
     let composite = LockmanCompositeStrategy2(
       strategy1: strategy1,
       strategy2: strategy2
     )
-    
+
     let boundaryId = TestBoundaryId("test")
     let info = LockmanCompositeInfo2(
       lockmanInfoForStrategy1: MockLockmanInfo(actionId: "1"),
       lockmanInfoForStrategy2: MockLockmanInfo(actionId: "2")
     )
-    
+
     // Lock
     composite.lock(id: boundaryId, info: info)
     XCTAssertEqual(lockOrder, ["1", "2"])
-    
+
     // Unlock (should be LIFO)
     composite.unlock(id: boundaryId, info: info)
     XCTAssertEqual(unlockOrder, ["2", "1"])
   }
-  
+
   func testLockAcquisitionState() {
     let strategy1 = LockmanSingleExecutionStrategy()
     let strategy2 = LockmanPriorityBasedStrategy()
@@ -247,34 +248,34 @@ final class LockmanCompositeStrategy2Tests: XCTestCase {
       strategy1: strategy1,
       strategy2: strategy2
     )
-    
+
     let boundaryId = TestBoundaryId("test")
     let info = LockmanCompositeInfo2(
       lockmanInfoForStrategy1: LockmanSingleExecutionInfo(actionId: "action1"),
       lockmanInfoForStrategy2: LockmanPriorityBasedInfo(actionId: "action2", priority: .medium)
     )
-    
+
     // Initially no locks
     XCTAssertTrue(strategy1.getCurrentLocks().isEmpty)
     XCTAssertTrue(strategy2.getCurrentLocks().isEmpty)
-    
+
     // Lock
     composite.lock(id: boundaryId, info: info)
-    
+
     // Both should have locks
     XCTAssertFalse(strategy1.getCurrentLocks().isEmpty)
     XCTAssertFalse(strategy2.getCurrentLocks().isEmpty)
-    
+
     // Unlock
     composite.unlock(id: boundaryId, info: info)
-    
+
     // Both should be cleared
     XCTAssertTrue(strategy1.getCurrentLocks().isEmpty)
     XCTAssertTrue(strategy2.getCurrentLocks().isEmpty)
   }
-  
+
   // MARK: - CleanUp Tests
-  
+
   func testCleanUpAll() {
     let strategy1 = LockmanSingleExecutionStrategy()
     let strategy2 = LockmanPriorityBasedStrategy()
@@ -282,33 +283,33 @@ final class LockmanCompositeStrategy2Tests: XCTestCase {
       strategy1: strategy1,
       strategy2: strategy2
     )
-    
+
     let boundaryId1 = TestBoundaryId("boundary1")
     let boundaryId2 = TestBoundaryId("boundary2")
-    
+
     let info1 = LockmanCompositeInfo2(
       lockmanInfoForStrategy1: LockmanSingleExecutionInfo(actionId: "action1"),
       lockmanInfoForStrategy2: LockmanPriorityBasedInfo(actionId: "action2", priority: .medium)
     )
-    
+
     let info2 = LockmanCompositeInfo2(
       lockmanInfoForStrategy1: LockmanSingleExecutionInfo(actionId: "action3"),
       lockmanInfoForStrategy2: LockmanPriorityBasedInfo(actionId: "action4", priority: .low)
     )
-    
+
     // Lock multiple boundaries
     composite.lock(id: boundaryId1, info: info1)
     composite.lock(id: boundaryId2, info: info2)
-    
+
     // Clean up all
     composite.cleanUp()
-    
+
     // All locks should be cleared
     XCTAssertTrue(strategy1.getCurrentLocks().isEmpty)
     XCTAssertTrue(strategy2.getCurrentLocks().isEmpty)
     XCTAssertTrue(composite.getCurrentLocks().isEmpty)
   }
-  
+
   func testCleanUpSpecificBoundary() {
     let strategy1 = LockmanSingleExecutionStrategy()
     let strategy2 = LockmanPriorityBasedStrategy()
@@ -316,38 +317,38 @@ final class LockmanCompositeStrategy2Tests: XCTestCase {
       strategy1: strategy1,
       strategy2: strategy2
     )
-    
+
     let boundaryId1 = TestBoundaryId("boundary1")
     let boundaryId2 = TestBoundaryId("boundary2")
-    
+
     let info1 = LockmanCompositeInfo2(
       lockmanInfoForStrategy1: LockmanSingleExecutionInfo(actionId: "action1"),
       lockmanInfoForStrategy2: LockmanPriorityBasedInfo(actionId: "action2", priority: .medium)
     )
-    
+
     let info2 = LockmanCompositeInfo2(
       lockmanInfoForStrategy1: LockmanSingleExecutionInfo(actionId: "action3"),
       lockmanInfoForStrategy2: LockmanPriorityBasedInfo(actionId: "action4", priority: .low)
     )
-    
+
     // Lock both boundaries
     composite.lock(id: boundaryId1, info: info1)
     composite.lock(id: boundaryId2, info: info2)
-    
+
     // Clean up only boundary1
     composite.cleanUp(id: boundaryId1)
-    
+
     // boundary1 should be cleared, boundary2 should remain
     let currentLocks = composite.getCurrentLocks()
     XCTAssertNil(currentLocks[AnyLockmanBoundaryId(boundaryId1)])
     XCTAssertNotNil(currentLocks[AnyLockmanBoundaryId(boundaryId2)])
-    
+
     // Cleanup
     composite.cleanUp()
   }
-  
+
   // MARK: - GetCurrentLocks Tests
-  
+
   func testGetCurrentLocksEmpty() {
     let strategy1 = LockmanSingleExecutionStrategy()
     let strategy2 = LockmanPriorityBasedStrategy()
@@ -355,11 +356,11 @@ final class LockmanCompositeStrategy2Tests: XCTestCase {
       strategy1: strategy1,
       strategy2: strategy2
     )
-    
+
     let locks = composite.getCurrentLocks()
     XCTAssertTrue(locks.isEmpty)
   }
-  
+
   func testGetCurrentLocksMerged() {
     let strategy1 = LockmanSingleExecutionStrategy()
     let strategy2 = LockmanPriorityBasedStrategy()
@@ -367,61 +368,62 @@ final class LockmanCompositeStrategy2Tests: XCTestCase {
       strategy1: strategy1,
       strategy2: strategy2
     )
-    
+
     let boundaryId = TestBoundaryId("test")
     let info = LockmanCompositeInfo2(
       lockmanInfoForStrategy1: LockmanSingleExecutionInfo(actionId: "action1"),
       lockmanInfoForStrategy2: LockmanPriorityBasedInfo(actionId: "action2", priority: .medium)
     )
-    
+
     composite.lock(id: boundaryId, info: info)
-    
+
     let locks = composite.getCurrentLocks()
     let anyBoundaryId = AnyLockmanBoundaryId(boundaryId)
-    
+
     XCTAssertNotNil(locks[anyBoundaryId])
     XCTAssertEqual(locks[anyBoundaryId]?.count, 2)
-    
+
     // Verify both info types are present
     let lockInfos = locks[anyBoundaryId] ?? []
     XCTAssertTrue(lockInfos.contains { $0 is LockmanSingleExecutionInfo })
     XCTAssertTrue(lockInfos.contains { $0 is LockmanPriorityBasedInfo })
-    
+
     // Cleanup
     composite.cleanUp()
   }
-  
+
   // MARK: - Complex Scenario Tests
-  
+
   func testMixedStrategyTypes() {
     // Test with different strategy combinations
     let singleStrategy = LockmanSingleExecutionStrategy()
     let priorityStrategy = LockmanPriorityBasedStrategy()
     let concurrencyStrategy = LockmanConcurrencyLimitedStrategy()
     let dynamicStrategy = LockmanDynamicConditionStrategy()
-    
+
     // Single + Priority
     let composite1 = LockmanCompositeStrategy2(
       strategy1: singleStrategy,
       strategy2: priorityStrategy
     )
-    
+
     // Concurrency + Dynamic
     let composite2 = LockmanCompositeStrategy2(
       strategy1: concurrencyStrategy,
       strategy2: dynamicStrategy
     )
-    
+
     let boundaryId = TestBoundaryId("test")
-    
+
     // Test composite1
     let info1 = LockmanCompositeInfo2(
       lockmanInfoForStrategy1: LockmanSingleExecutionInfo(actionId: "single"),
-      lockmanInfoForStrategy2: LockmanPriorityBasedInfo(actionId: "priority", priority: .high(.exclusive))
+      lockmanInfoForStrategy2: LockmanPriorityBasedInfo(
+        actionId: "priority", priority: .high(.exclusive))
     )
-    
+
     XCTAssertEqual(composite1.canLock(id: boundaryId, info: info1), .success)
-    
+
     // Test composite2
     let info2 = LockmanCompositeInfo2(
       lockmanInfoForStrategy1: LockmanConcurrencyLimitedInfo(
@@ -433,10 +435,10 @@ final class LockmanCompositeStrategy2Tests: XCTestCase {
         condition: { .success }
       )
     )
-    
+
     XCTAssertEqual(composite2.canLock(id: boundaryId, info: info2), .success)
   }
-  
+
   func testConcurrentAccess() {
     let strategy1 = LockmanSingleExecutionStrategy()
     let strategy2 = LockmanPriorityBasedStrategy()
@@ -444,13 +446,13 @@ final class LockmanCompositeStrategy2Tests: XCTestCase {
       strategy1: strategy1,
       strategy2: strategy2
     )
-    
+
     let expectation = expectation(description: "Concurrent operations")
     expectation.expectedFulfillmentCount = 100
-    
+
     let queue = DispatchQueue(label: "test", attributes: .concurrent)
     let group = DispatchGroup()
-    
+
     // Perform concurrent operations
     for i in 0..<100 {
       group.enter()
@@ -463,30 +465,30 @@ final class LockmanCompositeStrategy2Tests: XCTestCase {
             priority: i % 2 == 0 ? .high(.exclusive) : .low
           )
         )
-        
+
         if composite.canLock(id: boundaryId, info: info) == .success {
           composite.lock(id: boundaryId, info: info)
-          
+
           // Simulate some work
           Thread.sleep(forTimeInterval: 0.001)
-          
+
           composite.unlock(id: boundaryId, info: info)
         }
-        
+
         group.leave()
         expectation.fulfill()
       }
     }
-    
+
     wait(for: [expectation], timeout: 10.0)
-    
+
     // Verify no locks remain
     group.wait()
     XCTAssertTrue(composite.getCurrentLocks().isEmpty)
   }
-  
+
   // MARK: - Edge Cases
-  
+
   func testEmptyActionIds() {
     let strategy1 = LockmanSingleExecutionStrategy()
     let strategy2 = LockmanPriorityBasedStrategy()
@@ -494,23 +496,23 @@ final class LockmanCompositeStrategy2Tests: XCTestCase {
       strategy1: strategy1,
       strategy2: strategy2
     )
-    
+
     let boundaryId = TestBoundaryId("test")
     let info = LockmanCompositeInfo2(
       lockmanInfoForStrategy1: LockmanSingleExecutionInfo(actionId: ""),
       lockmanInfoForStrategy2: LockmanPriorityBasedInfo(actionId: "", priority: .medium)
     )
-    
+
     // Should still work with empty action IDs
     XCTAssertEqual(composite.canLock(id: boundaryId, info: info), .success)
-    
+
     composite.lock(id: boundaryId, info: info)
     XCTAssertFalse(composite.getCurrentLocks().isEmpty)
-    
+
     composite.unlock(id: boundaryId, info: info)
     XCTAssertTrue(composite.getCurrentLocks().isEmpty)
   }
-  
+
   func testVeryLongActionIds() {
     let strategy1 = LockmanSingleExecutionStrategy()
     let strategy2 = LockmanPriorityBasedStrategy()
@@ -518,14 +520,14 @@ final class LockmanCompositeStrategy2Tests: XCTestCase {
       strategy1: strategy1,
       strategy2: strategy2
     )
-    
+
     let longActionId = String(repeating: "a", count: 10000)
     let boundaryId = TestBoundaryId("test")
     let info = LockmanCompositeInfo2(
       lockmanInfoForStrategy1: LockmanSingleExecutionInfo(actionId: longActionId),
       lockmanInfoForStrategy2: LockmanPriorityBasedInfo(actionId: longActionId, priority: .medium)
     )
-    
+
     XCTAssertEqual(composite.canLock(id: boundaryId, info: info), .success)
   }
 }
@@ -548,35 +550,35 @@ private struct MockLockmanInfo: LockmanInfo {
 
 private final class MockLockmanStrategy: LockmanStrategy {
   typealias I = MockLockmanInfo
-  
+
   let strategyId: LockmanStrategyId = .singleExecution
   let canLockResult: LockmanResult
   private var locks: [AnyLockmanBoundaryId: [MockLockmanInfo]] = [:]
-  
+
   init(canLockResult: LockmanResult) {
     self.canLockResult = canLockResult
   }
-  
+
   func canLock<B: LockmanBoundaryId>(id: B, info: MockLockmanInfo) -> LockmanResult {
     return canLockResult
   }
-  
+
   func lock<B: LockmanBoundaryId>(id: B, info: MockLockmanInfo) {
     locks[AnyLockmanBoundaryId(id), default: []].append(info)
   }
-  
+
   func unlock<B: LockmanBoundaryId>(id: B, info: MockLockmanInfo) {
     locks[AnyLockmanBoundaryId(id)]?.removeAll { $0.uniqueId == info.uniqueId }
   }
-  
+
   func cleanUp() {
     locks.removeAll()
   }
-  
+
   func cleanUp<B: LockmanBoundaryId>(id: B) {
     locks[AnyLockmanBoundaryId(id)] = nil
   }
-  
+
   func getCurrentLocks() -> [AnyLockmanBoundaryId: [any LockmanInfo]] {
     locks.mapValues { $0 as [any LockmanInfo] }
   }
@@ -584,35 +586,35 @@ private final class MockLockmanStrategy: LockmanStrategy {
 
 private final class MockOrderTrackingStrategy: LockmanStrategy {
   typealias I = MockLockmanInfo
-  
+
   let strategyId: LockmanStrategyId
   let id: String
   private var lockOrder: UnsafeMutablePointer<[String]>
   private var unlockOrder: UnsafeMutablePointer<[String]>
-  
+
   init(id: String, lockOrder: inout [String], unlockOrder: inout [String]) {
     self.id = id
     self.strategyId = LockmanStrategyId("Mock\(id)")
     self.lockOrder = withUnsafeMutablePointer(to: &lockOrder) { $0 }
     self.unlockOrder = withUnsafeMutablePointer(to: &unlockOrder) { $0 }
   }
-  
+
   func canLock<B: LockmanBoundaryId>(id: B, info: MockLockmanInfo) -> LockmanResult {
     .success
   }
-  
+
   func lock<B: LockmanBoundaryId>(id: B, info: MockLockmanInfo) {
     lockOrder.pointee.append(self.id)
   }
-  
+
   func unlock<B: LockmanBoundaryId>(id: B, info: MockLockmanInfo) {
     unlockOrder.pointee.append(self.id)
   }
-  
+
   func cleanUp() {}
-  
+
   func cleanUp<B: LockmanBoundaryId>(id: B) {}
-  
+
   func getCurrentLocks() -> [AnyLockmanBoundaryId: [any LockmanInfo]] {
     [:]
   }

--- a/Tests/LockmanTests/Core/Strategies/CompositeStrategy/LockmanCompositeStrategy3Tests.swift
+++ b/Tests/LockmanTests/Core/Strategies/CompositeStrategy/LockmanCompositeStrategy3Tests.swift
@@ -1,59 +1,60 @@
 import XCTest
+
 @testable import Lockman
 
 final class LockmanCompositeStrategy3Tests: XCTestCase {
-  
+
   // MARK: - Test Types
-  
+
   private struct TestBoundaryId: LockmanBoundaryId {
     let value: String
-    
+
     init(_ value: String) {
       self.value = value
     }
   }
-  
+
   // MARK: - Basic Tests
-  
+
   func testInitialization() {
     let strategy1 = LockmanSingleExecutionStrategy()
     let strategy2 = LockmanPriorityBasedStrategy()
     let strategy3 = LockmanConcurrencyLimitedStrategy()
-    
+
     let composite = LockmanCompositeStrategy3(
       strategy1: strategy1,
       strategy2: strategy2,
       strategy3: strategy3
     )
-    
+
     XCTAssertEqual(composite.strategyId.name, "CompositeStrategy3")
     XCTAssertNotNil(composite.strategyId.configuration)
-    
+
     let config = composite.strategyId.configuration ?? ""
     XCTAssertTrue(config.contains(strategy1.strategyId.value))
     XCTAssertTrue(config.contains(strategy2.strategyId.value))
     XCTAssertTrue(config.contains(strategy3.strategyId.value))
     XCTAssertEqual(config.components(separatedBy: "+").count, 3)
   }
-  
+
   func testMakeStrategyIdWithStrategies() {
     let strategy1 = LockmanSingleExecutionStrategy()
     let strategy2 = LockmanPriorityBasedStrategy()
     let strategy3 = LockmanConcurrencyLimitedStrategy()
-    
+
     let strategyId = LockmanCompositeStrategy3.makeStrategyId(
       strategy1: strategy1,
       strategy2: strategy2,
       strategy3: strategy3
     )
-    
+
     XCTAssertEqual(strategyId.name, "CompositeStrategy3")
     XCTAssertEqual(
       strategyId.configuration,
       "\(strategy1.strategyId.value)+\(strategy2.strategyId.value)+\(strategy3.strategyId.value)"
     )
   }
-  
+
   func testMakeStrategyIdWithoutParameters() {
     let strategyId = LockmanCompositeStrategy3<
       LockmanSingleExecutionInfo,
@@ -63,24 +64,24 @@ final class LockmanCompositeStrategy3Tests: XCTestCase {
       LockmanConcurrencyLimitedInfo,
       LockmanConcurrencyLimitedStrategy
     >.makeStrategyId()
-    
+
     XCTAssertEqual(strategyId.name, "CompositeStrategy3")
     XCTAssertNil(strategyId.configuration)
   }
-  
+
   // MARK: - CanLock Tests
-  
+
   func testCanLockAllSuccess() {
     let strategy1 = LockmanSingleExecutionStrategy()
     let strategy2 = LockmanPriorityBasedStrategy()
     let strategy3 = LockmanConcurrencyLimitedStrategy()
-    
+
     let composite = LockmanCompositeStrategy3(
       strategy1: strategy1,
       strategy2: strategy2,
       strategy3: strategy3
     )
-    
+
     let boundaryId = TestBoundaryId("test")
     let info = LockmanCompositeInfo3(
       lockmanInfoForStrategy1: LockmanSingleExecutionInfo(actionId: "action1"),
@@ -90,28 +91,28 @@ final class LockmanCompositeStrategy3Tests: XCTestCase {
         limit: .limited(5)
       )
     )
-    
+
     let result = composite.canLock(id: boundaryId, info: info)
     XCTAssertEqual(result, .success)
   }
-  
+
   func testCanLockFirstStrategyFails() {
     let strategy1 = LockmanSingleExecutionStrategy()
     let strategy2 = LockmanPriorityBasedStrategy()
     let strategy3 = LockmanConcurrencyLimitedStrategy()
-    
+
     let composite = LockmanCompositeStrategy3(
       strategy1: strategy1,
       strategy2: strategy2,
       strategy3: strategy3
     )
-    
+
     let boundaryId = TestBoundaryId("test")
     let blockingInfo = LockmanSingleExecutionInfo(actionId: "action1")
-    
+
     // Block strategy1
     strategy1.lockAcquired(id: boundaryId, info: blockingInfo)
-    
+
     let compositeInfo = LockmanCompositeInfo3(
       lockmanInfoForStrategy1: blockingInfo,
       lockmanInfoForStrategy2: LockmanPriorityBasedInfo(actionId: "action2", priority: .medium),
@@ -120,40 +121,40 @@ final class LockmanCompositeStrategy3Tests: XCTestCase {
         limit: .limited(5)
       )
     )
-    
+
     let result = composite.canLock(id: boundaryId, info: compositeInfo)
-    
+
     switch result {
     case .failure(let error):
       XCTAssertTrue(error is LockmanSingleExecutionError)
     default:
       XCTFail("Expected failure but got \(result)")
     }
-    
+
     // Cleanup
     strategy1.lockReleased(id: boundaryId, info: blockingInfo)
   }
-  
+
   func testCanLockSecondStrategyFails() {
     let strategy1 = LockmanSingleExecutionStrategy()
     let strategy2 = LockmanPriorityBasedStrategy()
     let strategy3 = LockmanConcurrencyLimitedStrategy()
-    
+
     let composite = LockmanCompositeStrategy3(
       strategy1: strategy1,
       strategy2: strategy2,
       strategy3: strategy3
     )
-    
+
     let boundaryId = TestBoundaryId("test")
     let blockingInfo = LockmanPriorityBasedInfo(
       actionId: "blocking",
       priority: .high(.preferLater)
     )
-    
+
     // Block strategy2 with high priority
     strategy2.lockAcquired(id: boundaryId, info: blockingInfo)
-    
+
     let compositeInfo = LockmanCompositeInfo3(
       lockmanInfoForStrategy1: LockmanSingleExecutionInfo(actionId: "action1"),
       lockmanInfoForStrategy2: LockmanPriorityBasedInfo(actionId: "action2", priority: .low),
@@ -162,34 +163,34 @@ final class LockmanCompositeStrategy3Tests: XCTestCase {
         limit: .limited(5)
       )
     )
-    
+
     let result = composite.canLock(id: boundaryId, info: compositeInfo)
-    
+
     switch result {
     case .failure(let error):
       XCTAssertTrue(error is LockmanPriorityBasedError)
     default:
       XCTFail("Expected failure but got \(result)")
     }
-    
+
     // Cleanup
     strategy2.lockReleased(id: boundaryId, info: blockingInfo)
   }
-  
+
   func testCanLockThirdStrategyFails() {
     let strategy1 = LockmanSingleExecutionStrategy()
     let strategy2 = LockmanPriorityBasedStrategy()
     let strategy3 = LockmanConcurrencyLimitedStrategy()
-    
+
     let composite = LockmanCompositeStrategy3(
       strategy1: strategy1,
       strategy2: strategy2,
       strategy3: strategy3
     )
-    
+
     let boundaryId = TestBoundaryId("test")
     let groupId = AnyLockmanGroupId("limited-group")
-    
+
     // Fill up the concurrency limit
     let blockingInfo1 = LockmanConcurrencyLimitedInfo(
       concurrencyId: groupId,
@@ -199,10 +200,10 @@ final class LockmanCompositeStrategy3Tests: XCTestCase {
       concurrencyId: groupId,
       limit: .limited(2)
     )
-    
+
     strategy3.lockAcquired(id: boundaryId, info: blockingInfo1)
     strategy3.lockAcquired(id: boundaryId, info: blockingInfo2)
-    
+
     let compositeInfo = LockmanCompositeInfo3(
       lockmanInfoForStrategy1: LockmanSingleExecutionInfo(actionId: "action1"),
       lockmanInfoForStrategy2: LockmanPriorityBasedInfo(actionId: "action2", priority: .medium),
@@ -211,43 +212,43 @@ final class LockmanCompositeStrategy3Tests: XCTestCase {
         limit: .limited(2)
       )
     )
-    
+
     let result = composite.canLock(id: boundaryId, info: compositeInfo)
-    
+
     switch result {
     case .failure(let error):
       XCTAssertTrue(error is LockmanConcurrencyLimitedError)
     default:
       XCTFail("Expected failure but got \(result)")
     }
-    
+
     // Cleanup
     strategy3.lockReleased(id: boundaryId, info: blockingInfo1)
     strategy3.lockReleased(id: boundaryId, info: blockingInfo2)
   }
-  
+
   func testCanLockWithMixedCancellations() {
     let strategy1 = MockLockmanStrategy(canLockResult: .success)
     let strategy2 = MockLockmanStrategy(
       canLockResult: .successWithPrecedingCancellation(error: TestError.cancellationError)
     )
     let strategy3 = MockLockmanStrategy(canLockResult: .success)
-    
+
     let composite = LockmanCompositeStrategy3(
       strategy1: strategy1,
       strategy2: strategy2,
       strategy3: strategy3
     )
-    
+
     let boundaryId = TestBoundaryId("test")
     let info = LockmanCompositeInfo3(
       lockmanInfoForStrategy1: MockLockmanInfo(actionId: "action1"),
       lockmanInfoForStrategy2: MockLockmanInfo(actionId: "action2"),
       lockmanInfoForStrategy3: MockLockmanInfo(actionId: "action3")
     )
-    
+
     let result = composite.canLock(id: boundaryId, info: info)
-    
+
     switch result {
     case .successWithPrecedingCancellation(let error):
       XCTAssertTrue(error is TestError)
@@ -255,7 +256,7 @@ final class LockmanCompositeStrategy3Tests: XCTestCase {
       XCTFail("Expected successWithPrecedingCancellation but got \(result)")
     }
   }
-  
+
   func testCanLockAllCancellations() {
     // All three strategies return cancellation
     let strategy1 = MockLockmanStrategy(
@@ -267,22 +268,22 @@ final class LockmanCompositeStrategy3Tests: XCTestCase {
     let strategy3 = MockLockmanStrategy(
       canLockResult: .successWithPrecedingCancellation(error: TestError.thirdCancellation)
     )
-    
+
     let composite = LockmanCompositeStrategy3(
       strategy1: strategy1,
       strategy2: strategy2,
       strategy3: strategy3
     )
-    
+
     let boundaryId = TestBoundaryId("test")
     let info = LockmanCompositeInfo3(
       lockmanInfoForStrategy1: MockLockmanInfo(actionId: "action1"),
       lockmanInfoForStrategy2: MockLockmanInfo(actionId: "action2"),
       lockmanInfoForStrategy3: MockLockmanInfo(actionId: "action3")
     )
-    
+
     let result = composite.canLock(id: boundaryId, info: info)
-    
+
     switch result {
     case .successWithPrecedingCancellation(let error):
       // Should use the first cancellation error
@@ -291,13 +292,13 @@ final class LockmanCompositeStrategy3Tests: XCTestCase {
       XCTFail("Expected successWithPrecedingCancellation but got \(result)")
     }
   }
-  
+
   // MARK: - Lock/Unlock Tests
-  
+
   func testLockUnlockOrder() {
     var lockOrder: [String] = []
     var unlockOrder: [String] = []
-    
+
     let strategy1 = MockOrderTrackingStrategy(
       id: "1",
       lockOrder: &lockOrder,
@@ -313,40 +314,40 @@ final class LockmanCompositeStrategy3Tests: XCTestCase {
       lockOrder: &lockOrder,
       unlockOrder: &unlockOrder
     )
-    
+
     let composite = LockmanCompositeStrategy3(
       strategy1: strategy1,
       strategy2: strategy2,
       strategy3: strategy3
     )
-    
+
     let boundaryId = TestBoundaryId("test")
     let info = LockmanCompositeInfo3(
       lockmanInfoForStrategy1: MockLockmanInfo(actionId: "1"),
       lockmanInfoForStrategy2: MockLockmanInfo(actionId: "2"),
       lockmanInfoForStrategy3: MockLockmanInfo(actionId: "3")
     )
-    
+
     // Lock
     composite.lock(id: boundaryId, info: info)
     XCTAssertEqual(lockOrder, ["1", "2", "3"])
-    
+
     // Unlock (should be LIFO)
     composite.unlock(id: boundaryId, info: info)
     XCTAssertEqual(unlockOrder, ["3", "2", "1"])
   }
-  
+
   func testLockAcquisitionStateAllStrategies() {
     let strategy1 = LockmanSingleExecutionStrategy()
     let strategy2 = LockmanPriorityBasedStrategy()
     let strategy3 = LockmanConcurrencyLimitedStrategy()
-    
+
     let composite = LockmanCompositeStrategy3(
       strategy1: strategy1,
       strategy2: strategy2,
       strategy3: strategy3
     )
-    
+
     let boundaryId = TestBoundaryId("test")
     let info = LockmanCompositeInfo3(
       lockmanInfoForStrategy1: LockmanSingleExecutionInfo(actionId: "action1"),
@@ -356,45 +357,45 @@ final class LockmanCompositeStrategy3Tests: XCTestCase {
         limit: .limited(5)
       )
     )
-    
+
     // Initially no locks
     XCTAssertTrue(strategy1.getCurrentLocks().isEmpty)
     XCTAssertTrue(strategy2.getCurrentLocks().isEmpty)
     XCTAssertTrue(strategy3.getCurrentLocks().isEmpty)
-    
+
     // Lock
     composite.lock(id: boundaryId, info: info)
-    
+
     // All should have locks
     XCTAssertFalse(strategy1.getCurrentLocks().isEmpty)
     XCTAssertFalse(strategy2.getCurrentLocks().isEmpty)
     XCTAssertFalse(strategy3.getCurrentLocks().isEmpty)
-    
+
     // Unlock
     composite.unlock(id: boundaryId, info: info)
-    
+
     // All should be cleared
     XCTAssertTrue(strategy1.getCurrentLocks().isEmpty)
     XCTAssertTrue(strategy2.getCurrentLocks().isEmpty)
     XCTAssertTrue(strategy3.getCurrentLocks().isEmpty)
   }
-  
+
   // MARK: - CleanUp Tests
-  
+
   func testCleanUpAll() {
     let strategy1 = LockmanSingleExecutionStrategy()
     let strategy2 = LockmanPriorityBasedStrategy()
     let strategy3 = LockmanConcurrencyLimitedStrategy()
-    
+
     let composite = LockmanCompositeStrategy3(
       strategy1: strategy1,
       strategy2: strategy2,
       strategy3: strategy3
     )
-    
+
     let boundaryId1 = TestBoundaryId("boundary1")
     let boundaryId2 = TestBoundaryId("boundary2")
-    
+
     let info1 = LockmanCompositeInfo3(
       lockmanInfoForStrategy1: LockmanSingleExecutionInfo(actionId: "action1"),
       lockmanInfoForStrategy2: LockmanPriorityBasedInfo(actionId: "action2", priority: .medium),
@@ -403,7 +404,7 @@ final class LockmanCompositeStrategy3Tests: XCTestCase {
         limit: .limited(5)
       )
     )
-    
+
     let info2 = LockmanCompositeInfo3(
       lockmanInfoForStrategy1: LockmanSingleExecutionInfo(actionId: "action3"),
       lockmanInfoForStrategy2: LockmanPriorityBasedInfo(actionId: "action4", priority: .low),
@@ -412,35 +413,35 @@ final class LockmanCompositeStrategy3Tests: XCTestCase {
         limit: .limited(10)
       )
     )
-    
+
     // Lock multiple boundaries
     composite.lock(id: boundaryId1, info: info1)
     composite.lock(id: boundaryId2, info: info2)
-    
+
     // Clean up all
     composite.cleanUp()
-    
+
     // All locks should be cleared
     XCTAssertTrue(strategy1.getCurrentLocks().isEmpty)
     XCTAssertTrue(strategy2.getCurrentLocks().isEmpty)
     XCTAssertTrue(strategy3.getCurrentLocks().isEmpty)
     XCTAssertTrue(composite.getCurrentLocks().isEmpty)
   }
-  
+
   func testCleanUpSpecificBoundary() {
     let strategy1 = LockmanSingleExecutionStrategy()
     let strategy2 = LockmanPriorityBasedStrategy()
     let strategy3 = LockmanConcurrencyLimitedStrategy()
-    
+
     let composite = LockmanCompositeStrategy3(
       strategy1: strategy1,
       strategy2: strategy2,
       strategy3: strategy3
     )
-    
+
     let boundaryId1 = TestBoundaryId("boundary1")
     let boundaryId2 = TestBoundaryId("boundary2")
-    
+
     let info1 = LockmanCompositeInfo3(
       lockmanInfoForStrategy1: LockmanSingleExecutionInfo(actionId: "action1"),
       lockmanInfoForStrategy2: LockmanPriorityBasedInfo(actionId: "action2", priority: .medium),
@@ -449,7 +450,7 @@ final class LockmanCompositeStrategy3Tests: XCTestCase {
         limit: .limited(5)
       )
     )
-    
+
     let info2 = LockmanCompositeInfo3(
       lockmanInfoForStrategy1: LockmanSingleExecutionInfo(actionId: "action3"),
       lockmanInfoForStrategy2: LockmanPriorityBasedInfo(actionId: "action4", priority: .low),
@@ -458,45 +459,45 @@ final class LockmanCompositeStrategy3Tests: XCTestCase {
         limit: .limited(10)
       )
     )
-    
+
     // Lock both boundaries
     composite.lock(id: boundaryId1, info: info1)
     composite.lock(id: boundaryId2, info: info2)
-    
+
     // Clean up only boundary1
     composite.cleanUp(id: boundaryId1)
-    
+
     // boundary1 should be cleared, boundary2 should remain
     let currentLocks = composite.getCurrentLocks()
     XCTAssertNil(currentLocks[AnyLockmanBoundaryId(boundaryId1)])
     XCTAssertNotNil(currentLocks[AnyLockmanBoundaryId(boundaryId2)])
-    
+
     // Verify each strategy cleaned up correctly
     XCTAssertNil(strategy1.getCurrentLocks()[AnyLockmanBoundaryId(boundaryId1)])
     XCTAssertNil(strategy2.getCurrentLocks()[AnyLockmanBoundaryId(boundaryId1)])
     XCTAssertNil(strategy3.getCurrentLocks()[AnyLockmanBoundaryId(boundaryId1)])
-    
+
     XCTAssertNotNil(strategy1.getCurrentLocks()[AnyLockmanBoundaryId(boundaryId2)])
     XCTAssertNotNil(strategy2.getCurrentLocks()[AnyLockmanBoundaryId(boundaryId2)])
     XCTAssertNotNil(strategy3.getCurrentLocks()[AnyLockmanBoundaryId(boundaryId2)])
-    
+
     // Cleanup
     composite.cleanUp()
   }
-  
+
   // MARK: - GetCurrentLocks Tests
-  
+
   func testGetCurrentLocksMergedFromThreeStrategies() {
     let strategy1 = LockmanSingleExecutionStrategy()
     let strategy2 = LockmanPriorityBasedStrategy()
     let strategy3 = LockmanConcurrencyLimitedStrategy()
-    
+
     let composite = LockmanCompositeStrategy3(
       strategy1: strategy1,
       strategy2: strategy2,
       strategy3: strategy3
     )
-    
+
     let boundaryId = TestBoundaryId("test")
     let info = LockmanCompositeInfo3(
       lockmanInfoForStrategy1: LockmanSingleExecutionInfo(actionId: "action1"),
@@ -506,27 +507,27 @@ final class LockmanCompositeStrategy3Tests: XCTestCase {
         limit: .limited(5)
       )
     )
-    
+
     composite.lock(id: boundaryId, info: info)
-    
+
     let locks = composite.getCurrentLocks()
     let anyBoundaryId = AnyLockmanBoundaryId(boundaryId)
-    
+
     XCTAssertNotNil(locks[anyBoundaryId])
     XCTAssertEqual(locks[anyBoundaryId]?.count, 3)
-    
+
     // Verify all three info types are present
     let lockInfos = locks[anyBoundaryId] ?? []
     XCTAssertTrue(lockInfos.contains { $0 is LockmanSingleExecutionInfo })
     XCTAssertTrue(lockInfos.contains { $0 is LockmanPriorityBasedInfo })
     XCTAssertTrue(lockInfos.contains { $0 is LockmanConcurrencyLimitedInfo })
-    
+
     // Cleanup
     composite.cleanUp()
   }
-  
+
   // MARK: - Complex Scenario Tests
-  
+
   func testDifferentStrategyMixtures() {
     // Test 1: Single + Priority + Concurrency
     let composite1 = LockmanCompositeStrategy3(
@@ -534,28 +535,29 @@ final class LockmanCompositeStrategy3Tests: XCTestCase {
       strategy2: LockmanPriorityBasedStrategy(),
       strategy3: LockmanConcurrencyLimitedStrategy()
     )
-    
+
     // Test 2: Concurrency + Dynamic + Group
     let composite2 = LockmanCompositeStrategy3(
       strategy1: LockmanConcurrencyLimitedStrategy(),
       strategy2: LockmanDynamicConditionStrategy(),
       strategy3: LockmanGroupCoordinationStrategy()
     )
-    
+
     let boundaryId = TestBoundaryId("test")
-    
+
     // Test composite1
     let info1 = LockmanCompositeInfo3(
       lockmanInfoForStrategy1: LockmanSingleExecutionInfo(actionId: "single"),
-      lockmanInfoForStrategy2: LockmanPriorityBasedInfo(actionId: "priority", priority: .high(.exclusive)),
+      lockmanInfoForStrategy2: LockmanPriorityBasedInfo(
+        actionId: "priority", priority: .high(.exclusive)),
       lockmanInfoForStrategy3: LockmanConcurrencyLimitedInfo(
         concurrencyId: AnyLockmanGroupId("api"),
         limit: .limited(10)
       )
     )
-    
+
     XCTAssertEqual(composite1.canLock(id: boundaryId, info: info1), .success)
-    
+
     // Test composite2
     let info2 = LockmanCompositeInfo3(
       lockmanInfoForStrategy1: LockmanConcurrencyLimitedInfo(
@@ -572,27 +574,27 @@ final class LockmanCompositeStrategy3Tests: XCTestCase {
         groupMode: .allOrNone
       )
     )
-    
+
     XCTAssertEqual(composite2.canLock(id: boundaryId, info: info2), .success)
   }
-  
+
   func testConcurrentAccessThreeStrategies() {
     let strategy1 = LockmanSingleExecutionStrategy()
     let strategy2 = LockmanPriorityBasedStrategy()
     let strategy3 = LockmanConcurrencyLimitedStrategy()
-    
+
     let composite = LockmanCompositeStrategy3(
       strategy1: strategy1,
       strategy2: strategy2,
       strategy3: strategy3
     )
-    
+
     let expectation = expectation(description: "Concurrent operations")
     expectation.expectedFulfillmentCount = 150
-    
+
     let queue = DispatchQueue(label: "test", attributes: .concurrent)
     let group = DispatchGroup()
-    
+
     // Perform concurrent operations
     for i in 0..<150 {
       group.enter()
@@ -609,30 +611,30 @@ final class LockmanCompositeStrategy3Tests: XCTestCase {
             limit: .limited(3)
           )
         )
-        
+
         if composite.canLock(id: boundaryId, info: info) == .success {
           composite.lock(id: boundaryId, info: info)
-          
+
           // Simulate some work
           Thread.sleep(forTimeInterval: 0.001)
-          
+
           composite.unlock(id: boundaryId, info: info)
         }
-        
+
         group.leave()
         expectation.fulfill()
       }
     }
-    
+
     wait(for: [expectation], timeout: 15.0)
-    
+
     // Verify no locks remain
     group.wait()
     XCTAssertTrue(composite.getCurrentLocks().isEmpty)
   }
-  
+
   // MARK: - Edge Cases
-  
+
   func testCoordinateResultsEdgeCase() {
     // Test the edge case where we have exactly one non-success result
     // that is successWithPrecedingCancellation
@@ -641,44 +643,44 @@ final class LockmanCompositeStrategy3Tests: XCTestCase {
     let strategy3 = MockLockmanStrategy(
       canLockResult: .successWithPrecedingCancellation(error: TestError.cancellationError)
     )
-    
+
     let composite = LockmanCompositeStrategy3(
       strategy1: strategy1,
       strategy2: strategy2,
       strategy3: strategy3
     )
-    
+
     let boundaryId = TestBoundaryId("test")
     let info = LockmanCompositeInfo3(
       lockmanInfoForStrategy1: MockLockmanInfo(actionId: "1"),
       lockmanInfoForStrategy2: MockLockmanInfo(actionId: "2"),
       lockmanInfoForStrategy3: MockLockmanInfo(actionId: "3")
     )
-    
+
     let result = composite.canLock(id: boundaryId, info: info)
-    
+
     switch result {
     case .successWithPrecedingCancellation(let error):
-      XCTAssertNotNil(error) // Should not force unwrap nil
+      XCTAssertNotNil(error)  // Should not force unwrap nil
       XCTAssertTrue(error is TestError)
     default:
       XCTFail("Expected successWithPrecedingCancellation but got \(result)")
     }
   }
-  
+
   func testPerformanceWithManyOperations() {
     let strategy1 = LockmanSingleExecutionStrategy()
     let strategy2 = LockmanPriorityBasedStrategy()
     let strategy3 = LockmanConcurrencyLimitedStrategy()
-    
+
     let composite = LockmanCompositeStrategy3(
       strategy1: strategy1,
       strategy2: strategy2,
       strategy3: strategy3
     )
-    
+
     let boundaryId = TestBoundaryId("perf-test")
-    
+
     measure {
       for i in 0..<1000 {
         let info = LockmanCompositeInfo3(
@@ -692,7 +694,7 @@ final class LockmanCompositeStrategy3Tests: XCTestCase {
             limit: .unlimited
           )
         )
-        
+
         if composite.canLock(id: boundaryId, info: info) == .success {
           composite.lock(id: boundaryId, info: info)
           composite.unlock(id: boundaryId, info: info)
@@ -721,35 +723,35 @@ private struct MockLockmanInfo: LockmanInfo {
 
 private final class MockLockmanStrategy: LockmanStrategy {
   typealias I = MockLockmanInfo
-  
+
   let strategyId: LockmanStrategyId = .singleExecution
   let canLockResult: LockmanResult
   private var locks: [AnyLockmanBoundaryId: [MockLockmanInfo]] = [:]
-  
+
   init(canLockResult: LockmanResult) {
     self.canLockResult = canLockResult
   }
-  
+
   func canLock<B: LockmanBoundaryId>(id: B, info: MockLockmanInfo) -> LockmanResult {
     return canLockResult
   }
-  
+
   func lock<B: LockmanBoundaryId>(id: B, info: MockLockmanInfo) {
     locks[AnyLockmanBoundaryId(id), default: []].append(info)
   }
-  
+
   func unlock<B: LockmanBoundaryId>(id: B, info: MockLockmanInfo) {
     locks[AnyLockmanBoundaryId(id)]?.removeAll { $0.uniqueId == info.uniqueId }
   }
-  
+
   func cleanUp() {
     locks.removeAll()
   }
-  
+
   func cleanUp<B: LockmanBoundaryId>(id: B) {
     locks[AnyLockmanBoundaryId(id)] = nil
   }
-  
+
   func getCurrentLocks() -> [AnyLockmanBoundaryId: [any LockmanInfo]] {
     locks.mapValues { $0 as [any LockmanInfo] }
   }
@@ -757,35 +759,35 @@ private final class MockLockmanStrategy: LockmanStrategy {
 
 private final class MockOrderTrackingStrategy: LockmanStrategy {
   typealias I = MockLockmanInfo
-  
+
   let strategyId: LockmanStrategyId
   let id: String
   private var lockOrder: UnsafeMutablePointer<[String]>
   private var unlockOrder: UnsafeMutablePointer<[String]>
-  
+
   init(id: String, lockOrder: inout [String], unlockOrder: inout [String]) {
     self.id = id
     self.strategyId = LockmanStrategyId("Mock\(id)")
     self.lockOrder = withUnsafeMutablePointer(to: &lockOrder) { $0 }
     self.unlockOrder = withUnsafeMutablePointer(to: &unlockOrder) { $0 }
   }
-  
+
   func canLock<B: LockmanBoundaryId>(id: B, info: MockLockmanInfo) -> LockmanResult {
     .success
   }
-  
+
   func lock<B: LockmanBoundaryId>(id: B, info: MockLockmanInfo) {
     lockOrder.pointee.append(self.id)
   }
-  
+
   func unlock<B: LockmanBoundaryId>(id: B, info: MockLockmanInfo) {
     unlockOrder.pointee.append(self.id)
   }
-  
+
   func cleanUp() {}
-  
+
   func cleanUp<B: LockmanBoundaryId>(id: B) {}
-  
+
   func getCurrentLocks() -> [AnyLockmanBoundaryId: [any LockmanInfo]] {
     [:]
   }

--- a/Tests/LockmanTests/Core/Strategies/CompositeStrategy/LockmanCompositeStrategy4Tests.swift
+++ b/Tests/LockmanTests/Core/Strategies/CompositeStrategy/LockmanCompositeStrategy4Tests.swift
@@ -1,36 +1,37 @@
 import XCTest
+
 @testable import Lockman
 
 final class LockmanCompositeStrategy4Tests: XCTestCase {
-  
+
   // MARK: - Test Types
-  
+
   private struct TestBoundaryId: LockmanBoundaryId {
     let value: String
-    
+
     init(_ value: String) {
       self.value = value
     }
   }
-  
+
   // MARK: - Basic Tests
-  
+
   func testInitialization() {
     let strategy1 = LockmanSingleExecutionStrategy()
     let strategy2 = LockmanPriorityBasedStrategy()
     let strategy3 = LockmanConcurrencyLimitedStrategy()
     let strategy4 = LockmanDynamicConditionStrategy()
-    
+
     let composite = LockmanCompositeStrategy4(
       strategy1: strategy1,
       strategy2: strategy2,
       strategy3: strategy3,
       strategy4: strategy4
     )
-    
+
     XCTAssertEqual(composite.strategyId.name, "CompositeStrategy4")
     XCTAssertNotNil(composite.strategyId.configuration)
-    
+
     let config = composite.strategyId.configuration ?? ""
     XCTAssertTrue(config.contains(strategy1.strategyId.value))
     XCTAssertTrue(config.contains(strategy2.strategyId.value))
@@ -38,27 +39,27 @@ final class LockmanCompositeStrategy4Tests: XCTestCase {
     XCTAssertTrue(config.contains(strategy4.strategyId.value))
     XCTAssertEqual(config.components(separatedBy: "+").count, 4)
   }
-  
+
   func testMakeStrategyIdWithStrategies() {
     let strategy1 = LockmanSingleExecutionStrategy()
     let strategy2 = LockmanPriorityBasedStrategy()
     let strategy3 = LockmanConcurrencyLimitedStrategy()
     let strategy4 = LockmanDynamicConditionStrategy()
-    
+
     let strategyId = LockmanCompositeStrategy4.makeStrategyId(
       strategy1: strategy1,
       strategy2: strategy2,
       strategy3: strategy3,
       strategy4: strategy4
     )
-    
+
     XCTAssertEqual(strategyId.name, "CompositeStrategy4")
     XCTAssertEqual(
       strategyId.configuration,
       "\(strategy1.strategyId.value)+\(strategy2.strategyId.value)+\(strategy3.strategyId.value)+\(strategy4.strategyId.value)"
     )
   }
-  
+
   func testMakeStrategyIdWithoutParameters() {
     let strategyId = LockmanCompositeStrategy4<
       LockmanSingleExecutionInfo,
@@ -70,26 +71,26 @@ final class LockmanCompositeStrategy4Tests: XCTestCase {
       LockmanDynamicConditionInfo,
       LockmanDynamicConditionStrategy
     >.makeStrategyId()
-    
+
     XCTAssertEqual(strategyId.name, "CompositeStrategy4")
     XCTAssertNil(strategyId.configuration)
   }
-  
+
   // MARK: - CanLock Tests
-  
+
   func testCanLockAllSuccess() {
     let strategy1 = LockmanSingleExecutionStrategy()
     let strategy2 = LockmanPriorityBasedStrategy()
     let strategy3 = LockmanConcurrencyLimitedStrategy()
     let strategy4 = LockmanDynamicConditionStrategy()
-    
+
     let composite = LockmanCompositeStrategy4(
       strategy1: strategy1,
       strategy2: strategy2,
       strategy3: strategy3,
       strategy4: strategy4
     )
-    
+
     let boundaryId = TestBoundaryId("test")
     let info = LockmanCompositeInfo4(
       lockmanInfoForStrategy1: LockmanSingleExecutionInfo(actionId: "action1"),
@@ -103,30 +104,30 @@ final class LockmanCompositeStrategy4Tests: XCTestCase {
         condition: { .success }
       )
     )
-    
+
     let result = composite.canLock(id: boundaryId, info: info)
     XCTAssertEqual(result, .success)
   }
-  
+
   func testCanLockFirstStrategyFails() {
     let strategy1 = LockmanSingleExecutionStrategy()
     let strategy2 = LockmanPriorityBasedStrategy()
     let strategy3 = LockmanConcurrencyLimitedStrategy()
     let strategy4 = LockmanDynamicConditionStrategy()
-    
+
     let composite = LockmanCompositeStrategy4(
       strategy1: strategy1,
       strategy2: strategy2,
       strategy3: strategy3,
       strategy4: strategy4
     )
-    
+
     let boundaryId = TestBoundaryId("test")
     let blockingInfo = LockmanSingleExecutionInfo(actionId: "action1")
-    
+
     // Block strategy1
     strategy1.lockAcquired(id: boundaryId, info: blockingInfo)
-    
+
     let compositeInfo = LockmanCompositeInfo4(
       lockmanInfoForStrategy1: blockingInfo,
       lockmanInfoForStrategy2: LockmanPriorityBasedInfo(actionId: "action2", priority: .medium),
@@ -139,42 +140,42 @@ final class LockmanCompositeStrategy4Tests: XCTestCase {
         condition: { .success }
       )
     )
-    
+
     let result = composite.canLock(id: boundaryId, info: compositeInfo)
-    
+
     switch result {
     case .failure(let error):
       XCTAssertTrue(error is LockmanSingleExecutionError)
     default:
       XCTFail("Expected failure but got \(result)")
     }
-    
+
     // Cleanup
     strategy1.lockReleased(id: boundaryId, info: blockingInfo)
   }
-  
+
   func testCanLockSecondStrategyFails() {
     let strategy1 = LockmanSingleExecutionStrategy()
     let strategy2 = LockmanPriorityBasedStrategy()
     let strategy3 = LockmanConcurrencyLimitedStrategy()
     let strategy4 = LockmanDynamicConditionStrategy()
-    
+
     let composite = LockmanCompositeStrategy4(
       strategy1: strategy1,
       strategy2: strategy2,
       strategy3: strategy3,
       strategy4: strategy4
     )
-    
+
     let boundaryId = TestBoundaryId("test")
     let blockingInfo = LockmanPriorityBasedInfo(
       actionId: "blocking",
       priority: .high(.preferLater)
     )
-    
+
     // Block strategy2 with high priority
     strategy2.lockAcquired(id: boundaryId, info: blockingInfo)
-    
+
     let compositeInfo = LockmanCompositeInfo4(
       lockmanInfoForStrategy1: LockmanSingleExecutionInfo(actionId: "action1"),
       lockmanInfoForStrategy2: LockmanPriorityBasedInfo(actionId: "action2", priority: .low),
@@ -187,36 +188,36 @@ final class LockmanCompositeStrategy4Tests: XCTestCase {
         condition: { .success }
       )
     )
-    
+
     let result = composite.canLock(id: boundaryId, info: compositeInfo)
-    
+
     switch result {
     case .failure(let error):
       XCTAssertTrue(error is LockmanPriorityBasedError)
     default:
       XCTFail("Expected failure but got \(result)")
     }
-    
+
     // Cleanup
     strategy2.lockReleased(id: boundaryId, info: blockingInfo)
   }
-  
+
   func testCanLockThirdStrategyFails() {
     let strategy1 = LockmanSingleExecutionStrategy()
     let strategy2 = LockmanPriorityBasedStrategy()
     let strategy3 = LockmanConcurrencyLimitedStrategy()
     let strategy4 = LockmanDynamicConditionStrategy()
-    
+
     let composite = LockmanCompositeStrategy4(
       strategy1: strategy1,
       strategy2: strategy2,
       strategy3: strategy3,
       strategy4: strategy4
     )
-    
+
     let boundaryId = TestBoundaryId("test")
     let groupId = AnyLockmanGroupId("limited-group")
-    
+
     // Fill up the concurrency limit
     let blockingInfo1 = LockmanConcurrencyLimitedInfo(
       concurrencyId: groupId,
@@ -226,10 +227,10 @@ final class LockmanCompositeStrategy4Tests: XCTestCase {
       concurrencyId: groupId,
       limit: .limited(2)
     )
-    
+
     strategy3.lockAcquired(id: boundaryId, info: blockingInfo1)
     strategy3.lockAcquired(id: boundaryId, info: blockingInfo2)
-    
+
     let compositeInfo = LockmanCompositeInfo4(
       lockmanInfoForStrategy1: LockmanSingleExecutionInfo(actionId: "action1"),
       lockmanInfoForStrategy2: LockmanPriorityBasedInfo(actionId: "action2", priority: .medium),
@@ -242,34 +243,34 @@ final class LockmanCompositeStrategy4Tests: XCTestCase {
         condition: { .success }
       )
     )
-    
+
     let result = composite.canLock(id: boundaryId, info: compositeInfo)
-    
+
     switch result {
     case .failure(let error):
       XCTAssertTrue(error is LockmanConcurrencyLimitedError)
     default:
       XCTFail("Expected failure but got \(result)")
     }
-    
+
     // Cleanup
     strategy3.lockReleased(id: boundaryId, info: blockingInfo1)
     strategy3.lockReleased(id: boundaryId, info: blockingInfo2)
   }
-  
+
   func testCanLockFourthStrategyFails() {
     let strategy1 = LockmanSingleExecutionStrategy()
     let strategy2 = LockmanPriorityBasedStrategy()
     let strategy3 = LockmanConcurrencyLimitedStrategy()
     let strategy4 = LockmanDynamicConditionStrategy()
-    
+
     let composite = LockmanCompositeStrategy4(
       strategy1: strategy1,
       strategy2: strategy2,
       strategy3: strategy3,
       strategy4: strategy4
     )
-    
+
     let boundaryId = TestBoundaryId("test")
     let compositeInfo = LockmanCompositeInfo4(
       lockmanInfoForStrategy1: LockmanSingleExecutionInfo(actionId: "action1"),
@@ -283,9 +284,9 @@ final class LockmanCompositeStrategy4Tests: XCTestCase {
         condition: { .failure(TestError.mockError) }
       )
     )
-    
+
     let result = composite.canLock(id: boundaryId, info: compositeInfo)
-    
+
     switch result {
     case .failure(let error):
       XCTAssertTrue(error is TestError)
@@ -293,7 +294,7 @@ final class LockmanCompositeStrategy4Tests: XCTestCase {
       XCTFail("Expected failure but got \(result)")
     }
   }
-  
+
   func testCanLockWithMultipleCancellations() {
     let strategy1 = MockLockmanStrategy(canLockResult: .success)
     let strategy2 = MockLockmanStrategy(
@@ -303,14 +304,14 @@ final class LockmanCompositeStrategy4Tests: XCTestCase {
     let strategy4 = MockLockmanStrategy(
       canLockResult: .successWithPrecedingCancellation(error: TestError.secondCancellation)
     )
-    
+
     let composite = LockmanCompositeStrategy4(
       strategy1: strategy1,
       strategy2: strategy2,
       strategy3: strategy3,
       strategy4: strategy4
     )
-    
+
     let boundaryId = TestBoundaryId("test")
     let info = LockmanCompositeInfo4(
       lockmanInfoForStrategy1: MockLockmanInfo(actionId: "action1"),
@@ -318,9 +319,9 @@ final class LockmanCompositeStrategy4Tests: XCTestCase {
       lockmanInfoForStrategy3: MockLockmanInfo(actionId: "action3"),
       lockmanInfoForStrategy4: MockLockmanInfo(actionId: "action4")
     )
-    
+
     let result = composite.canLock(id: boundaryId, info: info)
-    
+
     switch result {
     case .successWithPrecedingCancellation(let error):
       // Should use the first cancellation error
@@ -329,13 +330,13 @@ final class LockmanCompositeStrategy4Tests: XCTestCase {
       XCTFail("Expected successWithPrecedingCancellation but got \(result)")
     }
   }
-  
+
   // MARK: - Lock/Unlock Tests
-  
+
   func testLockUnlockOrder() {
     var lockOrder: [String] = []
     var unlockOrder: [String] = []
-    
+
     let strategy1 = MockOrderTrackingStrategy(
       id: "1",
       lockOrder: &lockOrder,
@@ -356,14 +357,14 @@ final class LockmanCompositeStrategy4Tests: XCTestCase {
       lockOrder: &lockOrder,
       unlockOrder: &unlockOrder
     )
-    
+
     let composite = LockmanCompositeStrategy4(
       strategy1: strategy1,
       strategy2: strategy2,
       strategy3: strategy3,
       strategy4: strategy4
     )
-    
+
     let boundaryId = TestBoundaryId("test")
     let info = LockmanCompositeInfo4(
       lockmanInfoForStrategy1: MockLockmanInfo(actionId: "1"),
@@ -371,29 +372,29 @@ final class LockmanCompositeStrategy4Tests: XCTestCase {
       lockmanInfoForStrategy3: MockLockmanInfo(actionId: "3"),
       lockmanInfoForStrategy4: MockLockmanInfo(actionId: "4")
     )
-    
+
     // Lock
     composite.lock(id: boundaryId, info: info)
     XCTAssertEqual(lockOrder, ["1", "2", "3", "4"])
-    
+
     // Unlock (should be LIFO)
     composite.unlock(id: boundaryId, info: info)
     XCTAssertEqual(unlockOrder, ["4", "3", "2", "1"])
   }
-  
+
   func testLockAcquisitionStateAllStrategies() {
     let strategy1 = LockmanSingleExecutionStrategy()
     let strategy2 = LockmanPriorityBasedStrategy()
     let strategy3 = LockmanConcurrencyLimitedStrategy()
     let strategy4 = LockmanDynamicConditionStrategy()
-    
+
     let composite = LockmanCompositeStrategy4(
       strategy1: strategy1,
       strategy2: strategy2,
       strategy3: strategy3,
       strategy4: strategy4
     )
-    
+
     let boundaryId = TestBoundaryId("test")
     let info = LockmanCompositeInfo4(
       lockmanInfoForStrategy1: LockmanSingleExecutionInfo(actionId: "action1"),
@@ -407,50 +408,50 @@ final class LockmanCompositeStrategy4Tests: XCTestCase {
         condition: { .success }
       )
     )
-    
+
     // Initially no locks
     XCTAssertTrue(strategy1.getCurrentLocks().isEmpty)
     XCTAssertTrue(strategy2.getCurrentLocks().isEmpty)
     XCTAssertTrue(strategy3.getCurrentLocks().isEmpty)
     XCTAssertTrue(strategy4.getCurrentLocks().isEmpty)
-    
+
     // Lock
     composite.lock(id: boundaryId, info: info)
-    
+
     // All should have locks
     XCTAssertFalse(strategy1.getCurrentLocks().isEmpty)
     XCTAssertFalse(strategy2.getCurrentLocks().isEmpty)
     XCTAssertFalse(strategy3.getCurrentLocks().isEmpty)
     XCTAssertFalse(strategy4.getCurrentLocks().isEmpty)
-    
+
     // Unlock
     composite.unlock(id: boundaryId, info: info)
-    
+
     // All should be cleared
     XCTAssertTrue(strategy1.getCurrentLocks().isEmpty)
     XCTAssertTrue(strategy2.getCurrentLocks().isEmpty)
     XCTAssertTrue(strategy3.getCurrentLocks().isEmpty)
     XCTAssertTrue(strategy4.getCurrentLocks().isEmpty)
   }
-  
+
   // MARK: - CleanUp Tests
-  
+
   func testCleanUpAll() {
     let strategy1 = LockmanSingleExecutionStrategy()
     let strategy2 = LockmanPriorityBasedStrategy()
     let strategy3 = LockmanConcurrencyLimitedStrategy()
     let strategy4 = LockmanDynamicConditionStrategy()
-    
+
     let composite = LockmanCompositeStrategy4(
       strategy1: strategy1,
       strategy2: strategy2,
       strategy3: strategy3,
       strategy4: strategy4
     )
-    
+
     let boundaryId1 = TestBoundaryId("boundary1")
     let boundaryId2 = TestBoundaryId("boundary2")
-    
+
     let info1 = LockmanCompositeInfo4(
       lockmanInfoForStrategy1: LockmanSingleExecutionInfo(actionId: "action1"),
       lockmanInfoForStrategy2: LockmanPriorityBasedInfo(actionId: "action2", priority: .medium),
@@ -463,7 +464,7 @@ final class LockmanCompositeStrategy4Tests: XCTestCase {
         condition: { .success }
       )
     )
-    
+
     let info2 = LockmanCompositeInfo4(
       lockmanInfoForStrategy1: LockmanSingleExecutionInfo(actionId: "action5"),
       lockmanInfoForStrategy2: LockmanPriorityBasedInfo(actionId: "action6", priority: .low),
@@ -476,14 +477,14 @@ final class LockmanCompositeStrategy4Tests: XCTestCase {
         condition: { .success }
       )
     )
-    
+
     // Lock multiple boundaries
     composite.lock(id: boundaryId1, info: info1)
     composite.lock(id: boundaryId2, info: info2)
-    
+
     // Clean up all
     composite.cleanUp()
-    
+
     // All locks should be cleared
     XCTAssertTrue(strategy1.getCurrentLocks().isEmpty)
     XCTAssertTrue(strategy2.getCurrentLocks().isEmpty)
@@ -491,23 +492,23 @@ final class LockmanCompositeStrategy4Tests: XCTestCase {
     XCTAssertTrue(strategy4.getCurrentLocks().isEmpty)
     XCTAssertTrue(composite.getCurrentLocks().isEmpty)
   }
-  
+
   func testCleanUpSpecificBoundary() {
     let strategy1 = LockmanSingleExecutionStrategy()
     let strategy2 = LockmanPriorityBasedStrategy()
     let strategy3 = LockmanConcurrencyLimitedStrategy()
     let strategy4 = LockmanDynamicConditionStrategy()
-    
+
     let composite = LockmanCompositeStrategy4(
       strategy1: strategy1,
       strategy2: strategy2,
       strategy3: strategy3,
       strategy4: strategy4
     )
-    
+
     let boundaryId1 = TestBoundaryId("boundary1")
     let boundaryId2 = TestBoundaryId("boundary2")
-    
+
     let info1 = LockmanCompositeInfo4(
       lockmanInfoForStrategy1: LockmanSingleExecutionInfo(actionId: "action1"),
       lockmanInfoForStrategy2: LockmanPriorityBasedInfo(actionId: "action2", priority: .medium),
@@ -520,7 +521,7 @@ final class LockmanCompositeStrategy4Tests: XCTestCase {
         condition: { .success }
       )
     )
-    
+
     let info2 = LockmanCompositeInfo4(
       lockmanInfoForStrategy1: LockmanSingleExecutionInfo(actionId: "action5"),
       lockmanInfoForStrategy2: LockmanPriorityBasedInfo(actionId: "action6", priority: .low),
@@ -533,49 +534,49 @@ final class LockmanCompositeStrategy4Tests: XCTestCase {
         condition: { .success }
       )
     )
-    
+
     // Lock both boundaries
     composite.lock(id: boundaryId1, info: info1)
     composite.lock(id: boundaryId2, info: info2)
-    
+
     // Clean up only boundary1
     composite.cleanUp(id: boundaryId1)
-    
+
     // boundary1 should be cleared, boundary2 should remain
     let currentLocks = composite.getCurrentLocks()
     XCTAssertNil(currentLocks[AnyLockmanBoundaryId(boundaryId1)])
     XCTAssertNotNil(currentLocks[AnyLockmanBoundaryId(boundaryId2)])
-    
+
     // Verify each strategy cleaned up correctly
     XCTAssertNil(strategy1.getCurrentLocks()[AnyLockmanBoundaryId(boundaryId1)])
     XCTAssertNil(strategy2.getCurrentLocks()[AnyLockmanBoundaryId(boundaryId1)])
     XCTAssertNil(strategy3.getCurrentLocks()[AnyLockmanBoundaryId(boundaryId1)])
     XCTAssertNil(strategy4.getCurrentLocks()[AnyLockmanBoundaryId(boundaryId1)])
-    
+
     XCTAssertNotNil(strategy1.getCurrentLocks()[AnyLockmanBoundaryId(boundaryId2)])
     XCTAssertNotNil(strategy2.getCurrentLocks()[AnyLockmanBoundaryId(boundaryId2)])
     XCTAssertNotNil(strategy3.getCurrentLocks()[AnyLockmanBoundaryId(boundaryId2)])
     XCTAssertNotNil(strategy4.getCurrentLocks()[AnyLockmanBoundaryId(boundaryId2)])
-    
+
     // Cleanup
     composite.cleanUp()
   }
-  
+
   // MARK: - GetCurrentLocks Tests
-  
+
   func testGetCurrentLocksMergedFromFourStrategies() {
     let strategy1 = LockmanSingleExecutionStrategy()
     let strategy2 = LockmanPriorityBasedStrategy()
     let strategy3 = LockmanConcurrencyLimitedStrategy()
     let strategy4 = LockmanDynamicConditionStrategy()
-    
+
     let composite = LockmanCompositeStrategy4(
       strategy1: strategy1,
       strategy2: strategy2,
       strategy3: strategy3,
       strategy4: strategy4
     )
-    
+
     let boundaryId = TestBoundaryId("test")
     let info = LockmanCompositeInfo4(
       lockmanInfoForStrategy1: LockmanSingleExecutionInfo(actionId: "action1"),
@@ -589,28 +590,28 @@ final class LockmanCompositeStrategy4Tests: XCTestCase {
         condition: { .success }
       )
     )
-    
+
     composite.lock(id: boundaryId, info: info)
-    
+
     let locks = composite.getCurrentLocks()
     let anyBoundaryId = AnyLockmanBoundaryId(boundaryId)
-    
+
     XCTAssertNotNil(locks[anyBoundaryId])
     XCTAssertEqual(locks[anyBoundaryId]?.count, 4)
-    
+
     // Verify all four info types are present
     let lockInfos = locks[anyBoundaryId] ?? []
     XCTAssertTrue(lockInfos.contains { $0 is LockmanSingleExecutionInfo })
     XCTAssertTrue(lockInfos.contains { $0 is LockmanPriorityBasedInfo })
     XCTAssertTrue(lockInfos.contains { $0 is LockmanConcurrencyLimitedInfo })
     XCTAssertTrue(lockInfos.contains { $0 is LockmanDynamicConditionInfo })
-    
+
     // Cleanup
     composite.cleanUp()
   }
-  
+
   // MARK: - Complex Scenario Tests
-  
+
   func testAllBuiltInStrategies() {
     // Test with all built-in strategies
     let composite = LockmanCompositeStrategy4(
@@ -619,11 +620,12 @@ final class LockmanCompositeStrategy4Tests: XCTestCase {
       strategy3: LockmanConcurrencyLimitedStrategy(),
       strategy4: LockmanDynamicConditionStrategy()
     )
-    
+
     let boundaryId = TestBoundaryId("test")
     let info = LockmanCompositeInfo4(
       lockmanInfoForStrategy1: LockmanSingleExecutionInfo(actionId: "single"),
-      lockmanInfoForStrategy2: LockmanPriorityBasedInfo(actionId: "priority", priority: .high(.exclusive)),
+      lockmanInfoForStrategy2: LockmanPriorityBasedInfo(
+        actionId: "priority", priority: .high(.exclusive)),
       lockmanInfoForStrategy3: LockmanConcurrencyLimitedInfo(
         concurrencyId: AnyLockmanGroupId("api"),
         limit: .limited(10)
@@ -633,35 +635,35 @@ final class LockmanCompositeStrategy4Tests: XCTestCase {
         condition: { .success }
       )
     )
-    
+
     XCTAssertEqual(composite.canLock(id: boundaryId, info: info), .success)
-    
+
     composite.lock(id: boundaryId, info: info)
     XCTAssertFalse(composite.getCurrentLocks().isEmpty)
-    
+
     composite.unlock(id: boundaryId, info: info)
     XCTAssertTrue(composite.getCurrentLocks().isEmpty)
   }
-  
+
   func testConcurrentAccessFourStrategies() {
     let strategy1 = LockmanSingleExecutionStrategy()
     let strategy2 = LockmanPriorityBasedStrategy()
     let strategy3 = LockmanConcurrencyLimitedStrategy()
     let strategy4 = LockmanDynamicConditionStrategy()
-    
+
     let composite = LockmanCompositeStrategy4(
       strategy1: strategy1,
       strategy2: strategy2,
       strategy3: strategy3,
       strategy4: strategy4
     )
-    
+
     let expectation = expectation(description: "Concurrent operations")
     expectation.expectedFulfillmentCount = 200
-    
+
     let queue = DispatchQueue(label: "test", attributes: .concurrent)
     let group = DispatchGroup()
-    
+
     // Perform concurrent operations
     for i in 0..<200 {
       group.enter()
@@ -671,7 +673,8 @@ final class LockmanCompositeStrategy4Tests: XCTestCase {
           lockmanInfoForStrategy1: LockmanSingleExecutionInfo(actionId: "action-\(i)"),
           lockmanInfoForStrategy2: LockmanPriorityBasedInfo(
             actionId: "priority-\(i)",
-            priority: i % 4 == 0 ? .high(.exclusive) : i % 4 == 1 ? .high(.preferLater) : i % 4 == 2 ? .medium : .low
+            priority: i % 4 == 0
+              ? .high(.exclusive) : i % 4 == 1 ? .high(.preferLater) : i % 4 == 2 ? .medium : .low
           ),
           lockmanInfoForStrategy3: LockmanConcurrencyLimitedInfo(
             concurrencyId: AnyLockmanGroupId("group-\(i % 5)"),
@@ -682,44 +685,44 @@ final class LockmanCompositeStrategy4Tests: XCTestCase {
             condition: { i % 10 == 0 ? .failure(TestError.mockError) : .success }
           )
         )
-        
+
         let result = composite.canLock(id: boundaryId, info: info)
         if result == .success {
           composite.lock(id: boundaryId, info: info)
-          
+
           // Simulate some work
           Thread.sleep(forTimeInterval: 0.001)
-          
+
           composite.unlock(id: boundaryId, info: info)
         }
-        
+
         group.leave()
         expectation.fulfill()
       }
     }
-    
+
     wait(for: [expectation], timeout: 20.0)
-    
+
     // Verify no locks remain
     group.wait()
     XCTAssertTrue(composite.getCurrentLocks().isEmpty)
   }
-  
+
   // MARK: - Edge Cases
-  
+
   func testCoordinateResultsWithAllSuccess() {
     let strategy1 = MockLockmanStrategy(canLockResult: .success)
     let strategy2 = MockLockmanStrategy(canLockResult: .success)
     let strategy3 = MockLockmanStrategy(canLockResult: .success)
     let strategy4 = MockLockmanStrategy(canLockResult: .success)
-    
+
     let composite = LockmanCompositeStrategy4(
       strategy1: strategy1,
       strategy2: strategy2,
       strategy3: strategy3,
       strategy4: strategy4
     )
-    
+
     let boundaryId = TestBoundaryId("test")
     let info = LockmanCompositeInfo4(
       lockmanInfoForStrategy1: MockLockmanInfo(actionId: "1"),
@@ -727,29 +730,29 @@ final class LockmanCompositeStrategy4Tests: XCTestCase {
       lockmanInfoForStrategy3: MockLockmanInfo(actionId: "3"),
       lockmanInfoForStrategy4: MockLockmanInfo(actionId: "4")
     )
-    
+
     let result = composite.canLock(id: boundaryId, info: info)
     XCTAssertEqual(result, .success)
   }
-  
+
   func testDynamicConditionVariations() {
     let strategy1 = LockmanSingleExecutionStrategy()
     let strategy2 = LockmanPriorityBasedStrategy()
     let strategy3 = LockmanConcurrencyLimitedStrategy()
     let strategy4 = LockmanDynamicConditionStrategy()
-    
+
     let composite = LockmanCompositeStrategy4(
       strategy1: strategy1,
       strategy2: strategy2,
       strategy3: strategy3,
       strategy4: strategy4
     )
-    
+
     let boundaryId = TestBoundaryId("test")
-    
+
     // Test with condition that changes based on external state
     var shouldSucceed = true
-    
+
     let info = LockmanCompositeInfo4(
       lockmanInfoForStrategy1: LockmanSingleExecutionInfo(actionId: "action1"),
       lockmanInfoForStrategy2: LockmanPriorityBasedInfo(actionId: "action2", priority: .medium),
@@ -762,13 +765,13 @@ final class LockmanCompositeStrategy4Tests: XCTestCase {
         condition: { shouldSucceed ? .success : .failure(TestError.mockError) }
       )
     )
-    
+
     // Should succeed
     XCTAssertEqual(composite.canLock(id: boundaryId, info: info), .success)
-    
+
     // Change condition
     shouldSucceed = false
-    
+
     // Should now fail
     let result = composite.canLock(id: boundaryId, info: info)
     switch result {
@@ -778,22 +781,22 @@ final class LockmanCompositeStrategy4Tests: XCTestCase {
       XCTFail("Expected failure but got \(result)")
     }
   }
-  
+
   func testPerformanceWithFourStrategies() {
     let strategy1 = LockmanSingleExecutionStrategy()
     let strategy2 = LockmanPriorityBasedStrategy()
     let strategy3 = LockmanConcurrencyLimitedStrategy()
     let strategy4 = LockmanDynamicConditionStrategy()
-    
+
     let composite = LockmanCompositeStrategy4(
       strategy1: strategy1,
       strategy2: strategy2,
       strategy3: strategy3,
       strategy4: strategy4
     )
-    
+
     let boundaryId = TestBoundaryId("perf-test")
-    
+
     measure {
       for i in 0..<1000 {
         let info = LockmanCompositeInfo4(
@@ -811,7 +814,7 @@ final class LockmanCompositeStrategy4Tests: XCTestCase {
             condition: { .success }
           )
         )
-        
+
         if composite.canLock(id: boundaryId, info: info) == .success {
           composite.lock(id: boundaryId, info: info)
           composite.unlock(id: boundaryId, info: info)
@@ -841,35 +844,35 @@ private struct MockLockmanInfo: LockmanInfo {
 
 private final class MockLockmanStrategy: LockmanStrategy {
   typealias I = MockLockmanInfo
-  
+
   let strategyId: LockmanStrategyId = .singleExecution
   let canLockResult: LockmanResult
   private var locks: [AnyLockmanBoundaryId: [MockLockmanInfo]] = [:]
-  
+
   init(canLockResult: LockmanResult) {
     self.canLockResult = canLockResult
   }
-  
+
   func canLock<B: LockmanBoundaryId>(id: B, info: MockLockmanInfo) -> LockmanResult {
     return canLockResult
   }
-  
+
   func lock<B: LockmanBoundaryId>(id: B, info: MockLockmanInfo) {
     locks[AnyLockmanBoundaryId(id), default: []].append(info)
   }
-  
+
   func unlock<B: LockmanBoundaryId>(id: B, info: MockLockmanInfo) {
     locks[AnyLockmanBoundaryId(id)]?.removeAll { $0.uniqueId == info.uniqueId }
   }
-  
+
   func cleanUp() {
     locks.removeAll()
   }
-  
+
   func cleanUp<B: LockmanBoundaryId>(id: B) {
     locks[AnyLockmanBoundaryId(id)] = nil
   }
-  
+
   func getCurrentLocks() -> [AnyLockmanBoundaryId: [any LockmanInfo]] {
     locks.mapValues { $0 as [any LockmanInfo] }
   }
@@ -877,35 +880,35 @@ private final class MockLockmanStrategy: LockmanStrategy {
 
 private final class MockOrderTrackingStrategy: LockmanStrategy {
   typealias I = MockLockmanInfo
-  
+
   let strategyId: LockmanStrategyId
   let id: String
   private var lockOrder: UnsafeMutablePointer<[String]>
   private var unlockOrder: UnsafeMutablePointer<[String]>
-  
+
   init(id: String, lockOrder: inout [String], unlockOrder: inout [String]) {
     self.id = id
     self.strategyId = LockmanStrategyId("Mock\(id)")
     self.lockOrder = withUnsafeMutablePointer(to: &lockOrder) { $0 }
     self.unlockOrder = withUnsafeMutablePointer(to: &unlockOrder) { $0 }
   }
-  
+
   func canLock<B: LockmanBoundaryId>(id: B, info: MockLockmanInfo) -> LockmanResult {
     .success
   }
-  
+
   func lock<B: LockmanBoundaryId>(id: B, info: MockLockmanInfo) {
     lockOrder.pointee.append(self.id)
   }
-  
+
   func unlock<B: LockmanBoundaryId>(id: B, info: MockLockmanInfo) {
     unlockOrder.pointee.append(self.id)
   }
-  
+
   func cleanUp() {}
-  
+
   func cleanUp<B: LockmanBoundaryId>(id: B) {}
-  
+
   func getCurrentLocks() -> [AnyLockmanBoundaryId: [any LockmanInfo]] {
     [:]
   }

--- a/Tests/LockmanTests/Core/Strategies/CompositeStrategy/LockmanCompositeStrategyTests.swift
+++ b/Tests/LockmanTests/Core/Strategies/CompositeStrategy/LockmanCompositeStrategyTests.swift
@@ -1,40 +1,41 @@
 import XCTest
+
 @testable import Lockman
 
 final class LockmanCompositeStrategyTests: XCTestCase {
-  
+
   // MARK: - LockmanCompositeStrategy2 Tests
-  
+
   func testCompositeStrategy2Initialization() {
     let strategy1 = LockmanSingleExecutionStrategy()
     let strategy2 = LockmanPriorityBasedStrategy()
-    
+
     let composite = LockmanCompositeStrategy2(
       strategy1: strategy1,
       strategy2: strategy2
     )
-    
+
     XCTAssertEqual(composite.strategyId.name, "CompositeStrategy2")
     XCTAssertTrue(composite.strategyId.value.contains(strategy1.strategyId.value))
     XCTAssertTrue(composite.strategyId.value.contains(strategy2.strategyId.value))
   }
-  
+
   func testCompositeStrategy2MakeStrategyId() {
     let strategy1 = LockmanSingleExecutionStrategy()
     let strategy2 = LockmanPriorityBasedStrategy()
-    
+
     let strategyId = LockmanCompositeStrategy2.makeStrategyId(
       strategy1: strategy1,
       strategy2: strategy2
     )
-    
+
     XCTAssertEqual(strategyId.name, "CompositeStrategy2")
     XCTAssertEqual(
       strategyId.configuration,
       "\(strategy1.strategyId.value)+\(strategy2.strategyId.value)"
     )
   }
-  
+
   func testCompositeStrategy2MakeStrategyIdWithoutParameters() {
     let strategyId = LockmanCompositeStrategy2<
       LockmanSingleExecutionInfo,
@@ -42,11 +43,11 @@ final class LockmanCompositeStrategyTests: XCTestCase {
       LockmanPriorityBasedInfo,
       LockmanPriorityBasedStrategy
     >.makeStrategyId()
-    
+
     XCTAssertEqual(strategyId.name, "CompositeStrategy2")
     XCTAssertNil(strategyId.configuration)
   }
-  
+
   func testCompositeStrategy2CanLockSuccess() {
     let strategy1 = LockmanSingleExecutionStrategy()
     let strategy2 = LockmanPriorityBasedStrategy()
@@ -54,18 +55,18 @@ final class LockmanCompositeStrategyTests: XCTestCase {
       strategy1: strategy1,
       strategy2: strategy2
     )
-    
+
     let boundaryId = AnyLockmanBoundaryId("test")
     let info = LockmanCompositeInfo2(
       lockmanInfoForStrategy1: LockmanSingleExecutionInfo(actionId: "action1"),
       lockmanInfoForStrategy2: LockmanPriorityBasedInfo(actionId: "action2", priority: .medium)
     )
-    
+
     // Both strategies should allow locking
     let result = composite.canLock(id: boundaryId, info: info)
     XCTAssertEqual(result, .success)
   }
-  
+
   func testCompositeStrategy2CanLockFailureStrategy1() {
     let strategy1 = LockmanSingleExecutionStrategy()
     let strategy2 = LockmanPriorityBasedStrategy()
@@ -73,22 +74,22 @@ final class LockmanCompositeStrategyTests: XCTestCase {
       strategy1: strategy1,
       strategy2: strategy2
     )
-    
+
     let boundaryId = AnyLockmanBoundaryId("test")
     let info1 = LockmanSingleExecutionInfo(actionId: "action1")
     let info2 = LockmanPriorityBasedInfo(actionId: "action2", priority: .medium)
-    
+
     // Lock with strategy1 first
     strategy1.lockAcquired(id: boundaryId, info: info1)
-    
+
     let compositeInfo = LockmanCompositeInfo2(
       lockmanInfoForStrategy1: info1,
       lockmanInfoForStrategy2: info2
     )
-    
+
     // Should fail because strategy1 already has a lock
     let result = composite.canLock(id: boundaryId, info: compositeInfo)
-    
+
     switch result {
     case .failure:
       // Expected
@@ -96,11 +97,11 @@ final class LockmanCompositeStrategyTests: XCTestCase {
     default:
       XCTFail("Expected failure but got \(result)")
     }
-    
+
     // Cleanup
     strategy1.lockReleased(id: boundaryId, info: info1)
   }
-  
+
   func testCompositeStrategy2CanLockFailureStrategy2() {
     let strategy1 = LockmanSingleExecutionStrategy()
     let strategy2 = LockmanPriorityBasedStrategy()
@@ -108,7 +109,7 @@ final class LockmanCompositeStrategyTests: XCTestCase {
       strategy1: strategy1,
       strategy2: strategy2
     )
-    
+
     let boundaryId = AnyLockmanBoundaryId("test")
     let info1 = LockmanSingleExecutionInfo(actionId: "action1")
     let info2 = LockmanPriorityBasedInfo(actionId: "action2", priority: .medium)
@@ -116,18 +117,18 @@ final class LockmanCompositeStrategyTests: XCTestCase {
       actionId: "blocking",
       priority: .high(.preferLater)
     )
-    
+
     // Lock with strategy2 first with higher priority
     strategy2.lockAcquired(id: boundaryId, info: blockingInfo2)
-    
+
     let compositeInfo = LockmanCompositeInfo2(
       lockmanInfoForStrategy1: info1,
       lockmanInfoForStrategy2: info2
     )
-    
+
     // Should fail because strategy2 has a higher priority lock
     let result = composite.canLock(id: boundaryId, info: compositeInfo)
-    
+
     switch result {
     case .failure:
       // Expected
@@ -135,29 +136,30 @@ final class LockmanCompositeStrategyTests: XCTestCase {
     default:
       XCTFail("Expected failure but got \(result)")
     }
-    
+
     // Cleanup
     strategy2.lockReleased(id: boundaryId, info: blockingInfo2)
   }
-  
+
   func testCompositeStrategy2CanLockWithCancellation() {
     // Create a mock strategy that returns successWithPrecedingCancellation
-    let strategy1 = MockLockmanStrategy(canLockResult: .successWithPrecedingCancellation(error: TestError.mockError))
+    let strategy1 = MockLockmanStrategy(
+      canLockResult: .successWithPrecedingCancellation(error: TestError.mockError))
     let strategy2 = LockmanSingleExecutionStrategy()
-    
+
     let composite = LockmanCompositeStrategy2(
       strategy1: strategy1,
       strategy2: strategy2
     )
-    
+
     let boundaryId = AnyLockmanBoundaryId("test")
     let compositeInfo = LockmanCompositeInfo2(
       lockmanInfoForStrategy1: MockLockmanInfo(actionId: "action1"),
       lockmanInfoForStrategy2: LockmanSingleExecutionInfo(actionId: "action2")
     )
-    
+
     let result = composite.canLock(id: boundaryId, info: compositeInfo)
-    
+
     switch result {
     case .successWithPrecedingCancellation(let error):
       XCTAssertTrue(error is TestError)
@@ -165,7 +167,7 @@ final class LockmanCompositeStrategyTests: XCTestCase {
       XCTFail("Expected successWithPrecedingCancellation but got \(result)")
     }
   }
-  
+
   func testCompositeStrategy2LockAndUnlock() {
     let strategy1 = LockmanSingleExecutionStrategy()
     let strategy2 = LockmanPriorityBasedStrategy()
@@ -173,28 +175,28 @@ final class LockmanCompositeStrategyTests: XCTestCase {
       strategy1: strategy1,
       strategy2: strategy2
     )
-    
+
     let boundaryId = AnyLockmanBoundaryId("test")
     let info = LockmanCompositeInfo2(
       lockmanInfoForStrategy1: LockmanSingleExecutionInfo(actionId: "action1"),
       lockmanInfoForStrategy2: LockmanPriorityBasedInfo(actionId: "action2", priority: .medium)
     )
-    
+
     // Lock
     composite.lock(id: boundaryId, info: info)
-    
+
     // Verify both strategies have locks
     XCTAssertFalse(strategy1.getCurrentLocks().isEmpty)
     XCTAssertFalse(strategy2.getCurrentLocks().isEmpty)
-    
+
     // Unlock
     composite.unlock(id: boundaryId, info: info)
-    
+
     // Verify both strategies released locks
     XCTAssertTrue(strategy1.getCurrentLocks().isEmpty)
     XCTAssertTrue(strategy2.getCurrentLocks().isEmpty)
   }
-  
+
   func testCompositeStrategy2CleanUp() {
     let strategy1 = LockmanSingleExecutionStrategy()
     let strategy2 = LockmanPriorityBasedStrategy()
@@ -202,24 +204,24 @@ final class LockmanCompositeStrategyTests: XCTestCase {
       strategy1: strategy1,
       strategy2: strategy2
     )
-    
+
     let boundaryId = AnyLockmanBoundaryId("test")
     let info = LockmanCompositeInfo2(
       lockmanInfoForStrategy1: LockmanSingleExecutionInfo(actionId: "action1"),
       lockmanInfoForStrategy2: LockmanPriorityBasedInfo(actionId: "action2", priority: .medium)
     )
-    
+
     // Lock
     composite.lock(id: boundaryId, info: info)
-    
+
     // Clean up all
     composite.cleanUp()
-    
+
     // Verify all locks are cleared
     XCTAssertTrue(strategy1.getCurrentLocks().isEmpty)
     XCTAssertTrue(strategy2.getCurrentLocks().isEmpty)
   }
-  
+
   func testCompositeStrategy2CleanUpBoundary() {
     let strategy1 = LockmanSingleExecutionStrategy()
     let strategy2 = LockmanPriorityBasedStrategy()
@@ -227,36 +229,36 @@ final class LockmanCompositeStrategyTests: XCTestCase {
       strategy1: strategy1,
       strategy2: strategy2
     )
-    
+
     let boundaryId1 = AnyLockmanBoundaryId("test1")
     let boundaryId2 = AnyLockmanBoundaryId("test2")
-    
+
     let info1 = LockmanCompositeInfo2(
       lockmanInfoForStrategy1: LockmanSingleExecutionInfo(actionId: "action1"),
       lockmanInfoForStrategy2: LockmanPriorityBasedInfo(actionId: "action2", priority: .medium)
     )
-    
+
     let info2 = LockmanCompositeInfo2(
       lockmanInfoForStrategy1: LockmanSingleExecutionInfo(actionId: "action3"),
       lockmanInfoForStrategy2: LockmanPriorityBasedInfo(actionId: "action4", priority: .low)
     )
-    
+
     // Lock both boundaries
     composite.lock(id: boundaryId1, info: info1)
     composite.lock(id: boundaryId2, info: info2)
-    
+
     // Clean up only boundary1
     composite.cleanUp(id: boundaryId1)
-    
+
     // Verify boundary1 locks are cleared but boundary2 locks remain
     let currentLocks = composite.getCurrentLocks()
     XCTAssertNil(currentLocks[boundaryId1])
     XCTAssertNotNil(currentLocks[boundaryId2])
-    
+
     // Cleanup
     composite.cleanUp()
   }
-  
+
   func testCompositeStrategy2GetCurrentLocks() {
     let strategy1 = LockmanSingleExecutionStrategy()
     let strategy2 = LockmanPriorityBasedStrategy()
@@ -264,57 +266,57 @@ final class LockmanCompositeStrategyTests: XCTestCase {
       strategy1: strategy1,
       strategy2: strategy2
     )
-    
+
     let boundaryId = AnyLockmanBoundaryId("test")
     let info = LockmanCompositeInfo2(
       lockmanInfoForStrategy1: LockmanSingleExecutionInfo(actionId: "action1"),
       lockmanInfoForStrategy2: LockmanPriorityBasedInfo(actionId: "action2", priority: .medium)
     )
-    
+
     // Initially empty
     XCTAssertTrue(composite.getCurrentLocks().isEmpty)
-    
+
     // Lock
     composite.lock(id: boundaryId, info: info)
-    
+
     // Should have locks from both strategies
     let currentLocks = composite.getCurrentLocks()
     XCTAssertEqual(currentLocks[boundaryId]?.count, 2)
-    
+
     // Cleanup
     composite.cleanUp()
   }
-  
+
   // MARK: - LockmanCompositeStrategy3 Tests
-  
+
   func testCompositeStrategy3Initialization() {
     let strategy1 = LockmanSingleExecutionStrategy()
     let strategy2 = LockmanPriorityBasedStrategy()
     let strategy3 = LockmanConcurrencyLimitedStrategy()
-    
+
     let composite = LockmanCompositeStrategy3(
       strategy1: strategy1,
       strategy2: strategy2,
       strategy3: strategy3
     )
-    
+
     XCTAssertEqual(composite.strategyId.name, "CompositeStrategy3")
     XCTAssertTrue(composite.strategyId.value.contains(strategy1.strategyId.value))
     XCTAssertTrue(composite.strategyId.value.contains(strategy2.strategyId.value))
     XCTAssertTrue(composite.strategyId.value.contains(strategy3.strategyId.value))
   }
-  
+
   func testCompositeStrategy3CanLockSuccess() {
     let strategy1 = LockmanSingleExecutionStrategy()
     let strategy2 = LockmanPriorityBasedStrategy()
     let strategy3 = LockmanConcurrencyLimitedStrategy()
-    
+
     let composite = LockmanCompositeStrategy3(
       strategy1: strategy1,
       strategy2: strategy2,
       strategy3: strategy3
     )
-    
+
     let boundaryId = AnyLockmanBoundaryId("test")
     let info = LockmanCompositeInfo3(
       lockmanInfoForStrategy1: LockmanSingleExecutionInfo(actionId: "action1"),
@@ -324,31 +326,32 @@ final class LockmanCompositeStrategyTests: XCTestCase {
         limit: 3
       )
     )
-    
+
     let result = composite.canLock(id: boundaryId, info: info)
     XCTAssertEqual(result, .success)
   }
-  
+
   func testCompositeStrategy3CoordinateResultsWithMixedResults() {
     let strategy1 = MockLockmanStrategy(canLockResult: .success)
-    let strategy2 = MockLockmanStrategy(canLockResult: .successWithPrecedingCancellation(error: TestError.mockError))
+    let strategy2 = MockLockmanStrategy(
+      canLockResult: .successWithPrecedingCancellation(error: TestError.mockError))
     let strategy3 = MockLockmanStrategy(canLockResult: .success)
-    
+
     let composite = LockmanCompositeStrategy3(
       strategy1: strategy1,
       strategy2: strategy2,
       strategy3: strategy3
     )
-    
+
     let boundaryId = AnyLockmanBoundaryId("test")
     let compositeInfo = LockmanCompositeInfo3(
       lockmanInfoForStrategy1: MockLockmanInfo(actionId: "action1"),
       lockmanInfoForStrategy2: MockLockmanInfo(actionId: "action2"),
       lockmanInfoForStrategy3: MockLockmanInfo(actionId: "action3")
     )
-    
+
     let result = composite.canLock(id: boundaryId, info: compositeInfo)
-    
+
     switch result {
     case .successWithPrecedingCancellation(let error):
       XCTAssertTrue(error is TestError)
@@ -356,39 +359,39 @@ final class LockmanCompositeStrategyTests: XCTestCase {
       XCTFail("Expected successWithPrecedingCancellation but got \(result)")
     }
   }
-  
+
   // MARK: - LockmanCompositeStrategy4 Tests
-  
+
   func testCompositeStrategy4Initialization() {
     let strategy1 = LockmanSingleExecutionStrategy()
     let strategy2 = LockmanPriorityBasedStrategy()
     let strategy3 = LockmanConcurrencyLimitedStrategy()
     let strategy4 = LockmanDynamicConditionStrategy()
-    
+
     let composite = LockmanCompositeStrategy4(
       strategy1: strategy1,
       strategy2: strategy2,
       strategy3: strategy3,
       strategy4: strategy4
     )
-    
+
     XCTAssertEqual(composite.strategyId.name, "CompositeStrategy4")
     XCTAssertTrue(composite.strategyId.configuration?.contains("+") ?? false)
   }
-  
+
   func testCompositeStrategy4GetCurrentLocks() {
     let strategy1 = LockmanSingleExecutionStrategy()
     let strategy2 = LockmanPriorityBasedStrategy()
     let strategy3 = LockmanConcurrencyLimitedStrategy()
     let strategy4 = LockmanDynamicConditionStrategy()
-    
+
     let composite = LockmanCompositeStrategy4(
       strategy1: strategy1,
       strategy2: strategy2,
       strategy3: strategy3,
       strategy4: strategy4
     )
-    
+
     let boundaryId = AnyLockmanBoundaryId("test")
     let info = LockmanCompositeInfo4(
       lockmanInfoForStrategy1: LockmanSingleExecutionInfo(actionId: "action1"),
@@ -399,20 +402,20 @@ final class LockmanCompositeStrategyTests: XCTestCase {
       ),
       lockmanInfoForStrategy4: LockmanDynamicConditionInfo(actionId: "action4")
     )
-    
+
     // Lock
     composite.lock(id: boundaryId, info: info)
-    
+
     // Should have locks from all 4 strategies
     let currentLocks = composite.getCurrentLocks()
     XCTAssertEqual(currentLocks[boundaryId]?.count, 4)
-    
+
     // Cleanup
     composite.cleanUp()
   }
-  
+
   // MARK: - LockmanCompositeStrategy5 Tests
-  
+
   func testCompositeStrategy5Initialization() {
     let strategies = (
       LockmanSingleExecutionStrategy(),
@@ -421,7 +424,7 @@ final class LockmanCompositeStrategyTests: XCTestCase {
       LockmanDynamicConditionStrategy(),
       LockmanGroupCoordinationStrategy()
     )
-    
+
     let composite = LockmanCompositeStrategy5(
       strategy1: strategies.0,
       strategy2: strategies.1,
@@ -429,20 +432,25 @@ final class LockmanCompositeStrategyTests: XCTestCase {
       strategy4: strategies.3,
       strategy5: strategies.4
     )
-    
+
     XCTAssertEqual(composite.strategyId.name, "CompositeStrategy5")
   }
-  
+
   func testCompositeStrategy5LockUnlockOrder() {
     var lockOrder: [String] = []
     var unlockOrder: [String] = []
-    
-    let strategy1 = MockOrderTrackingStrategy(id: "1", lockOrder: &lockOrder, unlockOrder: &unlockOrder)
-    let strategy2 = MockOrderTrackingStrategy(id: "2", lockOrder: &lockOrder, unlockOrder: &unlockOrder)
-    let strategy3 = MockOrderTrackingStrategy(id: "3", lockOrder: &lockOrder, unlockOrder: &unlockOrder)
-    let strategy4 = MockOrderTrackingStrategy(id: "4", lockOrder: &lockOrder, unlockOrder: &unlockOrder)
-    let strategy5 = MockOrderTrackingStrategy(id: "5", lockOrder: &lockOrder, unlockOrder: &unlockOrder)
-    
+
+    let strategy1 = MockOrderTrackingStrategy(
+      id: "1", lockOrder: &lockOrder, unlockOrder: &unlockOrder)
+    let strategy2 = MockOrderTrackingStrategy(
+      id: "2", lockOrder: &lockOrder, unlockOrder: &unlockOrder)
+    let strategy3 = MockOrderTrackingStrategy(
+      id: "3", lockOrder: &lockOrder, unlockOrder: &unlockOrder)
+    let strategy4 = MockOrderTrackingStrategy(
+      id: "4", lockOrder: &lockOrder, unlockOrder: &unlockOrder)
+    let strategy5 = MockOrderTrackingStrategy(
+      id: "5", lockOrder: &lockOrder, unlockOrder: &unlockOrder)
+
     let composite = LockmanCompositeStrategy5(
       strategy1: strategy1,
       strategy2: strategy2,
@@ -450,7 +458,7 @@ final class LockmanCompositeStrategyTests: XCTestCase {
       strategy4: strategy4,
       strategy5: strategy5
     )
-    
+
     let boundaryId = AnyLockmanBoundaryId("test")
     let info = LockmanCompositeInfo5(
       lockmanInfoForStrategy1: MockLockmanInfo(actionId: "1"),
@@ -459,20 +467,20 @@ final class LockmanCompositeStrategyTests: XCTestCase {
       lockmanInfoForStrategy4: MockLockmanInfo(actionId: "4"),
       lockmanInfoForStrategy5: MockLockmanInfo(actionId: "5")
     )
-    
+
     // Lock
     composite.lock(id: boundaryId, info: info)
-    
+
     // Verify lock order is 1, 2, 3, 4, 5
     XCTAssertEqual(lockOrder, ["1", "2", "3", "4", "5"])
-    
+
     // Unlock
     composite.unlock(id: boundaryId, info: info)
-    
+
     // Verify unlock order is LIFO: 5, 4, 3, 2, 1
     XCTAssertEqual(unlockOrder, ["5", "4", "3", "2", "1"])
   }
-  
+
   func testCompositeStrategy5CleanUpOrder() {
     let strategies = (
       LockmanSingleExecutionStrategy(),
@@ -481,7 +489,7 @@ final class LockmanCompositeStrategyTests: XCTestCase {
       LockmanDynamicConditionStrategy(),
       LockmanGroupCoordinationStrategy()
     )
-    
+
     let composite = LockmanCompositeStrategy5(
       strategy1: strategies.0,
       strategy2: strategies.1,
@@ -489,7 +497,7 @@ final class LockmanCompositeStrategyTests: XCTestCase {
       strategy4: strategies.3,
       strategy5: strategies.4
     )
-    
+
     let boundaryId = AnyLockmanBoundaryId("test")
     let info = LockmanCompositeInfo5(
       lockmanInfoForStrategy1: LockmanSingleExecutionInfo(actionId: "1"),
@@ -505,13 +513,13 @@ final class LockmanCompositeStrategyTests: XCTestCase {
         groupMode: .allOrNone
       )
     )
-    
+
     // Lock
     composite.lock(id: boundaryId, info: info)
-    
+
     // Clean up specific boundary
     composite.cleanUp(id: boundaryId)
-    
+
     // Verify all locks are cleared
     XCTAssertTrue(composite.getCurrentLocks().isEmpty)
   }
@@ -528,35 +536,35 @@ private struct MockLockmanInfo: LockmanInfo {
 
 private final class MockLockmanStrategy: LockmanStrategy {
   typealias I = MockLockmanInfo
-  
+
   let strategyId: LockmanStrategyId = .singleExecution
   let canLockResult: LockmanResult
   private var locks: [AnyLockmanBoundaryId: [MockLockmanInfo]] = [:]
-  
+
   init(canLockResult: LockmanResult) {
     self.canLockResult = canLockResult
   }
-  
+
   func canLock<B: LockmanBoundaryId>(id: B, info: MockLockmanInfo) -> LockmanResult {
     return canLockResult
   }
-  
+
   func lock<B: LockmanBoundaryId>(id: B, info: MockLockmanInfo) {
     locks[AnyLockmanBoundaryId(id), default: []].append(info)
   }
-  
+
   func unlock<B: LockmanBoundaryId>(id: B, info: MockLockmanInfo) {
     locks[AnyLockmanBoundaryId(id)]?.removeAll { $0.uniqueId == info.uniqueId }
   }
-  
+
   func cleanUp() {
     locks.removeAll()
   }
-  
+
   func cleanUp<B: LockmanBoundaryId>(id: B) {
     locks[AnyLockmanBoundaryId(id)] = nil
   }
-  
+
   func getCurrentLocks() -> [AnyLockmanBoundaryId: [any LockmanInfo]] {
     locks.mapValues { $0 as [any LockmanInfo] }
   }
@@ -564,35 +572,35 @@ private final class MockLockmanStrategy: LockmanStrategy {
 
 private final class MockOrderTrackingStrategy: LockmanStrategy {
   typealias I = MockLockmanInfo
-  
+
   let strategyId: LockmanStrategyId
   let id: String
   private var lockOrder: UnsafeMutablePointer<[String]>
   private var unlockOrder: UnsafeMutablePointer<[String]>
-  
+
   init(id: String, lockOrder: inout [String], unlockOrder: inout [String]) {
     self.id = id
     self.strategyId = LockmanStrategyId("Mock\(id)")
     self.lockOrder = withUnsafeMutablePointer(to: &lockOrder) { $0 }
     self.unlockOrder = withUnsafeMutablePointer(to: &unlockOrder) { $0 }
   }
-  
+
   func canLock<B: LockmanBoundaryId>(id: B, info: MockLockmanInfo) -> LockmanResult {
     .success
   }
-  
+
   func lock<B: LockmanBoundaryId>(id: B, info: MockLockmanInfo) {
     lockOrder.pointee.append(self.id)
   }
-  
+
   func unlock<B: LockmanBoundaryId>(id: B, info: MockLockmanInfo) {
     unlockOrder.pointee.append(self.id)
   }
-  
+
   func cleanUp() {}
-  
+
   func cleanUp<B: LockmanBoundaryId>(id: B) {}
-  
+
   func getCurrentLocks() -> [AnyLockmanBoundaryId: [any LockmanInfo]] {
     [:]
   }

--- a/Tests/LockmanTests/Core/Strategies/ConcurrencyLimitedStrategy/ConcurrencyLimitTests.swift
+++ b/Tests/LockmanTests/Core/Strategies/ConcurrencyLimitedStrategy/ConcurrencyLimitTests.swift
@@ -1,29 +1,30 @@
 import XCTest
+
 @testable import Lockman
 
 final class ConcurrencyLimitTests: XCTestCase {
-  
+
   // MARK: - Basic Functionality Tests
-  
+
   func testUnlimitedConcurrency() {
     let limit = ConcurrencyLimit.unlimited
-    
+
     // maxConcurrency should be nil for unlimited
     XCTAssertNil(limit.maxConcurrency)
-    
+
     // Should never be exceeded
     XCTAssertFalse(limit.isExceeded(currentCount: 0))
     XCTAssertFalse(limit.isExceeded(currentCount: 100))
     XCTAssertFalse(limit.isExceeded(currentCount: 1000))
     XCTAssertFalse(limit.isExceeded(currentCount: Int.max))
   }
-  
+
   func testLimitedConcurrency() {
     let limit = ConcurrencyLimit.limited(5)
-    
+
     // maxConcurrency should return the limit value
     XCTAssertEqual(limit.maxConcurrency, 5)
-    
+
     // Test boundary conditions
     XCTAssertFalse(limit.isExceeded(currentCount: 0))
     XCTAssertFalse(limit.isExceeded(currentCount: 1))
@@ -32,82 +33,82 @@ final class ConcurrencyLimitTests: XCTestCase {
     XCTAssertTrue(limit.isExceeded(currentCount: 6))  // Over limit
     XCTAssertTrue(limit.isExceeded(currentCount: 100))
   }
-  
+
   func testLimitedWithZero() {
     let limit = ConcurrencyLimit.limited(0)
-    
+
     XCTAssertEqual(limit.maxConcurrency, 0)
-    
+
     // Zero limit means no concurrency allowed
     XCTAssertTrue(limit.isExceeded(currentCount: 0))
     XCTAssertTrue(limit.isExceeded(currentCount: 1))
   }
-  
+
   func testLimitedWithOne() {
     let limit = ConcurrencyLimit.limited(1)
-    
+
     XCTAssertEqual(limit.maxConcurrency, 1)
-    
+
     // Only one concurrent execution allowed
     XCTAssertFalse(limit.isExceeded(currentCount: 0))
     XCTAssertTrue(limit.isExceeded(currentCount: 1))
     XCTAssertTrue(limit.isExceeded(currentCount: 2))
   }
-  
+
   func testLimitedWithLargeValue() {
     let largeLimit = 1_000_000
     let limit = ConcurrencyLimit.limited(largeLimit)
-    
+
     XCTAssertEqual(limit.maxConcurrency, largeLimit)
-    
+
     XCTAssertFalse(limit.isExceeded(currentCount: largeLimit - 1))
     XCTAssertTrue(limit.isExceeded(currentCount: largeLimit))
     XCTAssertTrue(limit.isExceeded(currentCount: largeLimit + 1))
   }
-  
+
   // MARK: - Debug Description Tests
-  
+
   func testDebugDescriptionUnlimited() {
     let limit = ConcurrencyLimit.unlimited
     XCTAssertEqual(limit.debugDescription, "unlimited")
   }
-  
+
   func testDebugDescriptionLimited() {
     XCTAssertEqual(ConcurrencyLimit.limited(1).debugDescription, "limited(1)")
     XCTAssertEqual(ConcurrencyLimit.limited(10).debugDescription, "limited(10)")
     XCTAssertEqual(ConcurrencyLimit.limited(100).debugDescription, "limited(100)")
   }
-  
+
   // MARK: - Equatable Tests
-  
+
   func testEquality() {
     // Unlimited cases
     XCTAssertEqual(ConcurrencyLimit.unlimited, ConcurrencyLimit.unlimited)
-    
+
     // Limited cases with same value
     XCTAssertEqual(ConcurrencyLimit.limited(5), ConcurrencyLimit.limited(5))
     XCTAssertEqual(ConcurrencyLimit.limited(0), ConcurrencyLimit.limited(0))
-    
+
     // Different values
     XCTAssertNotEqual(ConcurrencyLimit.limited(5), ConcurrencyLimit.limited(6))
     XCTAssertNotEqual(ConcurrencyLimit.unlimited, ConcurrencyLimit.limited(5))
     XCTAssertNotEqual(ConcurrencyLimit.limited(5), ConcurrencyLimit.unlimited)
   }
-  
+
   // MARK: - Pattern Matching Tests
-  
+
   func testPatternMatching() {
     let limits: [ConcurrencyLimit] = [
       .unlimited,
       .limited(1),
       .limited(5),
-      .limited(10)
+      .limited(10),
     ]
-    
+
     var unlimitedCount = 0
     var limitedCount = 0
     var totalLimitValue = 0
-    
+
     for limit in limits {
       switch limit {
       case .unlimited:
@@ -117,57 +118,57 @@ final class ConcurrencyLimitTests: XCTestCase {
         totalLimitValue += value
       }
     }
-    
+
     XCTAssertEqual(unlimitedCount, 1)
     XCTAssertEqual(limitedCount, 3)
-    XCTAssertEqual(totalLimitValue, 16) // 1 + 5 + 10
+    XCTAssertEqual(totalLimitValue, 16)  // 1 + 5 + 10
   }
-  
+
   // MARK: - Integration with Strategy Tests
-  
+
   func testConcurrencyLimitInStrategy() {
     let strategy = LockmanConcurrencyLimitedStrategy()
     let boundaryId = AnyLockmanBoundaryId("test")
-    
+
     // Test unlimited concurrency
     let unlimitedInfo = LockmanConcurrencyLimitedInfo(
       concurrencyId: AnyLockmanGroupId("unlimited-group"),
       limit: .unlimited
     )
-    
+
     // Should always allow locking for unlimited
     for _ in 0..<100 {
       let result = strategy.canLock(id: boundaryId, info: unlimitedInfo)
       XCTAssertEqual(result, .success)
       strategy.lock(id: boundaryId, info: unlimitedInfo)
     }
-    
+
     // Clean up
     strategy.cleanUp()
-    
+
     // Test limited concurrency
     let limitedInfo1 = LockmanConcurrencyLimitedInfo(
       concurrencyId: AnyLockmanGroupId("limited-group"),
       limit: .limited(2)
     )
-    
+
     let limitedInfo2 = LockmanConcurrencyLimitedInfo(
       concurrencyId: AnyLockmanGroupId("limited-group"),
       limit: .limited(2)
     )
-    
+
     let limitedInfo3 = LockmanConcurrencyLimitedInfo(
       concurrencyId: AnyLockmanGroupId("limited-group"),
       limit: .limited(2)
     )
-    
+
     // First two should succeed
     XCTAssertEqual(strategy.canLock(id: boundaryId, info: limitedInfo1), .success)
     strategy.lock(id: boundaryId, info: limitedInfo1)
-    
+
     XCTAssertEqual(strategy.canLock(id: boundaryId, info: limitedInfo2), .success)
     strategy.lock(id: boundaryId, info: limitedInfo2)
-    
+
     // Third should fail (limit reached)
     let result3 = strategy.canLock(id: boundaryId, info: limitedInfo3)
     switch result3 {
@@ -176,76 +177,76 @@ final class ConcurrencyLimitTests: XCTestCase {
     default:
       XCTFail("Expected failure but got \(result3)")
     }
-    
+
     // Clean up
     strategy.cleanUp()
   }
-  
+
   // MARK: - Edge Case Tests
-  
+
   func testNegativeCurrentCount() {
     // Even though currentCount should never be negative in practice,
     // test the behavior for robustness
     let limit = ConcurrencyLimit.limited(5)
-    
+
     // Negative count should not exceed limit
     XCTAssertFalse(limit.isExceeded(currentCount: -1))
     XCTAssertFalse(limit.isExceeded(currentCount: -100))
   }
-  
+
   func testConcurrencyLimitWithDifferentGroups() {
     let strategy = LockmanConcurrencyLimitedStrategy()
     let boundaryId = AnyLockmanBoundaryId("test")
-    
+
     // Different groups with different limits
     let apiGroup = AnyLockmanGroupId("api")
     let fileGroup = AnyLockmanGroupId("file")
-    
+
     let apiInfo1 = LockmanConcurrencyLimitedInfo(
       concurrencyId: apiGroup,
       limit: .limited(2)
     )
-    
+
     let apiInfo2 = LockmanConcurrencyLimitedInfo(
       concurrencyId: apiGroup,
       limit: .limited(2)
     )
-    
+
     let fileInfo1 = LockmanConcurrencyLimitedInfo(
       concurrencyId: fileGroup,
       limit: .limited(1)
     )
-    
+
     // Lock both API slots
     strategy.lock(id: boundaryId, info: apiInfo1)
     strategy.lock(id: boundaryId, info: apiInfo2)
-    
+
     // File group should still be available (different group)
     XCTAssertEqual(strategy.canLock(id: boundaryId, info: fileInfo1), .success)
     strategy.lock(id: boundaryId, info: fileInfo1)
-    
+
     // Clean up
     strategy.cleanUp()
   }
-  
+
   // MARK: - Sendable Conformance Test
-  
+
   func testSendableConformance() {
     // This test verifies that ConcurrencyLimit can be safely passed between threads
     let limit = ConcurrencyLimit.limited(5)
-    
+
     let expectation = expectation(description: "Concurrent access")
     expectation.expectedFulfillmentCount = 10
-    
+
     DispatchQueue.concurrentPerform(iterations: 10) { index in
       // Access limit from multiple threads
       _ = limit.maxConcurrency
       _ = limit.isExceeded(currentCount: index)
       _ = limit.debugDescription
-      
+
       expectation.fulfill()
     }
-    
+
     wait(for: [expectation], timeout: 1.0)
   }
 }

--- a/Tests/LockmanTests/Core/Strategies/ConcurrencyLimitedStrategy/LockmanConcurrencyLimitedErrorTests.swift
+++ b/Tests/LockmanTests/Core/Strategies/ConcurrencyLimitedStrategy/LockmanConcurrencyLimitedErrorTests.swift
@@ -137,4 +137,3 @@ final class LockmanConcurrencyLimitedErrorTests: XCTestCase {
     XCTAssertNotNil(error.failureReason)
   }
 }
-

--- a/Tests/LockmanTests/Core/Strategies/Core/LockmanStrategyContainerTests.swift
+++ b/Tests/LockmanTests/Core/Strategies/Core/LockmanStrategyContainerTests.swift
@@ -1,54 +1,55 @@
 import XCTest
+
 @testable import Lockman
 
 final class LockmanStrategyContainerTests: XCTestCase {
-  
+
   var container: LockmanStrategyContainer!
-  
+
   override func setUp() {
     super.setUp()
     container = LockmanStrategyContainer()
   }
-  
+
   override func tearDown() {
     container = nil
     super.tearDown()
   }
-  
+
   // MARK: - Basic Registration Tests
-  
+
   func testInitialState() {
     XCTAssertEqual(container.strategyCount(), 0)
     XCTAssertTrue(container.registeredStrategyIds().isEmpty)
   }
-  
+
   func testRegisterStrategyWithId() throws {
     let strategy = LockmanSingleExecutionStrategy()
     let id = LockmanStrategyId("test-strategy")
-    
+
     try container.register(id: id, strategy: strategy)
-    
+
     XCTAssertTrue(container.isRegistered(id: id))
     XCTAssertEqual(container.strategyCount(), 1)
     XCTAssertEqual(container.registeredStrategyIds(), [id])
   }
-  
+
   func testRegisterStrategyWithBuiltInId() throws {
     let strategy = LockmanSingleExecutionStrategy()
-    
+
     try container.register(strategy)
-    
+
     XCTAssertTrue(container.isRegistered(id: strategy.strategyId))
     XCTAssertEqual(container.strategyCount(), 1)
   }
-  
+
   func testRegisterDuplicateIdThrows() throws {
     let strategy1 = LockmanSingleExecutionStrategy()
     let strategy2 = LockmanSingleExecutionStrategy()
     let id = LockmanStrategyId("duplicate")
-    
+
     try container.register(id: id, strategy: strategy1)
-    
+
     XCTAssertThrowsError(try container.register(id: id, strategy: strategy2)) { error in
       guard case LockmanRegistrationError.strategyAlreadyRegistered(let registeredId) = error else {
         XCTFail("Expected strategyAlreadyRegistered error")
@@ -57,104 +58,104 @@ final class LockmanStrategyContainerTests: XCTestCase {
       XCTAssertEqual(registeredId, id.value)
     }
   }
-  
+
   // MARK: - Bulk Registration Tests
-  
+
   func testRegisterAllWithIds() throws {
     let strategies: [(LockmanStrategyId, LockmanSingleExecutionStrategy)] = [
       (LockmanStrategyId("strategy1"), LockmanSingleExecutionStrategy()),
       (LockmanStrategyId("strategy2"), LockmanSingleExecutionStrategy()),
-      (LockmanStrategyId("strategy3"), LockmanSingleExecutionStrategy())
+      (LockmanStrategyId("strategy3"), LockmanSingleExecutionStrategy()),
     ]
-    
+
     try container.registerAll(strategies)
-    
+
     XCTAssertEqual(container.strategyCount(), 3)
     for (id, _) in strategies {
       XCTAssertTrue(container.isRegistered(id: id))
     }
   }
-  
+
   func testRegisterAllWithBuiltInIds() throws {
     let strategies = [
       LockmanSingleExecutionStrategy(),
       LockmanPriorityBasedStrategy(),
-      LockmanConcurrencyLimitedStrategy()
+      LockmanConcurrencyLimitedStrategy(),
     ]
-    
+
     try container.registerAll(strategies)
-    
+
     XCTAssertEqual(container.strategyCount(), 3)
     XCTAssertTrue(container.isRegistered(id: .singleExecution))
     XCTAssertTrue(container.isRegistered(id: .priorityBased))
     XCTAssertTrue(container.isRegistered(id: .concurrencyLimited))
   }
-  
+
   func testRegisterAllWithDuplicateIdsInArray() throws {
     let strategies: [(LockmanStrategyId, LockmanSingleExecutionStrategy)] = [
       (LockmanStrategyId("same"), LockmanSingleExecutionStrategy()),
-      (LockmanStrategyId("same"), LockmanSingleExecutionStrategy())
+      (LockmanStrategyId("same"), LockmanSingleExecutionStrategy()),
     ]
-    
+
     XCTAssertThrowsError(try container.registerAll(strategies)) { error in
       guard case LockmanRegistrationError.strategyAlreadyRegistered = error else {
         XCTFail("Expected strategyAlreadyRegistered error")
         return
       }
     }
-    
+
     // Verify nothing was registered (atomic operation)
     XCTAssertEqual(container.strategyCount(), 0)
   }
-  
+
   func testRegisterAllWithExistingIdThrows() throws {
     let existingId = LockmanStrategyId("existing")
     try container.register(id: existingId, strategy: LockmanSingleExecutionStrategy())
-    
+
     let strategies: [(LockmanStrategyId, LockmanSingleExecutionStrategy)] = [
       (LockmanStrategyId("new1"), LockmanSingleExecutionStrategy()),
       (existingId, LockmanSingleExecutionStrategy()),
-      (LockmanStrategyId("new2"), LockmanSingleExecutionStrategy())
+      (LockmanStrategyId("new2"), LockmanSingleExecutionStrategy()),
     ]
-    
+
     XCTAssertThrowsError(try container.registerAll(strategies)) { error in
       guard case LockmanRegistrationError.strategyAlreadyRegistered = error else {
         XCTFail("Expected strategyAlreadyRegistered error")
         return
       }
     }
-    
+
     // Verify only the existing strategy remains (atomic operation)
     XCTAssertEqual(container.strategyCount(), 1)
     XCTAssertTrue(container.isRegistered(id: existingId))
     XCTAssertFalse(container.isRegistered(id: LockmanStrategyId("new1")))
     XCTAssertFalse(container.isRegistered(id: LockmanStrategyId("new2")))
   }
-  
+
   // MARK: - Resolution Tests
-  
+
   func testResolveRegisteredStrategy() throws {
     let strategy = LockmanSingleExecutionStrategy()
     let id = LockmanStrategyId("test")
-    
+
     try container.register(id: id, strategy: strategy)
-    
+
     let resolved: AnyLockmanStrategy<LockmanSingleExecutionInfo> = try container.resolve(id: id)
     XCTAssertNotNil(resolved)
     XCTAssertEqual(resolved.strategyId, strategy.strategyId)
   }
-  
+
   func testResolveByType() throws {
     let strategy = LockmanSingleExecutionStrategy()
     try container.register(strategy)
-    
+
     let resolved = try container.resolve(LockmanSingleExecutionStrategy.self)
     XCTAssertNotNil(resolved)
   }
-  
+
   func testResolveUnregisteredIdThrows() {
     let unknownId = LockmanStrategyId("unknown")
-    
+
     XCTAssertThrowsError(
       try container.resolve(id: unknownId, expecting: LockmanSingleExecutionInfo.self)
     ) { error in
@@ -165,13 +166,13 @@ final class LockmanStrategyContainerTests: XCTestCase {
       XCTAssertEqual(id, unknownId.value)
     }
   }
-  
+
   func testResolveWithWrongInfoTypeThrows() throws {
     let strategy = LockmanSingleExecutionStrategy()
     let id = LockmanStrategyId("test")
-    
+
     try container.register(id: id, strategy: strategy)
-    
+
     // Try to resolve with wrong info type
     XCTAssertThrowsError(
       try container.resolve(id: id, expecting: LockmanPriorityBasedInfo.self)
@@ -182,37 +183,37 @@ final class LockmanStrategyContainerTests: XCTestCase {
       }
     }
   }
-  
+
   // MARK: - Information Query Tests
-  
+
   func testIsRegisteredWithId() throws {
     let id = LockmanStrategyId("test")
-    
+
     XCTAssertFalse(container.isRegistered(id: id))
-    
+
     try container.register(id: id, strategy: LockmanSingleExecutionStrategy())
-    
+
     XCTAssertTrue(container.isRegistered(id: id))
   }
-  
+
   func testIsRegisteredWithType() throws {
     XCTAssertFalse(container.isRegistered(LockmanSingleExecutionStrategy.self))
-    
+
     try container.register(LockmanSingleExecutionStrategy())
-    
+
     XCTAssertTrue(container.isRegistered(LockmanSingleExecutionStrategy.self))
   }
-  
+
   func testRegisteredStrategyInfo() throws {
     let id1 = LockmanStrategyId("first")
     let id2 = LockmanStrategyId("second")
-    
+
     try container.register(id: id1, strategy: LockmanSingleExecutionStrategy())
-    Thread.sleep(forTimeInterval: 0.01) // Ensure different timestamps
+    Thread.sleep(forTimeInterval: 0.01)  // Ensure different timestamps
     try container.register(id: id2, strategy: LockmanPriorityBasedStrategy())
-    
+
     let info = container.registeredStrategyInfo()
-    
+
     XCTAssertEqual(info.count, 2)
     XCTAssertEqual(info[0].id, id1)
     XCTAssertEqual(info[1].id, id2)
@@ -220,135 +221,136 @@ final class LockmanStrategyContainerTests: XCTestCase {
     XCTAssertTrue(info[0].typeName.contains("SingleExecution"))
     XCTAssertTrue(info[1].typeName.contains("PriorityBased"))
   }
-  
+
   func testGetAllStrategies() throws {
     try container.register(LockmanSingleExecutionStrategy())
     try container.register(LockmanPriorityBasedStrategy())
     try container.register(LockmanConcurrencyLimitedStrategy())
-    
+
     let allStrategies = container.getAllStrategies()
-    
+
     XCTAssertEqual(allStrategies.count, 3)
-    
+
     let strategyIds = Set(allStrategies.map { $0.0 })
     XCTAssertTrue(strategyIds.contains(.singleExecution))
     XCTAssertTrue(strategyIds.contains(.priorityBased))
     XCTAssertTrue(strategyIds.contains(.concurrencyLimited))
   }
-  
+
   // MARK: - Cleanup Tests
-  
+
   func testCleanUpAllStrategies() throws {
     let strategy1 = LockmanSingleExecutionStrategy()
     let strategy2 = LockmanPriorityBasedStrategy()
     let boundaryId = AnyLockmanBoundaryId("test")
-    
+
     try container.register(strategy1)
     try container.register(strategy2)
-    
+
     // Add some locks
     strategy1.lockAcquired(id: boundaryId, info: LockmanSingleExecutionInfo(actionId: "action1"))
-    strategy2.lockAcquired(id: boundaryId, info: LockmanPriorityBasedInfo(actionId: "action2", priority: .medium))
-    
+    strategy2.lockAcquired(
+      id: boundaryId, info: LockmanPriorityBasedInfo(actionId: "action2", priority: .medium))
+
     // Clean up through container
     container.cleanUp()
-    
+
     // Verify locks were cleared
     XCTAssertTrue(strategy1.getCurrentLocks().isEmpty)
     XCTAssertTrue(strategy2.getCurrentLocks().isEmpty)
   }
-  
+
   func testCleanUpByBoundaryId() throws {
     let strategy = LockmanSingleExecutionStrategy()
     let boundaryId1 = AnyLockmanBoundaryId("boundary1")
     let boundaryId2 = AnyLockmanBoundaryId("boundary2")
-    
+
     try container.register(strategy)
-    
+
     // Add locks to both boundaries
     strategy.lockAcquired(id: boundaryId1, info: LockmanSingleExecutionInfo(actionId: "action1"))
     strategy.lockAcquired(id: boundaryId2, info: LockmanSingleExecutionInfo(actionId: "action2"))
-    
+
     // Clean up only boundary1
     container.cleanUp(id: boundaryId1)
-    
+
     // Verify only boundary1 was cleaned
     XCTAssertNil(strategy.getCurrentLocks()[boundaryId1])
     XCTAssertNotNil(strategy.getCurrentLocks()[boundaryId2])
   }
-  
+
   // MARK: - Unregister Tests
-  
+
   func testUnregisterById() throws {
     let id = LockmanStrategyId("test")
     try container.register(id: id, strategy: LockmanSingleExecutionStrategy())
-    
+
     XCTAssertTrue(container.isRegistered(id: id))
-    
+
     let wasRemoved = container.unregister(id: id)
-    
+
     XCTAssertTrue(wasRemoved)
     XCTAssertFalse(container.isRegistered(id: id))
     XCTAssertEqual(container.strategyCount(), 0)
   }
-  
+
   func testUnregisterByType() throws {
     try container.register(LockmanSingleExecutionStrategy())
-    
+
     XCTAssertTrue(container.isRegistered(LockmanSingleExecutionStrategy.self))
-    
+
     let wasRemoved = container.unregister(LockmanSingleExecutionStrategy.self)
-    
+
     XCTAssertTrue(wasRemoved)
     XCTAssertFalse(container.isRegistered(LockmanSingleExecutionStrategy.self))
   }
-  
+
   func testUnregisterNonExistentStrategy() {
     let wasRemoved = container.unregister(id: LockmanStrategyId("nonexistent"))
-    
+
     XCTAssertFalse(wasRemoved)
   }
-  
+
   func testUnregisterCallsCleanUp() throws {
     let strategy = LockmanSingleExecutionStrategy()
     let boundaryId = AnyLockmanBoundaryId("test")
     let id = LockmanStrategyId("test")
-    
+
     try container.register(id: id, strategy: strategy)
-    
+
     // Add a lock
     strategy.lockAcquired(id: boundaryId, info: LockmanSingleExecutionInfo(actionId: "action"))
     XCTAssertFalse(strategy.getCurrentLocks().isEmpty)
-    
+
     // Unregister should clean up
     container.unregister(id: id)
-    
+
     XCTAssertTrue(strategy.getCurrentLocks().isEmpty)
   }
-  
+
   func testRemoveAllStrategies() throws {
     try container.register(LockmanSingleExecutionStrategy())
     try container.register(LockmanPriorityBasedStrategy())
     try container.register(LockmanConcurrencyLimitedStrategy())
-    
+
     XCTAssertEqual(container.strategyCount(), 3)
-    
+
     container.removeAllStrategies()
-    
+
     XCTAssertEqual(container.strategyCount(), 0)
     XCTAssertTrue(container.registeredStrategyIds().isEmpty)
   }
-  
+
   // MARK: - Thread Safety Tests
-  
+
   func testConcurrentRegistration() throws {
     let expectation = expectation(description: "All registrations complete")
     expectation.expectedFulfillmentCount = 100
-    
+
     let queue = DispatchQueue(label: "test", attributes: .concurrent)
     var errors: [Error] = []
     let errorLock = NSLock()
-    
+
     for i in 0..<100 {
       queue.async {
         do {
@@ -362,87 +364,91 @@ final class LockmanStrategyContainerTests: XCTestCase {
         expectation.fulfill()
       }
     }
-    
+
     wait(for: [expectation], timeout: 5.0)
-    
+
     XCTAssertTrue(errors.isEmpty, "Registration errors: \(errors)")
     XCTAssertEqual(container.strategyCount(), 100)
   }
-  
+
   func testConcurrentResolution() throws {
     // Register strategies first
     for i in 0..<10 {
       let id = LockmanStrategyId("strategy-\(i)")
       try container.register(id: id, strategy: LockmanSingleExecutionStrategy())
     }
-    
+
     let expectation = expectation(description: "All resolutions complete")
     expectation.expectedFulfillmentCount = 100
-    
+
     let queue = DispatchQueue(label: "test", attributes: .concurrent)
-    
+
     for _ in 0..<100 {
       queue.async {
         let randomId = LockmanStrategyId("strategy-\(Int.random(in: 0..<10))")
         do {
-          let _: AnyLockmanStrategy<LockmanSingleExecutionInfo> = try self.container.resolve(id: randomId)
+          let _: AnyLockmanStrategy<LockmanSingleExecutionInfo> = try self.container.resolve(
+            id: randomId)
         } catch {
           XCTFail("Resolution failed: \(error)")
         }
         expectation.fulfill()
       }
     }
-    
+
     wait(for: [expectation], timeout: 5.0)
   }
-  
+
   // MARK: - Complex Scenario Tests
-  
+
   func testMixedStrategyTypes() throws {
     // Register different strategy types
     try container.register(id: .singleExecution, strategy: LockmanSingleExecutionStrategy())
     try container.register(id: .priorityBased, strategy: LockmanPriorityBasedStrategy())
     try container.register(id: .concurrencyLimited, strategy: LockmanConcurrencyLimitedStrategy())
-    
+
     // Custom configured strategies
     try container.register(
       id: LockmanStrategyId("high-concurrency"),
       strategy: LockmanConcurrencyLimitedStrategy()
     )
-    
+
     XCTAssertEqual(container.strategyCount(), 4)
-    
+
     // Resolve each type
-    let single: AnyLockmanStrategy<LockmanSingleExecutionInfo> = try container.resolve(id: .singleExecution)
-    let priority: AnyLockmanStrategy<LockmanPriorityBasedInfo> = try container.resolve(id: .priorityBased)
-    let concurrent: AnyLockmanStrategy<LockmanConcurrencyLimitedInfo> = try container.resolve(id: .concurrencyLimited)
-    
+    let single: AnyLockmanStrategy<LockmanSingleExecutionInfo> = try container.resolve(
+      id: .singleExecution)
+    let priority: AnyLockmanStrategy<LockmanPriorityBasedInfo> = try container.resolve(
+      id: .priorityBased)
+    let concurrent: AnyLockmanStrategy<LockmanConcurrencyLimitedInfo> = try container.resolve(
+      id: .concurrencyLimited)
+
     XCTAssertNotNil(single)
     XCTAssertNotNil(priority)
     XCTAssertNotNil(concurrent)
   }
-  
+
   func testStrategyLifecycle() throws {
     let id = LockmanStrategyId("lifecycle-test")
     let boundaryId = AnyLockmanBoundaryId("test")
-    
+
     // Register
     try container.register(id: id, strategy: LockmanSingleExecutionStrategy())
-    
+
     // Resolve and use
     let strategy: AnyLockmanStrategy<LockmanSingleExecutionInfo> = try container.resolve(id: id)
     let info = LockmanSingleExecutionInfo(actionId: "test")
-    
+
     XCTAssertEqual(strategy.canLock(id: boundaryId, info: info), .success)
     strategy.lock(id: boundaryId, info: info)
-    
+
     // Clean up through container
     container.cleanUp(id: boundaryId)
-    
+
     // Unregister
     let wasRemoved = container.unregister(id: id)
     XCTAssertTrue(wasRemoved)
-    
+
     // Verify it's gone
     XCTAssertThrowsError(try container.resolve(id: id, expecting: LockmanSingleExecutionInfo.self))
   }

--- a/Tests/LockmanTests/Core/Strategies/DynamicConditionStrategy/LockmanDynamicConditionActionTests.swift
+++ b/Tests/LockmanTests/Core/Strategies/DynamicConditionStrategy/LockmanDynamicConditionActionTests.swift
@@ -177,4 +177,3 @@ private enum TestError: Error {
   case insufficientPriority
   case unexpectedAction
 }
-


### PR DESCRIPTION
## Summary
- Change `handleCancellationErrors` default from `true` to `false`
- Change `defaultUnlockOption` default from `.transition` to `.immediate`

## Changes
- Updated default value for `handleCancellationErrors` in `LockmanManager.Configuration` to `false`
- Updated default value for `defaultUnlockOption` in `LockmanManager.Configuration` to `.immediate`
- Updated related documentation comments to reflect the new defaults

## Test plan
- [ ] Run existing tests to ensure no regressions
- [ ] Verify that the new defaults are applied correctly
- [ ] Check that existing code using explicit values continues to work

🤖 Generated with [Claude Code](https://claude.ai/code)