### PR TITLE
refactor: remove unused LockmanComposable.swift file

### DIFF
--- a/Sources/Lockman/Composable/LockmanComposable.swift
+++ b/Sources/Lockman/Composable/LockmanComposable.swift
@@ -1,7 +1,0 @@
-// This file is now part of the unified Lockman module
-// No need to import LockmanCore as we're in the same module
-
-// This file ensures that when users import LockmanComposable, they get:
-// 1. All LockmanCore functionality (including macros)
-// 2. TCA integration (Effect+Lockman)
-// 3. A single import statement for all Lockman features when using TCA


### PR DESCRIPTION
## Summary
Remove the unused LockmanComposable.swift file from the codebase.

## Changes
- Deleted `Sources/Lockman/Composable/LockmanComposable.swift`

## Test plan
- [x] Verified that the file is not referenced anywhere in the codebase
- [x] Confirmed the project builds successfully after removal
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)