### PR TITLE
docs: add missing strategyId parameter documentation

### DIFF
--- a/Sources/Lockman/Core/Strategies/CompositeStrategy/LockmanCompositeInfo.swift
+++ b/Sources/Lockman/Core/Strategies/CompositeStrategy/LockmanCompositeInfo.swift
@@ -58,6 +58,7 @@ public struct LockmanCompositeInfo2<I1: LockmanInfo, I2: LockmanInfo>: LockmanIn
   /// Creates a new composite info instance with user-specified action ID.
   ///
   /// - Parameters:
+  ///   - strategyId: The strategy identifier for this composite lock (defaults to "Lockman.CompositeStrategy2")
   ///   - actionId: User-specified action identifier for the composite operation
   ///   - lockmanInfoForStrategy1: Lock information for the first strategy
   ///   - lockmanInfoForStrategy2: Lock information for the second strategy
@@ -128,6 +129,7 @@ public struct LockmanCompositeInfo3<I1: LockmanInfo, I2: LockmanInfo, I3: Lockma
   /// Creates a new composite info instance with user-specified action ID.
   ///
   /// - Parameters:
+  ///   - strategyId: The strategy identifier for this composite lock (defaults to "Lockman.CompositeStrategy3")
   ///   - actionId: User-specified action identifier for the composite operation
   ///   - lockmanInfoForStrategy1: Lock information for the first strategy
   ///   - lockmanInfoForStrategy2: Lock information for the second strategy
@@ -200,6 +202,7 @@ public struct LockmanCompositeInfo4<
   /// Creates a new composite info instance with user-specified action ID.
   ///
   /// - Parameters:
+  ///   - strategyId: The strategy identifier for this composite lock (defaults to "Lockman.CompositeStrategy4")
   ///   - actionId: User-specified action identifier for the composite operation
   ///   - lockmanInfoForStrategy1: Lock information for the first strategy
   ///   - lockmanInfoForStrategy2: Lock information for the second strategy
@@ -278,6 +281,7 @@ public struct LockmanCompositeInfo5<
   /// Creates a new composite info instance with user-specified action ID.
   ///
   /// - Parameters:
+  ///   - strategyId: The strategy identifier for this composite lock (defaults to "Lockman.CompositeStrategy5")
   ///   - actionId: User-specified action identifier for the composite operation
   ///   - lockmanInfoForStrategy1: Lock information for the first strategy
   ///   - lockmanInfoForStrategy2: Lock information for the second strategy

--- a/Sources/Lockman/Core/Strategies/DynamicConditionStrategy/LockmanDynamicConditionInfo.swift
+++ b/Sources/Lockman/Core/Strategies/DynamicConditionStrategy/LockmanDynamicConditionInfo.swift
@@ -50,6 +50,7 @@ public struct LockmanDynamicConditionInfo: LockmanInfo, Sendable {
   /// Creates a new dynamic condition lock info with a custom condition.
   ///
   /// - Parameters:
+  ///   - strategyId: The strategy identifier for this lock (defaults to .dynamicCondition)
   ///   - actionId: The identifier for this action
   ///   - condition: A closure that evaluates whether the lock can be acquired,
   ///                returning a `LockmanResult`
@@ -68,7 +69,9 @@ public struct LockmanDynamicConditionInfo: LockmanInfo, Sendable {
   ///
   /// This initializer is useful when you want to use the lock without any restrictions.
   ///
-  /// - Parameter actionId: The identifier for this action
+  /// - Parameters:
+  ///   - strategyId: The strategy identifier for this lock (defaults to .dynamicCondition)
+  ///   - actionId: The identifier for this action
   public init(
     strategyId: LockmanStrategyId = .dynamicCondition,
     actionId: LockmanActionId

--- a/Sources/Lockman/Core/Strategies/GroupCoordinationStrategy/LockmanGroupCoordinatedInfo.swift
+++ b/Sources/Lockman/Core/Strategies/GroupCoordinationStrategy/LockmanGroupCoordinatedInfo.swift
@@ -65,6 +65,7 @@ public struct LockmanGroupCoordinatedInfo: LockmanInfo, Sendable {
   /// Creates a new group coordinated lock information with a single group.
   ///
   /// - Parameters:
+  ///   - strategyId: The strategy identifier for this lock (defaults to .groupCoordination)
   ///   - actionId: The identifier for this action
   ///   - groupId: The group identifier for coordination
   ///   - coordinationRole: The role this action plays in the group
@@ -84,6 +85,7 @@ public struct LockmanGroupCoordinatedInfo: LockmanInfo, Sendable {
   /// Creates a new group coordinated lock information with multiple groups.
   ///
   /// - Parameters:
+  ///   - strategyId: The strategy identifier for this lock (defaults to .groupCoordination)
   ///   - actionId: The identifier for this action
   ///   - groupIds: The set of group identifiers for coordination (maximum 5)
   ///   - coordinationRole: The role this action plays in all groups

--- a/Sources/Lockman/Core/Strategies/PriorityBasedStrategy/LockmanPriorityBasedInfo.swift
+++ b/Sources/Lockman/Core/Strategies/PriorityBasedStrategy/LockmanPriorityBasedInfo.swift
@@ -105,6 +105,7 @@ public struct LockmanPriorityBasedInfo: LockmanInfo, Sendable, Equatable {
   /// Creates a new priority-based lock information instance.
   ///
   /// - Parameters:
+  ///   - strategyId: The strategy identifier for this lock (defaults to .priorityBased)
   ///   - actionId: A unique identifier for the action
   ///   - priority: The priority level and concurrency behavior for this action
   ///   - blocksSameAction: Whether to block other actions with the same actionId (default: true)

--- a/Sources/Lockman/Core/Strategies/SingleExecutionStrategy/LockmanSingleExecutionInfo.swift
+++ b/Sources/Lockman/Core/Strategies/SingleExecutionStrategy/LockmanSingleExecutionInfo.swift
@@ -67,6 +67,7 @@ public struct LockmanSingleExecutionInfo: LockmanInfo, Sendable, Equatable {
   /// Creates a new single-execution lock information instance.
   ///
   /// - Parameters:
+  ///   - strategyId: The strategy identifier for this lock (defaults to .singleExecution)
   ///   - actionId: The action identifier for conflict detection. Defaults to empty string,
   ///     which is suitable for `.boundary` and `.none` modes where the specific action
   ///     identity doesn't affect locking behavior


### PR DESCRIPTION
## Summary
Add missing documentation for `strategyId` parameters in various init methods across strategy info structs.

## Changes
- Add `strategyId` parameter documentation to init methods in:
  - `LockmanCompositeInfo2`, `LockmanCompositeInfo3`, `LockmanCompositeInfo4`, `LockmanCompositeInfo5`
  - `LockmanDynamicConditionInfo` (both init methods)
  - `LockmanGroupCoordinatedInfo` (both init methods)
  - `LockmanPriorityBasedInfo`
  - `LockmanSingleExecutionInfo`
- Include default values in documentation for clarity
- Apply swift-format to maintain code consistency

## Test plan
- [ ] Documentation builds without warnings
- [ ] All tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)