### PR TITLE
breaking\!: remove blocksSameAction from PriorityBasedStrategy

### DIFF
--- a/Examples/Strategies/Strategies/02-PriorityBasedStrategy.swift
+++ b/Examples/Strategies/Strategies/02-PriorityBasedStrategy.swift
@@ -50,8 +50,7 @@ struct PriorityBasedStrategyFeature {
           actionId: actionId,
           lockmanInfoForStrategy1: LockmanPriorityBasedInfo(
             actionId: actionId,
-            priority: priority,
-            blocksSameAction: false  // SingleExecutionStrategyに委譲
+            priority: priority
           ),
           lockmanInfoForStrategy2: LockmanSingleExecutionInfo(
             actionId: actionId,
@@ -131,8 +130,6 @@ struct PriorityBasedStrategyFeature {
             failureMessage = "Blocked by higher priority"
           case .samePriorityConflict:
             failureMessage = "Same priority running"
-          case .blockedBySameAction:
-            failureMessage = "Already running"
           case let .precedingActionCancelled(cancelledInfo):
             // Update the cancelled task's button to show it was cancelled
             let cancelledButton: Action.ButtonType
@@ -200,9 +197,11 @@ struct PriorityBasedStrategyView: View {
           .font(.title2)
           .fontWeight(.bold)
 
-        Text("High priority cancels lower ones. Same priority: Exclusive blocks, Replaceable cancels and replaces.")
-          .font(.caption)
-          .foregroundColor(.secondary)
+        Text(
+          "High priority cancels lower ones. Same priority: Exclusive blocks, Replaceable cancels and replaces."
+        )
+        .font(.caption)
+        .foregroundColor(.secondary)
       }
       .padding()
       .frame(maxWidth: .infinity, alignment: .leading)

--- a/Sources/Lockman/Composable/LockmanComposableMacros.swift
+++ b/Sources/Lockman/Composable/LockmanComposableMacros.swift
@@ -77,9 +77,9 @@ public macro LockmanSingleExecution() =
 ///     var lockmanInfo: LockmanPriorityBasedInfo {
 ///       switch self {
 ///       case .highPriorityTask:
-///         return .init(priority: 100, perBoundary: false, blocksSameAction: true)
+///         return .init(actionId: actionName, priority: .high(.exclusive))
 ///       case .lowPriorityTask:
-///         return .init(priority: 10, perBoundary: false, blocksSameAction: true)
+///         return .init(actionId: actionName, priority: .low(.replaceable))
 ///       }
 ///     }
 ///   }

--- a/Sources/Lockman/Core/Strategies/PriorityBasedStrategy/LockmanPriorityBasedError.swift
+++ b/Sources/Lockman/Core/Strategies/PriorityBasedStrategy/LockmanPriorityBasedError.swift
@@ -20,12 +20,6 @@ public enum LockmanPriorityBasedError: LockmanError {
   /// existing one has exclusive behavior.
   case samePriorityConflict(priority: LockmanPriorityBasedInfo.Priority)
 
-  /// Indicates that the same action is already running and cannot be duplicated.
-  ///
-  /// This occurs when the strategy is configured to block duplicate actions
-  /// regardless of priority.
-  case blockedBySameAction(existingInfo: LockmanPriorityBasedInfo)
-
   /// Indicates that a preceding action will be cancelled due to preemption.
   ///
   /// This occurs when a higher priority action preempts a lower priority action.
@@ -40,9 +34,6 @@ public enum LockmanPriorityBasedError: LockmanError {
         "Cannot acquire lock: requested priority \(requested) is lower than current highest priority \(currentHighest)."
     case let .samePriorityConflict(priority):
       return "Cannot acquire lock: another action with priority \(priority) is already running."
-    case let .blockedBySameAction(existingInfo):
-      return
-        "Cannot acquire lock: action '\(existingInfo.actionId)' is already running and duplicates are blocked."
     case let .precedingActionCancelled(cancelledInfo):
       return
         "Lock acquired, preceding action '\(cancelledInfo.actionId)' will be cancelled."
@@ -56,8 +47,6 @@ public enum LockmanPriorityBasedError: LockmanError {
         "PriorityBasedStrategy only allows higher priority actions to preempt lower priority ones."
     case .samePriorityConflict:
       return "Actions with the same priority and exclusive behavior cannot run concurrently."
-    case .blockedBySameAction:
-      return "The strategy is configured to prevent duplicate action execution."
     case .precedingActionCancelled:
       return "A lower priority action was preempted by a higher priority action."
     }

--- a/Sources/Lockman/Core/Strategies/PriorityBasedStrategy/LockmanPriorityBasedInfo.swift
+++ b/Sources/Lockman/Core/Strategies/PriorityBasedStrategy/LockmanPriorityBasedInfo.swift
@@ -67,39 +67,6 @@ public struct LockmanPriorityBasedInfo: LockmanInfo, Sendable, Equatable {
   /// See `Priority` enum for detailed information about priority levels and behaviors.
   public let priority: Priority
 
-  /// Whether this action blocks other actions with the same actionId.
-  ///
-  /// When set to `true`, this action will prevent any other action with the same
-  /// `actionId` from being locked, regardless of priority levels. This is useful
-  /// for operations that must be unique per action type.
-  ///
-  /// When set to `false`, actions with the same `actionId` follow the
-  /// normal priority rules and can coexist based on their priority levels.
-  ///
-  /// ## Use Cases
-  /// - **true**: Payment processing, file saves, or any operation where only one
-  ///   instance of a specific action should run at a time
-  /// - **false**: Search queries, UI updates, or operations that can have multiple
-  ///   instances with different priorities
-  ///
-  /// ## Example
-  /// ```swift
-  /// // Only one payment can process at a time
-  /// let payment = LockmanPriorityBasedInfo(
-  ///   actionId: "payment",
-  ///   priority: .high(.exclusive),
-  ///   blocksSameAction: true
-  /// )
-  ///
-  /// // Multiple searches can coexist based on priority
-  /// let search = LockmanPriorityBasedInfo(
-  ///   actionId: "search",
-  ///   priority: .high(.replaceable),
-  ///   blocksSameAction: false
-  /// )
-  /// ```
-  public let blocksSameAction: Bool
-
   // MARK: - Initialization
 
   /// Creates a new priority-based lock information instance.
@@ -108,7 +75,6 @@ public struct LockmanPriorityBasedInfo: LockmanInfo, Sendable, Equatable {
   ///   - strategyId: The strategy identifier for this lock (defaults to .priorityBased)
   ///   - actionId: A unique identifier for the action
   ///   - priority: The priority level and concurrency behavior for this action
-  ///   - blocksSameAction: Whether to block other actions with the same actionId (default: true)
   ///
   /// ## Design Note
   /// The `uniqueId` is automatically generated to ensure each instance has
@@ -117,14 +83,12 @@ public struct LockmanPriorityBasedInfo: LockmanInfo, Sendable, Equatable {
   public init(
     strategyId: LockmanStrategyId = .priorityBased,
     actionId: LockmanActionId,
-    priority: Priority,
-    blocksSameAction: Bool = true
+    priority: Priority
   ) {
     self.strategyId = strategyId
     self.actionId = actionId
     self.uniqueId = UUID()
     self.priority = priority
-    self.blocksSameAction = blocksSameAction
   }
 
   // MARK: - Equatable Implementation
@@ -157,7 +121,7 @@ public struct LockmanPriorityBasedInfo: LockmanInfo, Sendable, Equatable {
     }
 
     return
-      "LockmanPriorityBasedInfo(strategyId: '\(strategyId)', actionId: '\(actionId)', uniqueId: \(uniqueId), priority: \(priorityStr), blocksSameAction: \(blocksSameAction))"
+      "LockmanPriorityBasedInfo(strategyId: '\(strategyId)', actionId: '\(actionId)', uniqueId: \(uniqueId), priority: \(priorityStr))"
   }
 
   // MARK: - Debug Additional Info
@@ -168,7 +132,6 @@ public struct LockmanPriorityBasedInfo: LockmanInfo, Sendable, Equatable {
       let behaviorStr = behavior == .exclusive ? ".exclusive" : ".replaceable"
       result = String(result.prefix(20 - 13)) + " b: " + behaviorStr
     }
-    result += " blocksSameAction: \(blocksSameAction)"
     return result
   }
 }

--- a/Sources/Lockman/Documentation.docc/PriorityBasedStrategy.md
+++ b/Sources/Lockman/Documentation.docc/PriorityBasedStrategy.md
@@ -87,15 +87,6 @@ enum Action {
 }
 ```
 
-### Same Action Blocking Setting
-
-```swift
-LockmanPriorityBasedInfo(
-    actionId: "criticalUpdate",
-    priority: .high(.exclusive),
-    blocksSameAction: true  // Block duplicate execution of the same action ID
-)
-```
 
 ## Operation Examples
 
@@ -145,16 +136,6 @@ lockFailure: { error, send in
 lockFailure: { error, send in
     if case .samePriorityConflict(let priority) = error as? LockmanPriorityBasedError {
         send(.busyMessage("Process with same priority is running"))
-    }
-}
-```
-
-**blockedBySameAction** - Blocked by same action
-
-```swift
-lockFailure: { error, send in
-    if case .blockedBySameAction(let existingInfo) = error as? LockmanPriorityBasedError {
-        send(.duplicateAction("Same process is already running"))
     }
 }
 ```

--- a/Tests/LockmanCoreTests/ErrorTests/LockmanErrorCoverageTests.swift
+++ b/Tests/LockmanCoreTests/ErrorTests/LockmanErrorCoverageTests.swift
@@ -51,12 +51,6 @@ final class LockmanErrorCoverageTests: XCTestCase {
     let error2 = LockmanPriorityBasedError.samePriorityConflict(priority: .low(.replaceable))
     XCTAssertNotNil(error2.failureReason)
     XCTAssertTrue(error2.failureReason!.contains("priority"))
-
-    let existingInfo3 = LockmanPriorityBasedInfo(
-      actionId: "test-action", priority: .high(.exclusive))
-    let error3 = LockmanPriorityBasedError.blockedBySameAction(existingInfo: existingInfo3)
-    XCTAssertNotNil(error3.failureReason)
-    XCTAssertTrue(error3.failureReason!.contains("action"))
   }
 
   // MARK: - TestDynamicConditionError Tests
@@ -114,14 +108,9 @@ final class LockmanErrorCoverageTests: XCTestCase {
     XCTAssertNotNil(error1.errorDescription)
     XCTAssertTrue(error1.errorDescription!.contains(specialId))
 
-    let existingInfo2 = LockmanPriorityBasedInfo(actionId: specialId, priority: .high(.exclusive))
-    let error2 = LockmanPriorityBasedError.blockedBySameAction(existingInfo: existingInfo2)
+    let error2 = TestDynamicConditionError.conditionNotMet(actionId: specialId, hint: nil)
     XCTAssertNotNil(error2.errorDescription)
     XCTAssertTrue(error2.errorDescription!.contains(specialId))
-
-    let error3 = TestDynamicConditionError.conditionNotMet(actionId: specialId, hint: nil)
-    XCTAssertNotNil(error3.errorDescription)
-    XCTAssertTrue(error3.errorDescription!.contains(specialId))
   }
 
   func testErrorDescriptionsWithEmptyStrings() {

--- a/Tests/LockmanCoreTests/LockmanEdgeCaseTests.swift
+++ b/Tests/LockmanCoreTests/LockmanEdgeCaseTests.swift
@@ -119,11 +119,11 @@ final class LockmanEdgeCaseTests: XCTestCase {
     let boundaryId = "priority-test"
 
     let noneInfo1 = LockmanPriorityBasedInfo(
-      actionId: "none-action", priority: .none, blocksSameAction: false)
+      actionId: "none-action", priority: .none)
     let noneInfo2 = LockmanPriorityBasedInfo(
-      actionId: "none-action", priority: .none, blocksSameAction: false)
+      actionId: "none-action", priority: .none)
     let highInfo = LockmanPriorityBasedInfo(
-      actionId: "none-action", priority: .high(.exclusive), blocksSameAction: false)
+      actionId: "none-action", priority: .high(.exclusive))
 
     // First none priority should succeed
     XCTAssertEqual(strategy.canLock(id: boundaryId, info: noneInfo1), .success)

--- a/Tests/LockmanCoreTests/PriorityBasedTests/LockmanPriorityBasedInfoTests.swift
+++ b/Tests/LockmanCoreTests/PriorityBasedTests/LockmanPriorityBasedInfoTests.swift
@@ -24,39 +24,39 @@ private struct TestBoundaryId: LockmanBoundaryId {
 
 /// Factory for creating test info instances with clear intent
 private enum TestInfoFactory {
-  static func none(_ actionId: String = "noneAction", blocksSameAction: Bool = true)
+  static func none(_ actionId: String = "noneAction")
     -> LockmanPriorityBasedInfo
   {
     LockmanPriorityBasedInfo(
-      actionId: actionId, priority: .none, blocksSameAction: blocksSameAction)
+      actionId: actionId, priority: .none)
   }
 
-  static func lowExclusive(_ actionId: String = "lowExclusive", blocksSameAction: Bool = true)
+  static func lowExclusive(_ actionId: String = "lowExclusive")
     -> LockmanPriorityBasedInfo
   {
     LockmanPriorityBasedInfo(
-      actionId: actionId, priority: .low(.exclusive), blocksSameAction: blocksSameAction)
+      actionId: actionId, priority: .low(.exclusive))
   }
 
-  static func lowReplaceable(_ actionId: String = "lowReplaceable", blocksSameAction: Bool = true)
+  static func lowReplaceable(_ actionId: String = "lowReplaceable")
     -> LockmanPriorityBasedInfo
   {
     LockmanPriorityBasedInfo(
-      actionId: actionId, priority: .low(.replaceable), blocksSameAction: blocksSameAction)
+      actionId: actionId, priority: .low(.replaceable))
   }
 
-  static func highExclusive(_ actionId: String = "highExclusive", blocksSameAction: Bool = true)
+  static func highExclusive(_ actionId: String = "highExclusive")
     -> LockmanPriorityBasedInfo
   {
     LockmanPriorityBasedInfo(
-      actionId: actionId, priority: .high(.exclusive), blocksSameAction: blocksSameAction)
+      actionId: actionId, priority: .high(.exclusive))
   }
 
-  static func highReplaceable(_ actionId: String = "highReplaceable", blocksSameAction: Bool = true)
+  static func highReplaceable(_ actionId: String = "highReplaceable")
     -> LockmanPriorityBasedInfo
   {
     LockmanPriorityBasedInfo(
-      actionId: actionId, priority: .high(.replaceable), blocksSameAction: blocksSameAction)
+      actionId: actionId, priority: .high(.replaceable))
   }
 }
 
@@ -80,30 +80,7 @@ final class LockmanPriorityBasedInfoTests: XCTestCase {
     for (info, expectedPriority) in testCases {
       XCTAssertEqual(info.actionId, actionId)
       XCTAssertEqual(info.priority, expectedPriority)
-      XCTAssertTrue(info.blocksSameAction)  // Default value
     }
-  }
-
-  func testInitializeWithBlocksSameAction() {
-    let actionId = "testAction"
-
-    // Test default value
-    let info1 = LockmanPriorityBasedInfo(actionId: actionId, priority: .high(.exclusive))
-    XCTAssertTrue(info1.blocksSameAction)
-
-    // Test explicit false
-    let info2 = LockmanPriorityBasedInfo(
-      actionId: actionId, priority: .high(.exclusive), blocksSameAction: false)
-    XCTAssertFalse(info2.blocksSameAction)
-
-    // Test explicit true
-    let info3 = LockmanPriorityBasedInfo(
-      actionId: actionId, priority: .high(.exclusive), blocksSameAction: true)
-    XCTAssertTrue(info3.blocksSameAction)
-
-    // Test with factory methods
-    let info4 = TestInfoFactory.highExclusive(actionId, blocksSameAction: true)
-    XCTAssertTrue(info4.blocksSameAction)
   }
 
   func testUniqueIdGenerationEnsuresInstanceUniqueness() {


### PR DESCRIPTION
## Summary
- Removed `blocksSameAction` option from `LockmanPriorityBasedInfo`
- This functionality can be achieved by combining strategies using `CompositeStrategy`
- Improves separation of concerns by having each strategy focus on a single responsibility

## Breaking Changes
The `blocksSameAction` parameter has been removed from `LockmanPriorityBasedInfo`. 

### Migration
If you were using `blocksSameAction`, combine `PriorityBasedStrategy` with `SingleExecutionStrategy`:

```swift
// Before
LockmanPriorityBasedInfo(
    actionId: "payment",
    priority: .high(.exclusive),
    blocksSameAction: true
)

// After
@LockmanCompositeStrategy(
    LockmanPriorityBasedStrategy.self,
    LockmanSingleExecutionStrategy.self
)
```

## Changes Made
- ❌ Removed `blocksSameAction` property from `LockmanPriorityBasedInfo`
- ❌ Removed `blockedBySameAction` error case from `LockmanPriorityBasedError`
- ❌ Removed bidirectional blocking logic from `LockmanPriorityBasedStrategy`
- 📝 Updated all tests to remove `blocksSameAction` usage
- 📝 Updated documentation to remove outdated references
- 📝 Updated macro example in `LockmanComposableMacros.swift`

## Testing
- ✅ All existing tests pass
- ✅ Examples build successfully
- ✅ No remaining references to `blocksSameAction` in the codebase

🤖 Generated with [Claude Code](https://claude.ai/code)