### PR TITLE
feat: update TCA to version 1.19.1

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ Develop a library to implement exclusive control of user actions in application 
 - Swift versions: 6.0, 5.10, 5.9
 - Type-safe implementation
 - Single unified Lockman module, developed exclusively for TCA
-- Based on Composable Architecture 1.18
+- Based on Composable Architecture 1.19
 - When modifying Package.swift, you MUST also update Package@swift-6.0 to keep them in sync
 
 ## Documentation

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "8218c56178067474c5da994a7a6722f18ccb0337753aab513857b343773e5708",
+  "originHash" : "e90c77ff12e73c01dca875871c848d193ca68a31d28176dd99d3075c1e288c72",
   "pins" : [
     {
       "identity" : "combine-schedulers",
@@ -42,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-composable-architecture",
       "state" : {
-        "revision" : "76c4411e02cc7768a3f27ca058bd2143c342e5b2",
-        "version" : "1.18.0"
+        "revision" : "b1d27a82b498b8e697acabd8cc01b585d26aab19",
+        "version" : "1.19.1"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -19,8 +19,8 @@ let package = Package(
       targets: ["Lockman"])
   ],
   dependencies: [
-    .package(url: "https://github.com/pointfreeco/swift-composable-architecture", exact: "1.18.0"),
-    .package(url: "https://github.com/swiftlang/swift-syntax", "509.0.0"..<"601.0.0"),
+    .package(url: "https://github.com/pointfreeco/swift-composable-architecture", exact: "1.19.1"),
+    .package(url: "https://github.com/swiftlang/swift-syntax", "509.0.0"..<"602.0.0"),
     .package(url: "https://github.com/pointfreeco/swift-macro-testing", from: "0.2.0"),
     .package(url: "https://github.com/apple/swift-collections.git", from: "1.1.4"),
     .package(url: "https://github.com/swiftlang/swift-docc-plugin", exact: "1.0.0"),

--- a/Package@swift-6.0.swift
+++ b/Package@swift-6.0.swift
@@ -19,8 +19,8 @@ let package = Package(
       targets: ["Lockman"])
   ],
   dependencies: [
-    .package(url: "https://github.com/pointfreeco/swift-composable-architecture", exact: "1.18.0"),
-    .package(url: "https://github.com/swiftlang/swift-syntax", "509.0.0"..<"601.0.0"),
+    .package(url: "https://github.com/pointfreeco/swift-composable-architecture", exact: "1.19.1"),
+    .package(url: "https://github.com/swiftlang/swift-syntax", "509.0.0"..<"602.0.0"),
     .package(url: "https://github.com/pointfreeco/swift-macro-testing", from: "0.2.0"),
     .package(url: "https://github.com/apple/swift-collections.git", from: "1.1.4"),
     .package(url: "https://github.com/swiftlang/swift-docc-plugin", exact: "1.0.0"),


### PR DESCRIPTION
## Summary
- Update The Composable Architecture from 1.18.0 to 1.19.1
- Update swift-syntax version range to support 601.0.0

## Changes
- Updated TCA dependency in Package.swift and Package@swift-6.0.swift
- Updated CLAUDE.md to reflect TCA 1.19 support

## Testing
- All tests pass without any code changes required
- Tested on macOS with Xcode 16.2

## Notes
- TCA 1.19.0 included significant store internals rewrite for performance improvements
- TCA 1.19.1 includes additional performance improvements and bug fixes
- No breaking changes that affect Lockman's implementation

🤖 Generated with [Claude Code](https://claude.ai/code)