### PR TITLE
docs: complete English translation of remaining Japanese text in DocC documentation

### DIFF
--- a/Sources/Lockman/Documentation.docc/CompositeStrategy.md
+++ b/Sources/Lockman/Documentation.docc/CompositeStrategy.md
@@ -105,8 +105,8 @@ enum Action {
 ### Operation with 2 Strategy Combination
 
 ```
-戦略1: SingleExecution(.action)
-戦略2: PriorityBased(.high(.exclusive))
+Strategy 1: SingleExecution(.action)
+Strategy 2: PriorityBased(.high(.exclusive))
 
 Time: 0s  - normalSave request
   Strategy 1: ✅ Success (no duplication)
@@ -127,9 +127,9 @@ Time: 2s  - criticalSave request (high priority)
 ### Operation with 3 Strategy Combination
 
 ```
-戦略1: SingleExecution(.action)
-戦略2: PriorityBased(.low(.replaceable))  
-戦略3: ConcurrencyLimited(.limited(2))
+Strategy 1: SingleExecution(.action)
+Strategy 2: PriorityBased(.low(.replaceable))  
+Strategy 3: ConcurrencyLimited(.limited(2))
 
 Current situation: 2 download processes running
 

--- a/Sources/Lockman/Documentation.docc/Lock.md
+++ b/Sources/Lockman/Documentation.docc/Lock.md
@@ -4,79 +4,79 @@ Understanding the locking mechanism in Lockman.
 
 ## Overview
 
-Lockmanにおけるロックは、戦略ベースの排他制御システムです。従来の単純なON/OFF制御とは異なり、選択した戦略によって以下のような多様な制御が可能になります。
+Locking in Lockman is a strategy-based exclusive control system. Unlike traditional simple ON/OFF control, the selected strategy enables various types of control:
 
-- **実行の防止**: 重複実行の阻止（[SingleExecutionStrategy](<doc:SingleExecutionStrategy>)）
-- **実行の優先**: 既存処理を中断した新しい処理の優先実行（[PriorityBasedStrategy](<doc:PriorityBasedStrategy>)）
-- **実行の協調**: 関連する処理グループの協調的な調整（[GroupCoordinationStrategy](<doc:GroupCoordinationStrategy>)）
-- **実行の制限**: 同時実行数の制限（[ConcurrencyLimitedStrategy](<doc:ConcurrencyLimitedStrategy>)）
-- **実行の条件付き制御**: カスタムロジックによる動的な条件制御（[DynamicConditionStrategy](<doc:DynamicConditionStrategy>)）
+- **Execution Prevention**: Blocking duplicate execution ([SingleExecutionStrategy](<doc:SingleExecutionStrategy>))
+- **Execution Priority**: Prioritizing new processing by interrupting existing processing ([PriorityBasedStrategy](<doc:PriorityBasedStrategy>))
+- **Execution Coordination**: Coordinating related processing groups ([GroupCoordinationStrategy](<doc:GroupCoordinationStrategy>))
+- **Execution Limitation**: Limiting concurrent execution count ([ConcurrencyLimitedStrategy](<doc:ConcurrencyLimitedStrategy>))
+- **Conditional Execution Control**: Dynamic conditional control through custom logic ([DynamicConditionStrategy](<doc:DynamicConditionStrategy>))
 
-## 仕様
+## Specifications
 
-Lockmanは戦略に基づいてロック取得の成否を判定し、その結果に応じて処理を実行します。ロック取得の判定プロセスは、指定された戦略のルールに従って行われ、[CompositeStrategy](<doc:CompositeStrategy>)で複数戦略が指定されている場合は、すべての戦略でロック取得が可能である場合のみ成功となります。
+Lockman determines the success or failure of lock acquisition based on the strategy and executes processing according to the result. The lock acquisition judgment process follows the rules of the specified strategy, and when multiple strategies are specified with [CompositeStrategy](<doc:CompositeStrategy>), lock acquisition succeeds only when all strategies allow it.
 
-## メソッド
+## Methods
 
-Lockmanは3つの主要なメソッドを提供し、用途に応じて使い分けることができます。
+Lockman provides three main methods that can be used according to different purposes.
 
-### withLock（自動解除版）
+### withLock (Auto-release Version)
 
-最も基本的で推奨される使用方法です。ロックの取得と解除を自動で管理します。
+The most basic and recommended usage. Automatically manages lock acquisition and release.
 
 ```swift
 .withLock(
-  priority: .userInitiated, // オプション: タスク優先度
-  unlockOption: .immediate, // オプション: ロック解除タイミング
-  operation: { send in /* 処理 */ },
-  catch handler: { error, send in /* エラー処理 */ }, // オプション
-  lockFailure: { error, send in /* ロック取得失敗処理 */ }, // オプション
+  priority: .userInitiated, // Optional: Task priority
+  unlockOption: .immediate, // Optional: Lock release timing
+  operation: { send in /* Processing */ },
+  catch handler: { error, send in /* Error handling */ }, // Optional
+  lockFailure: { error, send in /* Lock acquisition failure handling */ }, // Optional
   action: action,
   cancelID: cancelID
 )
 ```
 
-**パラメータ:**
-- `priority`: タスクの優先度（オプション）
-- `unlockOption`: ロック解除のタイミング（オプション、デフォルトは設定値）
-- `handleCancellationErrors`: キャンセルエラーの扱い（オプション、デフォルトは設定値）
-- `operation`: 排他制御下で実行する処理
-- `catch handler`: エラーハンドラー（オプション）
-- `lockFailure`: ロック取得失敗時のハンドラー（オプション）
-- `action`: 現在のアクション
-- `cancelID`: Effectのキャンセル識別子
+**Parameters:**
+- `priority`: Task priority (optional)
+- `unlockOption`: Lock release timing (optional, default is configured value)
+- `handleCancellationErrors`: Handling of cancellation errors (optional, default is configured value)
+- `operation`: Processing to execute under exclusive control
+- `catch handler`: Error handler (optional)
+- `lockFailure`: Handler for lock acquisition failure (optional)
+- `action`: Current action
+- `cancelID`: Effect cancellation identifier
 
-**特徴:**
-- 自動的なロック管理
-- 処理の正常終了、例外発生、キャンセル時も確実にロック解除
-- エラーハンドリング機能
+**Features:**
+- Automatic lock management
+- Reliable lock release on normal completion, exception, or cancellation
+- Error handling capability
 
-### withLock（手動解除版）
+### withLock (Manual Release Version)
 
-ロックの解除タイミングを手動で制御したい場合に使用します。パラメータは自動解除版と同じですが、`operation`と`catch handler`にunlockパラメータが追加されます。
+Used when you want to manually control the lock release timing. Parameters are the same as the auto-release version, but an unlock parameter is added to `operation` and `catch handler`.
 
 ```swift
 .withLock(
   operation: { send, unlock in 
-    /* 処理 */
-    unlock() // 手動解除
+    /* Processing */
+    unlock() // Manual release
   },
   catch handler: { error, send, unlock in 
-    unlock() // エラー時も解除
+    unlock() // Release on error too
   },
   action: action,
   cancelID: cancelID
 )
 ```
 
-**特徴:**
-- 明示的なロック解除制御
-- より細かい制御が可能
-- **重要**: 必ず全てのコードパスでunlock()を呼び出す必要があります（詳細は[Unlock](<doc:Unlock>)ページを参照）
+**Features:**
+- Explicit lock release control
+- Finer control possible
+- **Important**: You must call unlock() in all code paths (see [Unlock](<doc:Unlock>) page for details)
 
 ### concatenateWithLock
 
-複数のEffectを順次実行する間、同一のロックを保持し続けます。
+Maintains the same lock while executing multiple Effects sequentially.
 
 ```swift
 .concatenateWithLock(
@@ -92,8 +92,8 @@ Lockmanは3つの主要なメソッドを提供し、用途に応じて使い分
 )
 ```
 
-**特徴:**
-- 複数のEffect間で同じロックを維持
-- トランザクション的な処理に適している
-- 一つでも失敗すると全体が中断される
+**Features:**
+- Maintains the same lock across multiple Effects
+- Suitable for transactional processing
+- If any one fails, the entire process is interrupted
 

--- a/Sources/Lockman/Documentation.docc/SingleExecutionStrategy.md
+++ b/Sources/Lockman/Documentation.docc/SingleExecutionStrategy.md
@@ -4,15 +4,15 @@ Prevent duplicate execution of the same action.
 
 ## Overview
 
-SingleExecutionStrategyは、重複実行を防止するための戦略です。同じ処理が重複して実行されることを防ぎ、データの整合性とアプリケーションの安定性を保ちます。
+SingleExecutionStrategy is a strategy for preventing duplicate execution. It prevents the same processing from being executed redundantly, maintaining data consistency and application stability.
 
-この戦略は、ユーザーの連続的な操作や自動処理の重複実行を防ぐために最も頻繁に使用される基本的な戦略です。
+This is the most frequently used basic strategy for preventing continuous user operations and duplicate execution of automatic processing.
 
-## 実行モード
+## Execution Modes
 
-SingleExecutionStrategyは3つの実行モードをサポートしています：
+SingleExecutionStrategy supports three execution modes:
 
-### none - 制御なし
+### none - No Control
 
 ```swift
 LockmanSingleExecutionInfo(
@@ -21,11 +21,11 @@ LockmanSingleExecutionInfo(
 )
 ```
 
-- 排他制御を行わず、全ての処理を同時実行
-- 一時的にロック機能を無効化したい場合に使用
-- デバッグやテスト時の動作確認に適用
+- Executes all processing concurrently without exclusive control
+- Used when temporarily disabling lock functionality
+- Applied for behavior verification during debugging or testing
 
-### boundary - 境界単位の排他制御
+### boundary - Boundary-level Exclusive Control
 
 ```swift
 LockmanSingleExecutionInfo(
@@ -38,7 +38,7 @@ LockmanSingleExecutionInfo(
 - Exclusive control at screen or component level
 - Applied when wanting to control entire UI operations
 
-### action - アクション単位の排他制御
+### action - Action-level Exclusive Control
 
 ```swift
 LockmanSingleExecutionInfo(
@@ -47,13 +47,13 @@ LockmanSingleExecutionInfo(
 )
 ```
 
-- 同一アクションの重複実行のみ防止
-- 異なるアクションは同時実行可能
-- 特定の処理のみを制御したい場合に適用
+- Prevents only duplicate execution of the same action
+- Different actions can execute concurrently
+- Applied when wanting to control only specific processing
 
-## 使用方法
+## Usage
 
-### 基本的な使用例
+### Basic Usage Example
 
 ```swift
 @LockmanSingleExecution
@@ -78,7 +78,7 @@ enum Action {
 }
 ```
 
-### Effect内での使用
+### Usage within Effects
 
 ```swift
 case .saveButtonTapped:
@@ -91,57 +91,57 @@ case .saveButtonTapped:
             send(.saveError(error.localizedDescription))
         },
         lockFailure: { error, send in
-            send(.saveBusy("保存処理が実行中です"))
+            send(.saveBusy("Save process is currently running"))
         },
         action: .save,
         cancelID: CancelID.userAction
     )
 ```
 
-## 動作例
+## Operation Examples
 
-### action モードの場合
-
-```
-時刻: 0秒  - saveアクション開始 → ✅ 実行
-時刻: 1秒  - saveアクション要求 → ❌ 拒否（同じアクション実行中）
-時刻: 1秒  - loadアクション要求 → ✅ 実行（異なるアクション）
-時刻: 3秒  - saveアクション完了 → 🔓 ロック解除
-時刻: 4秒  - saveアクション要求 → ✅ 実行（前回処理完了済み）
-```
-
-### boundary モードの場合
+### action mode
 
 ```
-時刻: 0秒  - saveアクション開始 → ✅ 実行
-時刻: 1秒  - saveアクション要求 → ❌ 拒否（境界内で実行中）
-時刻: 1秒  - loadアクション要求 → ❌ 拒否（境界内で実行中）
-時刻: 3秒  - saveアクション完了 → 🔓 ロック解除
-時刻: 4秒  - loadアクション要求 → ✅ 実行（境界内の処理完了済み）
+Time: 0s  - save action starts → ✅ Execute
+Time: 1s  - save action request → ❌ Reject (same action running)
+Time: 1s  - load action request → ✅ Execute (different action)
+Time: 3s  - save action complete → 🔓 Unlock
+Time: 4s  - save action request → ✅ Execute (previous process completed)
 ```
 
-## エラーハンドリング
+### boundary mode
 
-SingleExecutionStrategyで発生する可能性のあるエラーと、その対処法については[Error Handling](<doc:ErrorHandling>)ページの共通パターンも参照してください。
+```
+Time: 0s  - save action starts → ✅ Execute
+Time: 1s  - save action request → ❌ Reject (running within boundary)
+Time: 1s  - load action request → ❌ Reject (running within boundary)
+Time: 3s  - save action complete → 🔓 Unlock
+Time: 4s  - load action request → ✅ Execute (boundary process completed)
+```
+
+## Error Handling
+
+For errors that may occur with SingleExecutionStrategy and their solutions, please also refer to the common patterns on the [Error Handling](<doc:ErrorHandling>) page.
 
 ### LockmanSingleExecutionError
 
-**boundaryAlreadyLocked** - 境界が既にロックされている
-- `boundaryId`: ロックされている境界のID
-- `existingInfo`: 既存のロック情報
+**boundaryAlreadyLocked** - Boundary is already locked
+- `boundaryId`: ID of the locked boundary
+- `existingInfo`: Existing lock information
 
-**actionAlreadyRunning** - 同じアクションが既に実行中  
-- `existingInfo`: 実行中のアクション情報
+**actionAlreadyRunning** - Same action is already running  
+- `existingInfo`: Running action information
 
 ```swift
 lockFailure: { error, send in
     switch error as? LockmanSingleExecutionError {
     case .boundaryAlreadyLocked(_, let existingInfo):
-        send(.showBusyMessage("他の処理が実行中です: \(existingInfo.actionId)"))
+        send(.showBusyMessage("Another process is running: \(existingInfo.actionId)"))
     case .actionAlreadyRunning(let existingInfo):
-        send(.showBusyMessage("\(existingInfo.actionId)が実行中です"))
+        send(.showBusyMessage("\(existingInfo.actionId) is running"))
     default:
-        send(.showBusyMessage("処理を開始できません"))
+        send(.showBusyMessage("Cannot start processing"))
     }
 }
 ```


### PR DESCRIPTION
## Summary
- Complete the English translation of all remaining Japanese text in DocC documentation files
- Ensure all documentation is consistently in English

## Changes
- **SingleExecutionStrategy.md**: Translated all Japanese text including overview, execution modes, usage examples, operation examples, and error handling sections
- **Lock.md**: Translated all Japanese text including overview, specifications, methods descriptions, and features
- **CompositeStrategy.md**: Translated Japanese strategy labels in operation examples (戦略1 → Strategy 1, etc.)

## Test plan
- [x] Verified all DocC files no longer contain Japanese text
- [x] Documentation builds successfully
- [x] All examples and code snippets remain valid

🤖 Generated with [Claude Code](https://claude.ai/code)