### PR TITLE
docs: organize README files into Docs directory

### DIFF
--- a/Docs/README_de.md
+++ b/Docs/README_de.md
@@ -1,58 +1,58 @@
-<img src="Lockman.png" alt="Lockman Logo" width="400">
+<img src="../Lockman.png" alt="Lockman Logo" width="400">
 
 [![CI](https://github.com/takeshishimada/Lockman/workflows/CI/badge.svg)](https://github.com/takeshishimada/Lockman/actions?query=workflow%3ACI)
 [![Swift](https://img.shields.io/badge/Swift-5.9%20%7C%205.10%20%7C%206.0-ED523F.svg?style=flat)](https://swift.org/download/)
 [![Platforms](https://img.shields.io/badge/Platforms-iOS%20%7C%20macOS%20%7C%20tvOS%20%7C%20watchOS%20%7C%20Mac%20Catalyst-333333.svg?style=flat)](https://developer.apple.com/)
 
-[English](README.md) | [日本語](README_ja.md) | [简体中文](README_zh-CN.md) | [繁體中文](README_zh-TW.md) | [Español](README_es.md) | [Français](README_fr.md) | [Deutsch](README_de.md) | [한국어](README_ko.md) | [Português](README_pt-BR.md) | [Italiano](README_it.md)
+[English](../README.md) | [日本語](README_ja.md) | [简体中文](README_zh-CN.md) | [繁體中文](README_zh-TW.md) | [Español](README_es.md) | [Français](README_fr.md) | [Deutsch](README_de.md) | [한국어](README_ko.md) | [Português](README_pt-BR.md) | [Italiano](README_it.md)
 
-Lockman은 The Composable Architecture (TCA) 애플리케이션에서 동시 액션 제어 문제를 해결하는 Swift 라이브러리로, 반응성, 투명성, 선언적 설계에 중점을 둡니다.
+Lockman ist eine Swift-Bibliothek, die Probleme bei der Kontrolle konkurrierender Aktionen in The Composable Architecture (TCA) Anwendungen löst, mit Fokus auf Reaktionsfähigkeit, Transparenz und deklaratives Design.
 
-* [설계 철학](#설계-철학)
-* [개요](#개요)
-* [기본 예제](#기본-예제)
-* [설치](#설치)
-* [커뮤니티](#커뮤니티)
+* [Design-Philosophie](#design-philosophie)
+* [Überblick](#überblick)
+* [Grundlegendes Beispiel](#grundlegendes-beispiel)
+* [Installation](#installation)
+* [Community](#community)
 
-## 설계 철학
+## Design-Philosophie
 
-### Designing Fluid Interfaces 원칙
+### Designing Fluid Interfaces Prinzipien
 
-WWDC18의 "Designing Fluid Interfaces" 프레젠테이션은 뛰어난 인터페이스를 위한 원칙을 제시했습니다:
+Die Präsentation "Designing Fluid Interfaces" der WWDC18 stellte Prinzipien für außergewöhnliche Schnittstellen vor:
 
-* **즉각적인 응답과 지속적인 리디렉션** - 10ms의 지연도 허용하지 않는 반응성
-* **터치와 콘텐츠 간의 일대일 움직임** - 드래그 작업 중 콘텐츠가 손가락을 따라감
-* **지속적인 피드백** - 모든 상호작용에 대한 즉각적인 반응
-* **병렬 제스처 감지** - 여러 제스처를 동시에 인식
-* **공간적 일관성** - 애니메이션 중 위치 일관성 유지
-* **가벼운 상호작용, 증폭된 출력** - 작은 입력에서 큰 효과
+* **Sofortige Reaktion und kontinuierliche Umleitung** - Reaktionsfähigkeit, die nicht einmal 10ms Verzögerung toleriert
+* **Eins-zu-Eins-Bewegung zwischen Berührung und Inhalt** - Inhalt folgt dem Finger während Ziehvorgängen
+* **Kontinuierliches Feedback** - Sofortige Reaktion auf alle Interaktionen
+* **Parallele Gestenerkennung** - Gleichzeitige Erkennung mehrerer Gesten
+* **Räumliche Konsistenz** - Beibehaltung der Positionskonsistenz während Animationen
+* **Leichte Interaktionen, verstärkte Ausgabe** - Große Effekte aus kleinen Eingaben
 
-### 기존의 과제
+### Traditionelle Herausforderungen
 
-기존 UI 개발은 단순히 동시 버튼 누름과 중복 실행을 금지하여 문제를 해결했습니다. 이러한 접근 방식은 현대적인 유동적 인터페이스 설계에서 사용자 경험을 저해하는 요인이 되었습니다.
+Die traditionelle UI-Entwicklung löste Probleme, indem sie gleichzeitige Tasteneingaben und doppelte Ausführungen einfach verbot. Diese Ansätze wurden zu Faktoren, die die Benutzererfahrung im modernen flüssigen Interface-Design behindern.
 
-사용자는 동시에 버튼을 누르더라도 어떤 형태의 피드백을 기대합니다. UI 레이어에서의 즉각적인 응답과 비즈니스 로직 레이어에서의 적절한 상호 배제 제어를 명확히 분리하는 것이 중요합니다.
+Benutzer erwarten eine Form von Feedback, auch wenn sie gleichzeitig Tasten drücken. Es ist entscheidend, die sofortige Reaktion auf UI-Ebene klar von der angemessenen gegenseitigen Ausschlusskontrolle auf Geschäftslogikebene zu trennen.
 
-## 개요
+## Überblick
 
-Lockman은 애플리케이션 개발의 일반적인 문제를 해결하기 위해 다음과 같은 제어 전략을 제공합니다:
+Lockman bietet die folgenden Kontrollstrategien zur Lösung häufiger Probleme in der Anwendungsentwicklung:
 
-* **Single Execution**: 동일한 액션의 중복 실행 방지
-* **Priority Based**: 우선순위 기반 액션 제어 및 취소
-* **Group Coordination**: 리더/멤버 역할을 통한 그룹 제어
-* **Dynamic Condition**: 실행 조건에 기반한 동적 제어
-* **Concurrency Limited**: 그룹당 동시 실행 수 제한
-* **Composite Strategy**: 여러 전략 조합
+* **Single Execution**: Verhindert doppelte Ausführung derselben Aktion
+* **Priority Based**: Prioritätsbasierte Aktionskontrolle und -stornierung
+* **Group Coordination**: Gruppenkontrolle über Leader/Member-Rollen
+* **Dynamic Condition**: Dynamische Kontrolle basierend auf Ausführungsbedingungen
+* **Concurrency Limited**: Begrenzt die Anzahl gleichzeitiger Ausführungen pro Gruppe
+* **Composite Strategy**: Kombination mehrerer Strategien
 
-## 예제
+## Beispiele
 
 | Single Execution Strategy | Priority Based Strategy | Concurrency Limited Strategy |
 |--------------------------|------------------------|------------------------------|
-| ![Single Execution Strategy](Sources/Lockman/Documentation.docc/images/01-SingleExecutionStrategy.gif) | ![Priority Based Strategy](Sources/Lockman/Documentation.docc/images/02-PriorityBasedStrategy.gif) | ![Concurrency Limited Strategy](Sources/Lockman/Documentation.docc/images/03-ConcurrencyLimitedStrategy.gif) |
+| ![Single Execution Strategy](../Sources/Lockman/Documentation.docc/images/01-SingleExecutionStrategy.gif) | ![Priority Based Strategy](../Sources/Lockman/Documentation.docc/images/02-PriorityBasedStrategy.gif) | ![Concurrency Limited Strategy](../Sources/Lockman/Documentation.docc/images/03-ConcurrencyLimitedStrategy.gif) |
 
-## 코드 예제
+## Code-Beispiel
 
-`@LockmanSingleExecution` 매크로를 사용하여 프로세스의 중복 실행을 방지하는 기능을 구현하는 방법입니다:
+So implementieren Sie eine Funktion, die doppelte Prozessausführung mit dem `@LockmanSingleExecution` Makro verhindert:
 
 ```swift
 import ComposableArchitecture
@@ -129,9 +129,9 @@ struct ProcessFeature {
 }
 ```
 
-`withLock` 메서드는 처리가 진행 중일 때 `startProcessButtonTapped`가 실행되지 않도록 보장하여, 사용자가 버튼을 여러 번 눌러도 중복 작업을 방지합니다.
+Die `withLock` Methode stellt sicher, dass `startProcessButtonTapped` nicht ausgeführt wird, während die Verarbeitung läuft, wodurch doppelte Operationen verhindert werden, auch wenn der Benutzer mehrmals auf die Schaltfläche drückt.
 
-### 디버그 출력 예제
+### Debug-Ausgabe Beispiel
 
 ```
 ✅ [Lockman] canLock succeeded - Strategy: SingleExecution, BoundaryId: process, Info: LockmanSingleExecutionInfo(actionId: 'startProcessButtonTapped', uniqueId: 7BFC785A-3D25-4722-B9BC-A3A63A7F49FC, mode: boundary)
@@ -152,9 +152,9 @@ struct ProcessFeature {
 └─────────────────┴──────────────────┴──────────────────────────────────────┴─────────────────┘
 ```
 
-## 문서
+## Dokumentation
 
-출시된 버전과 `main`에 대한 문서는 여기에서 사용할 수 있습니다:
+Die Dokumentation für veröffentlichte Versionen und `main` ist hier verfügbar:
 
 * [`main`](https://takeshishimada.github.io/Lockman/main/documentation/lockman/)
 * [0.11.0](https://takeshishimada.github.io/Lockman/0.11.0/documentation/lockman/)
@@ -163,7 +163,7 @@ struct ProcessFeature {
 * [0.8.0](https://takeshishimada.github.io/Lockman/0.8.0/documentation/lockman/)
 
 <details>
-<summary>다른 버전</summary>
+<summary>Weitere Versionen</summary>
 
 * [0.7.0](https://takeshishimada.github.io/Lockman/0.7.0/documentation/lockman/)
 * [0.6.0](https://takeshishimada.github.io/Lockman/0.6.0/documentation/lockman/)
@@ -173,35 +173,35 @@ struct ProcessFeature {
 
 </details>
 
-라이브러리에 익숙해지는 데 도움이 될 수 있는 여러 문서가 있습니다:
+Es gibt mehrere Artikel in der Dokumentation, die Ihnen beim Einstieg in die Bibliothek helfen können:
 
-### 필수 사항
-* [시작하기](https://takeshishimada.github.io/Lockman/main/documentation/lockman/gettingstarted) - TCA 애플리케이션에 Lockman을 통합하는 방법 알아보기
-* [Boundary 개요](https://takeshishimada.github.io/Lockman/main/documentation/lockman/boundaryoverview) - Lockman의 boundary 개념 이해하기
-* [잠금](https://takeshishimada.github.io/Lockman/main/documentation/lockman/lock) - 잠금 메커니즘 이해하기
-* [잠금 해제](https://takeshishimada.github.io/Lockman/main/documentation/lockman/unlock) - 잠금 해제 메커니즘 이해하기
-* [전략 선택](https://takeshishimada.github.io/Lockman/main/documentation/lockman/choosingstrategy) - 사용 사례에 맞는 전략 선택하기
-* [구성](https://takeshishimada.github.io/Lockman/main/documentation/lockman/configuration) - 애플리케이션 요구 사항에 맞게 Lockman 구성하기
-* [오류 처리](https://takeshishimada.github.io/Lockman/main/documentation/lockman/errorhandling) - 일반적인 오류 처리 패턴 알아보기
-* [디버깅 가이드](https://takeshishimada.github.io/Lockman/main/documentation/lockman/debuggingguide) - 애플리케이션에서 Lockman 관련 문제 디버깅하기
+### Grundlagen
+* [Erste Schritte](https://takeshishimada.github.io/Lockman/main/documentation/lockman/gettingstarted) - Lernen Sie, wie Sie Lockman in Ihre TCA-Anwendung integrieren
+* [Boundary-Überblick](https://takeshishimada.github.io/Lockman/main/documentation/lockman/boundaryoverview) - Verstehen Sie das Boundary-Konzept in Lockman
+* [Sperren](https://takeshishimada.github.io/Lockman/main/documentation/lockman/lock) - Verstehen Sie den Sperrmechanismus
+* [Entsperren](https://takeshishimada.github.io/Lockman/main/documentation/lockman/unlock) - Verstehen Sie den Entsperrmechanismus
+* [Eine Strategie wählen](https://takeshishimada.github.io/Lockman/main/documentation/lockman/choosingstrategy) - Wählen Sie die richtige Strategie für Ihren Anwendungsfall
+* [Konfiguration](https://takeshishimada.github.io/Lockman/main/documentation/lockman/configuration) - Konfigurieren Sie Lockman für Ihre Anwendungsanforderungen
+* [Fehlerbehandlung](https://takeshishimada.github.io/Lockman/main/documentation/lockman/errorhandling) - Lernen Sie gängige Fehlerbehandlungsmuster
+* [Debugging-Leitfaden](https://takeshishimada.github.io/Lockman/main/documentation/lockman/debuggingguide) - Debuggen Sie Lockman-bezogene Probleme in Ihrer Anwendung
 
-### 전략
-* [Single Execution Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/singleexecutionstrategy) - 중복 실행 방지
-* [Priority Based Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/prioritybasedstrategy) - 우선순위 기반 제어
-* [Concurrency Limited Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/concurrencylimitedstrategy) - 동시 실행 제한
-* [Group Coordination Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/groupcoordinationstrategy) - 관련 액션 조정
-* [Dynamic Condition Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/dynamicconditionstrategy) - 동적 런타임 제어
-* [Composite Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/compositestrategy) - 여러 전략 결합
+### Strategien
+* [Single Execution Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/singleexecutionstrategy) - Doppelte Ausführung verhindern
+* [Priority Based Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/prioritybasedstrategy) - Prioritätsbasierte Kontrolle
+* [Concurrency Limited Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/concurrencylimitedstrategy) - Gleichzeitige Ausführungen begrenzen
+* [Group Coordination Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/groupcoordinationstrategy) - Verwandte Aktionen koordinieren
+* [Dynamic Condition Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/dynamicconditionstrategy) - Dynamische Laufzeitkontrolle
+* [Composite Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/compositestrategy) - Mehrere Strategien kombinieren
 
-참고: 문서는 영어로만 제공됩니다.
+Hinweis: Die Dokumentation ist nur auf Englisch verfügbar.
 
-## 설치
+## Installation
 
-Lockman은 [Swift Package Manager](https://swift.org/package-manager/)를 사용하여 설치할 수 있습니다.
+Lockman kann über den [Swift Package Manager](https://swift.org/package-manager/) installiert werden.
 
 ### Xcode
 
-Xcode에서 File → Add Package Dependencies를 선택하고 다음 URL을 입력하세요:
+Wählen Sie in Xcode File → Add Package Dependencies und geben Sie die folgende URL ein:
 
 ```
 https://github.com/takeshishimada/Lockman
@@ -209,7 +209,7 @@ https://github.com/takeshishimada/Lockman
 
 ### Package.swift
 
-Package.swift 파일에 종속성을 추가하세요:
+Fügen Sie die Abhängigkeit zu Ihrer Package.swift-Datei hinzu:
 
 ```swift
 dependencies: [
@@ -217,7 +217,7 @@ dependencies: [
 ]
 ```
 
-타겟에 종속성을 추가하세요:
+Fügen Sie die Abhängigkeit zu Ihrem Target hinzu:
 
 ```swift
 .target(
@@ -228,16 +228,16 @@ dependencies: [
 )
 ```
 
-### 요구 사항
+### Anforderungen
 
-| 플랫폼  | 최소 버전 |
-|---------|-----------|
-| iOS     | 13.0      |
-| macOS   | 10.15     |
-| tvOS    | 13.0      |
-| watchOS | 6.0       |
+| Plattform | Mindestversion |
+|-----------|----------------|
+| iOS       | 13.0           |
+| macOS     | 10.15          |
+| tvOS      | 13.0           |
+| watchOS   | 6.0            |
 
-### 버전 호환성
+### Versionskompatibilität
 
 | Lockman | The Composable Architecture |
 |---------|----------------------------|
@@ -246,7 +246,7 @@ dependencies: [
 | 0.9.0   | 1.18.0                     |
 
 <details>
-<summary>다른 버전</summary>
+<summary>Weitere Versionen</summary>
 
 | Lockman | The Composable Architecture |
 |---------|----------------------------|
@@ -262,20 +262,20 @@ dependencies: [
 
 </details>
 
-## 커뮤니티
+## Community
 
-### 토론 및 도움말
+### Diskussion und Hilfe
 
-질문과 토론은 [GitHub Discussions](https://github.com/takeshishimada/Lockman/discussions)에서 진행할 수 있습니다.
+Fragen und Diskussionen können in [GitHub Discussions](https://github.com/takeshishimada/Lockman/discussions) geführt werden.
 
-### 버그 보고
+### Fehlerberichte
 
-버그를 발견하면 [Issues](https://github.com/takeshishimada/Lockman/issues)에 보고해 주세요.
+Wenn Sie einen Fehler finden, melden Sie ihn bitte unter [Issues](https://github.com/takeshishimada/Lockman/issues).
 
-### 기여
+### Beitragen
 
-라이브러리에 기여하고 싶으시면 링크와 함께 PR을 열어주세요!
+Wenn Sie zur Bibliothek beitragen möchten, öffnen Sie bitte eine PR mit einem Link dazu!
 
-## 라이선스
+## Lizenz
 
-이 라이브러리는 MIT 라이선스로 출시되었습니다. 자세한 내용은 [LICENSE](./LICENSE) 파일을 참조하세요.
+Diese Bibliothek wird unter der MIT-Lizenz veröffentlicht. Siehe [LICENSE](./LICENSE) Datei für Details.

--- a/Docs/README_es.md
+++ b/Docs/README_es.md
@@ -1,58 +1,58 @@
-<img src="Lockman.png" alt="Lockman Logo" width="400">
+<img src="../Lockman.png" alt="Lockman Logo" width="400">
 
 [![CI](https://github.com/takeshishimada/Lockman/workflows/CI/badge.svg)](https://github.com/takeshishimada/Lockman/actions?query=workflow%3ACI)
 [![Swift](https://img.shields.io/badge/Swift-5.9%20%7C%205.10%20%7C%206.0-ED523F.svg?style=flat)](https://swift.org/download/)
 [![Platforms](https://img.shields.io/badge/Platforms-iOS%20%7C%20macOS%20%7C%20tvOS%20%7C%20watchOS%20%7C%20Mac%20Catalyst-333333.svg?style=flat)](https://developer.apple.com/)
 
-[English](README.md) | [日本語](README_ja.md) | [简体中文](README_zh-CN.md) | [繁體中文](README_zh-TW.md) | [Español](README_es.md) | [Français](README_fr.md) | [Deutsch](README_de.md) | [한국어](README_ko.md) | [Português](README_pt-BR.md) | [Italiano](README_it.md)
+[English](../README.md) | [日本語](README_ja.md) | [简体中文](README_zh-CN.md) | [繁體中文](README_zh-TW.md) | [Español](README_es.md) | [Français](README_fr.md) | [Deutsch](README_de.md) | [한국어](README_ko.md) | [Português](README_pt-BR.md) | [Italiano](README_it.md)
 
-Lockman é uma biblioteca Swift que resolve problemas de controle de ações concorrentes em aplicações The Composable Architecture (TCA), com responsividade, transparência e design declarativo em mente.
+Lockman es una biblioteca Swift que resuelve problemas de control de acciones concurrentes en aplicaciones The Composable Architecture (TCA), con énfasis en la capacidad de respuesta, transparencia y diseño declarativo.
 
-* [Filosofia de Design](#filosofia-de-design)
-* [Visão Geral](#visão-geral)
-* [Exemplo Básico](#exemplo-básico)
-* [Instalação](#instalação)
-* [Comunidade](#comunidade)
+* [Filosofía de Diseño](#filosofía-de-diseño)
+* [Descripción General](#descripción-general)
+* [Ejemplo Básico](#ejemplo-básico)
+* [Instalación](#instalación)
+* [Comunidad](#comunidad)
 
-## Filosofia de Design
+## Filosofía de Diseño
 
-### Princípios de Designing Fluid Interfaces
+### Principios de Designing Fluid Interfaces
 
-O "Designing Fluid Interfaces" da WWDC18 apresentou princípios para interfaces excepcionais:
+La charla "Designing Fluid Interfaces" de WWDC18 presentó principios para interfaces excepcionales:
 
-* **Resposta Imediata e Redirecionamento Contínuo** - Responsividade que não permite nem 10ms de atraso
-* **Movimento de Toque e Conteúdo Um-para-Um** - O conteúdo segue o dedo durante operações de arraste
-* **Feedback Contínuo** - Reação imediata a todas as interações
-* **Detecção de Gestos Paralelos** - Reconhecendo múltiplos gestos simultaneamente
-* **Consistência Espacial** - Mantendo consistência de posição durante animações
-* **Interações Leves, Saída Amplificada** - Grandes efeitos a partir de pequenas entradas
+* **Respuesta Inmediata y Redirección Continua** - Capacidad de respuesta que no permite ni 10ms de retraso
+* **Movimiento Uno a Uno de Toque y Contenido** - El contenido sigue al dedo durante las operaciones de arrastre
+* **Retroalimentación Continua** - Reacción inmediata a todas las interacciones
+* **Detección de Gestos en Paralelo** - Reconocimiento de múltiples gestos simultáneamente
+* **Consistencia Espacial** - Mantenimiento de la consistencia de posición durante las animaciones
+* **Interacciones Ligeras, Salida Amplificada** - Grandes efectos a partir de pequeñas entradas
 
-### Desafios Tradicionais
+### Desafíos Tradicionales
 
-O desenvolvimento tradicional de UI resolveu problemas simplesmente proibindo pressionamentos simultâneos de botões e execuções duplicadas. Essas abordagens se tornaram fatores que prejudicam a experiência do usuário no design moderno de interfaces fluidas.
+El desarrollo tradicional de UI ha resuelto problemas simplemente prohibiendo presionar botones simultáneamente y ejecuciones duplicadas. Estos enfoques se han convertido en factores que obstaculizan la experiencia del usuario en el diseño moderno de interfaces fluidas.
 
-Os usuários esperam algum tipo de feedback mesmo ao pressionar botões simultaneamente. É crucial separar claramente a resposta imediata na camada de UI do controle apropriado de exclusão mútua na camada de lógica de negócios.
+Los usuarios esperan alguna forma de retroalimentación incluso al presionar botones simultáneamente. Es crucial separar claramente la respuesta inmediata en la capa de UI del control de exclusión mutua apropiado en la capa de lógica de negocio.
 
-## Visão Geral
+## Descripción General
 
-Lockman fornece as seguintes estratégias de controle para abordar problemas comuns no desenvolvimento de aplicativos:
+Lockman proporciona las siguientes estrategias de control para abordar problemas comunes en el desarrollo de aplicaciones:
 
-* **Execução Única**: Previne execução duplicada da mesma ação
-* **Baseado em Prioridade**: Controle e cancelamento de ação baseado em prioridade
-* **Coordenação de Grupo**: Controle de grupo através de papéis líder/membro
-* **Condição Dinâmica**: Controle dinâmico baseado em condições de tempo de execução
-* **Concorrência Limitada**: Limita o número de execuções concorrentes por grupo
-* **Estratégia Composta**: Combinação de múltiplas estratégias
+* **Single Execution**: Previene la ejecución duplicada de la misma acción
+* **Priority Based**: Control y cancelación de acciones basado en prioridad
+* **Group Coordination**: Control de grupo mediante roles de líder/miembro
+* **Dynamic Condition**: Control dinámico basado en condiciones de tiempo de ejecución
+* **Concurrency Limited**: Limita el número de ejecuciones concurrentes por grupo
+* **Composite Strategy**: Combinación de múltiples estrategias
 
-## Exemplos
+## Ejemplos
 
-| Estratégia de Execução Única | Estratégia Baseada em Prioridade | Estratégia de Concorrência Limitada |
-|------------------------------|----------------------------------|-------------------------------------|
-| ![Estratégia de Execução Única](Sources/Lockman/Documentation.docc/images/01-SingleExecutionStrategy.gif) | ![Estratégia Baseada em Prioridade](Sources/Lockman/Documentation.docc/images/02-PriorityBasedStrategy.gif) | ![Estratégia de Concorrência Limitada](Sources/Lockman/Documentation.docc/images/03-ConcurrencyLimitedStrategy.gif) |
+| Single Execution Strategy | Priority Based Strategy | Concurrency Limited Strategy |
+|--------------------------|------------------------|------------------------------|
+| ![Single Execution Strategy](../Sources/Lockman/Documentation.docc/images/01-SingleExecutionStrategy.gif) | ![Priority Based Strategy](../Sources/Lockman/Documentation.docc/images/02-PriorityBasedStrategy.gif) | ![Concurrency Limited Strategy](../Sources/Lockman/Documentation.docc/images/03-ConcurrencyLimitedStrategy.gif) |
 
-## Exemplo de Código
+## Ejemplo de Código
 
-Veja como implementar um recurso que previne execução duplicada de processos usando o macro `@LockmanSingleExecution`:
+Aquí se muestra cómo implementar una función que previene la ejecución duplicada de procesos usando el macro `@LockmanSingleExecution`:
 
 ```swift
 import ComposableArchitecture
@@ -129,9 +129,9 @@ struct ProcessFeature {
 }
 ```
 
-O método `withLock` garante que `startProcessButtonTapped` não será executado enquanto o processamento estiver em andamento, prevenindo operações duplicadas mesmo se o usuário tocar o botão várias vezes.
+El método `withLock` asegura que `startProcessButtonTapped` no se ejecute mientras el procesamiento está en curso, previniendo operaciones duplicadas incluso si el usuario toca el botón múltiples veces.
 
-### Exemplo de Saída de Debug
+### Ejemplo de Salida de Depuración
 
 ```
 ✅ [Lockman] canLock succeeded - Strategy: SingleExecution, BoundaryId: process, Info: LockmanSingleExecutionInfo(actionId: 'startProcessButtonTapped', uniqueId: 7BFC785A-3D25-4722-B9BC-A3A63A7F49FC, mode: boundary)
@@ -152,9 +152,9 @@ O método `withLock` garante que `startProcessButtonTapped` não será executado
 └─────────────────┴──────────────────┴──────────────────────────────────────┴─────────────────┘
 ```
 
-## Documentação
+## Documentación
 
-A documentação para lançamentos e `main` estão disponíveis aqui:
+La documentación para las versiones publicadas y `main` está disponible aquí:
 
 * [`main`](https://takeshishimada.github.io/Lockman/main/documentation/lockman/)
 * [0.11.0](https://takeshishimada.github.io/Lockman/0.11.0/documentation/lockman/)
@@ -163,7 +163,7 @@ A documentação para lançamentos e `main` estão disponíveis aqui:
 * [0.8.0](https://takeshishimada.github.io/Lockman/0.8.0/documentation/lockman/)
 
 <details>
-<summary>Outras versões</summary>
+<summary>Otras versiones</summary>
 
 * [0.7.0](https://takeshishimada.github.io/Lockman/0.7.0/documentation/lockman/)
 * [0.6.0](https://takeshishimada.github.io/Lockman/0.6.0/documentation/lockman/)
@@ -173,35 +173,35 @@ A documentação para lançamentos e `main` estão disponíveis aqui:
 
 </details>
 
-Existem vários artigos na documentação que você pode achar úteis à medida que se familiariza com a biblioteca:
+Hay varios artículos en la documentación que pueden resultarte útiles a medida que te familiarizas con la biblioteca:
 
-### Essenciais
-* [Começando](https://takeshishimada.github.io/Lockman/main/documentation/lockman/gettingstarted) - Aprenda como integrar Lockman em sua aplicação TCA
-* [Visão Geral de Limites](https://takeshishimada.github.io/Lockman/main/documentation/lockman/boundaryoverview) - Entenda o conceito de limites em Lockman
-* [Bloquear](https://takeshishimada.github.io/Lockman/main/documentation/lockman/lock) - Entendendo o mecanismo de bloqueio
-* [Desbloquear](https://takeshishimada.github.io/Lockman/main/documentation/lockman/unlock) - Entendendo o mecanismo de desbloqueio
-* [Escolhendo uma Estratégia](https://takeshishimada.github.io/Lockman/main/documentation/lockman/choosingstrategy) - Selecione a estratégia certa para seu caso de uso
-* [Configuração](https://takeshishimada.github.io/Lockman/main/documentation/lockman/configuration) - Configure Lockman para as necessidades de sua aplicação
-* [Tratamento de Erros](https://takeshishimada.github.io/Lockman/main/documentation/lockman/errorhandling) - Aprenda sobre padrões comuns de tratamento de erros
-* [Guia de Depuração](https://takeshishimada.github.io/Lockman/main/documentation/lockman/debuggingguide) - Depure problemas relacionados ao Lockman em sua aplicação
+### Esenciales
+* [Primeros Pasos](https://takeshishimada.github.io/Lockman/main/documentation/lockman/gettingstarted) - Aprende cómo integrar Lockman en tu aplicación TCA
+* [Descripción General de Límites](https://takeshishimada.github.io/Lockman/main/documentation/lockman/boundaryoverview) - Comprende el concepto de límites en Lockman
+* [Bloqueo](https://takeshishimada.github.io/Lockman/main/documentation/lockman/lock) - Comprensión del mecanismo de bloqueo
+* [Desbloqueo](https://takeshishimada.github.io/Lockman/main/documentation/lockman/unlock) - Comprensión del mecanismo de desbloqueo
+* [Elegir una Estrategia](https://takeshishimada.github.io/Lockman/main/documentation/lockman/choosingstrategy) - Selecciona la estrategia correcta para tu caso de uso
+* [Configuración](https://takeshishimada.github.io/Lockman/main/documentation/lockman/configuration) - Configura Lockman para las necesidades de tu aplicación
+* [Manejo de Errores](https://takeshishimada.github.io/Lockman/main/documentation/lockman/errorhandling) - Aprende sobre patrones comunes de manejo de errores
+* [Guía de Depuración](https://takeshishimada.github.io/Lockman/main/documentation/lockman/debuggingguide) - Depura problemas relacionados con Lockman en tu aplicación
 
-### Estratégias
-* [Estratégia de Execução Única](https://takeshishimada.github.io/Lockman/main/documentation/lockman/singleexecutionstrategy) - Previne execução duplicada
-* [Estratégia Baseada em Prioridade](https://takeshishimada.github.io/Lockman/main/documentation/lockman/prioritybasedstrategy) - Controle baseado em prioridade
-* [Estratégia de Concorrência Limitada](https://takeshishimada.github.io/Lockman/main/documentation/lockman/concurrencylimitedstrategy) - Limita execuções concorrentes
-* [Estratégia de Coordenação de Grupo](https://takeshishimada.github.io/Lockman/main/documentation/lockman/groupcoordinationstrategy) - Coordena ações relacionadas
-* [Estratégia de Condição Dinâmica](https://takeshishimada.github.io/Lockman/main/documentation/lockman/dynamicconditionstrategy) - Controle dinâmico em tempo de execução
-* [Estratégia Composta](https://takeshishimada.github.io/Lockman/main/documentation/lockman/compositestrategy) - Combina múltiplas estratégias
+### Estrategias
+* [Single Execution Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/singleexecutionstrategy) - Prevenir ejecución duplicada
+* [Priority Based Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/prioritybasedstrategy) - Control basado en prioridad
+* [Concurrency Limited Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/concurrencylimitedstrategy) - Limitar ejecuciones concurrentes
+* [Group Coordination Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/groupcoordinationstrategy) - Coordinar acciones relacionadas
+* [Dynamic Condition Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/dynamicconditionstrategy) - Control dinámico en tiempo de ejecución
+* [Composite Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/compositestrategy) - Combinar múltiples estrategias
 
-Nota: A documentação está disponível apenas em inglês.
+Nota: La documentación está disponible solo en inglés.
 
-## Instalação
+## Instalación
 
-Lockman pode ser instalado usando [Swift Package Manager](https://swift.org/package-manager/).
+Lockman se puede instalar usando [Swift Package Manager](https://swift.org/package-manager/).
 
 ### Xcode
 
-No Xcode, selecione File → Add Package Dependencies e insira a seguinte URL:
+En Xcode, selecciona File → Add Package Dependencies e ingresa la siguiente URL:
 
 ```
 https://github.com/takeshishimada/Lockman
@@ -209,7 +209,7 @@ https://github.com/takeshishimada/Lockman
 
 ### Package.swift
 
-Adicione a dependência ao seu arquivo Package.swift:
+Agrega la dependencia a tu archivo Package.swift:
 
 ```swift
 dependencies: [
@@ -217,7 +217,7 @@ dependencies: [
 ]
 ```
 
-Adicione a dependência ao seu alvo:
+Agrega la dependencia a tu objetivo:
 
 ```swift
 .target(
@@ -230,14 +230,14 @@ Adicione a dependência ao seu alvo:
 
 ### Requisitos
 
-| Plataforma | Versão Mínima |
-|------------|---------------|
-| iOS        | 13.0          |
-| macOS      | 10.15         |
-| tvOS       | 13.0          |
-| watchOS    | 6.0           |
+| Plataforma | Versión Mínima |
+|------------|----------------|
+| iOS        | 13.0           |
+| macOS      | 10.15          |
+| tvOS       | 13.0           |
+| watchOS    | 6.0            |
 
-### Compatibilidade de Versão
+### Compatibilidad de Versiones
 
 | Lockman | The Composable Architecture |
 |---------|----------------------------|
@@ -246,7 +246,7 @@ Adicione a dependência ao seu alvo:
 | 0.9.0   | 1.18.0                     |
 
 <details>
-<summary>Outras versões</summary>
+<summary>Otras versiones</summary>
 
 | Lockman | The Composable Architecture |
 |---------|----------------------------|
@@ -262,20 +262,20 @@ Adicione a dependência ao seu alvo:
 
 </details>
 
-## Comunidade
+## Comunidad
 
-### Discussão e Ajuda
+### Discusión y Ayuda
 
-Perguntas e discussões podem ser realizadas no [GitHub Discussions](https://github.com/takeshishimada/Lockman/discussions).
+Las preguntas y discusiones se pueden realizar en [GitHub Discussions](https://github.com/takeshishimada/Lockman/discussions).
 
-### Relatórios de Bugs
+### Reporte de Errores
 
-Se você encontrar um bug, por favor reporte em [Issues](https://github.com/takeshishimada/Lockman/issues).
+Si encuentras un error, por favor repórtalo en [Issues](https://github.com/takeshishimada/Lockman/issues).
 
-### Contribuindo
+### Contribuir
 
-Se você gostaria de contribuir para a biblioteca, por favor abra um PR com um link para ele!
+¡Si deseas contribuir a la biblioteca, abre un PR con un enlace a él!
 
-## Licença
+## Licencia
 
-Esta biblioteca é lançada sob a Licença MIT. Veja o arquivo [LICENSE](./LICENSE) para detalhes.
+Esta biblioteca se publica bajo la licencia MIT. Consulta el archivo [LICENSE](./LICENSE) para más detalles.

--- a/Docs/README_fr.md
+++ b/Docs/README_fr.md
@@ -1,58 +1,58 @@
-<img src="Lockman.png" alt="Lockman Logo" width="400">
+<img src="../Lockman.png" alt="Lockman Logo" width="400">
 
 [![CI](https://github.com/takeshishimada/Lockman/workflows/CI/badge.svg)](https://github.com/takeshishimada/Lockman/actions?query=workflow%3ACI)
 [![Swift](https://img.shields.io/badge/Swift-5.9%20%7C%205.10%20%7C%206.0-ED523F.svg?style=flat)](https://swift.org/download/)
 [![Platforms](https://img.shields.io/badge/Platforms-iOS%20%7C%20macOS%20%7C%20tvOS%20%7C%20watchOS%20%7C%20Mac%20Catalyst-333333.svg?style=flat)](https://developer.apple.com/)
 
-[English](README.md) | [日本語](README_ja.md) | [简体中文](README_zh-CN.md) | [繁體中文](README_zh-TW.md) | [Español](README_es.md) | [Français](README_fr.md) | [Deutsch](README_de.md) | [한국어](README_ko.md) | [Português](README_pt-BR.md) | [Italiano](README_it.md)
+[English](../README.md) | [日本語](README_ja.md) | [简体中文](README_zh-CN.md) | [繁體中文](README_zh-TW.md) | [Español](README_es.md) | [Français](README_fr.md) | [Deutsch](README_de.md) | [한국어](README_ko.md) | [Português](README_pt-BR.md) | [Italiano](README_it.md)
 
-Lockman 是一个 Swift 库，旨在解决 The Composable Architecture (TCA) 应用程序中的并发动作控制问题，注重响应性、透明性和声明式设计。
+Lockman est une bibliothèque Swift qui résout les problèmes de contrôle des actions concurrentes dans les applications The Composable Architecture (TCA), en mettant l'accent sur la réactivité, la transparence et la conception déclarative.
 
-* [设计理念](#设计理念)
-* [概述](#概述)
-* [基本示例](#基本示例)
-* [安装](#安装)
-* [社区](#社区)
+* [Philosophie de Conception](#philosophie-de-conception)
+* [Vue d'Ensemble](#vue-densemble)
+* [Exemple de Base](#exemple-de-base)
+* [Installation](#installation)
+* [Communauté](#communauté)
 
-## 设计理念
+## Philosophie de Conception
 
-### Designing Fluid Interfaces 原则
+### Principes de Designing Fluid Interfaces
 
-WWDC18 的"Designing Fluid Interfaces"提出了卓越界面的原则：
+La présentation "Designing Fluid Interfaces" de WWDC18 a présenté des principes pour des interfaces exceptionnelles :
 
-* **即时响应和持续重定向** - 不允许有 10 毫秒延迟的响应性
-* **一对一的触摸和内容移动** - 拖动操作时内容跟随手指
-* **持续反馈** - 对所有交互的即时反应
-* **并行手势检测** - 同时识别多个手势
-* **空间一致性** - 动画期间保持位置一致性
-* **轻量级交互，放大输出** - 小输入产生大效果
+* **Réponse Immédiate et Redirection Continue** - Une réactivité qui ne tolère pas même 10ms de délai
+* **Mouvement Un-à-Un entre le Toucher et le Contenu** - Le contenu suit le doigt pendant les opérations de glissement
+* **Retour d'Information Continu** - Réaction immédiate à toutes les interactions
+* **Détection de Gestes en Parallèle** - Reconnaissance de plusieurs gestes simultanément
+* **Cohérence Spatiale** - Maintien de la cohérence de position pendant les animations
+* **Interactions Légères, Sortie Amplifiée** - Grands effets à partir de petites entrées
 
-### 传统挑战
+### Défis Traditionnels
 
-传统 UI 开发通过简单地禁止同时按下按钮和重复执行来解决问题。这些方法已成为现代流畅界面设计中阻碍用户体验的因素。
+Le développement d'interface utilisateur traditionnel a résolu les problèmes en interdisant simplement les pressions simultanées de boutons et les exécutions en double. Ces approches sont devenues des facteurs qui entravent l'expérience utilisateur dans la conception moderne d'interfaces fluides.
 
-用户期望即使同时按下按钮也能获得某种形式的反馈。在 UI 层的即时响应与业务逻辑层的适当互斥控制之间进行清晰分离至关重要。
+Les utilisateurs attendent une forme de retour d'information même lorsqu'ils appuient simultanément sur des boutons. Il est crucial de séparer clairement la réponse immédiate au niveau de la couche UI du contrôle d'exclusion mutuelle approprié au niveau de la couche de logique métier.
 
-## 概述
+## Vue d'Ensemble
 
-Lockman 提供以下控制策略来解决应用开发中的常见问题：
+Lockman fournit les stratégies de contrôle suivantes pour résoudre les problèmes courants dans le développement d'applications :
 
-* **Single Execution**：防止相同动作的重复执行
-* **Priority Based**：基于优先级的动作控制和取消
-* **Group Coordination**：通过领导者/成员角色进行组控制
-* **Dynamic Condition**：基于运行时条件的动态控制
-* **Concurrency Limited**：限制每组的并发执行数量
-* **Composite Strategy**：多种策略的组合
+* **Single Execution** : Empêche l'exécution en double de la même action
+* **Priority Based** : Contrôle et annulation d'actions basés sur la priorité
+* **Group Coordination** : Contrôle de groupe via les rôles leader/membre
+* **Dynamic Condition** : Contrôle dynamique basé sur les conditions d'exécution
+* **Concurrency Limited** : Limite le nombre d'exécutions concurrentes par groupe
+* **Composite Strategy** : Combinaison de plusieurs stratégies
 
-## 示例
+## Exemples
 
 | Single Execution Strategy | Priority Based Strategy | Concurrency Limited Strategy |
 |--------------------------|------------------------|------------------------------|
-| ![Single Execution Strategy](Sources/Lockman/Documentation.docc/images/01-SingleExecutionStrategy.gif) | ![Priority Based Strategy](Sources/Lockman/Documentation.docc/images/02-PriorityBasedStrategy.gif) | ![Concurrency Limited Strategy](Sources/Lockman/Documentation.docc/images/03-ConcurrencyLimitedStrategy.gif) |
+| ![Single Execution Strategy](../Sources/Lockman/Documentation.docc/images/01-SingleExecutionStrategy.gif) | ![Priority Based Strategy](../Sources/Lockman/Documentation.docc/images/02-PriorityBasedStrategy.gif) | ![Concurrency Limited Strategy](../Sources/Lockman/Documentation.docc/images/03-ConcurrencyLimitedStrategy.gif) |
 
-## 代码示例
+## Exemple de Code
 
-以下是如何使用 `@LockmanSingleExecution` 宏实现防止进程重复执行的功能：
+Voici comment implémenter une fonctionnalité qui empêche l'exécution en double de processus en utilisant la macro `@LockmanSingleExecution` :
 
 ```swift
 import ComposableArchitecture
@@ -129,9 +129,9 @@ struct ProcessFeature {
 }
 ```
 
-`withLock` 方法确保在处理进行中时不会执行 `startProcessButtonTapped`，即使用户多次点击按钮也能防止重复操作。
+La méthode `withLock` garantit que `startProcessButtonTapped` ne s'exécutera pas pendant que le traitement est en cours, empêchant les opérations en double même si l'utilisateur appuie plusieurs fois sur le bouton.
 
-### 调试输出示例
+### Exemple de Sortie de Débogage
 
 ```
 ✅ [Lockman] canLock succeeded - Strategy: SingleExecution, BoundaryId: process, Info: LockmanSingleExecutionInfo(actionId: 'startProcessButtonTapped', uniqueId: 7BFC785A-3D25-4722-B9BC-A3A63A7F49FC, mode: boundary)
@@ -152,9 +152,9 @@ struct ProcessFeature {
 └─────────────────┴──────────────────┴──────────────────────────────────────┴─────────────────┘
 ```
 
-## 文档
+## Documentation
 
-发布版本和 `main` 分支的文档可在此处获取：
+La documentation pour les versions publiées et `main` est disponible ici :
 
 * [`main`](https://takeshishimada.github.io/Lockman/main/documentation/lockman/)
 * [0.11.0](https://takeshishimada.github.io/Lockman/0.11.0/documentation/lockman/)
@@ -163,7 +163,7 @@ struct ProcessFeature {
 * [0.8.0](https://takeshishimada.github.io/Lockman/0.8.0/documentation/lockman/)
 
 <details>
-<summary>其他版本</summary>
+<summary>Autres versions</summary>
 
 * [0.7.0](https://takeshishimada.github.io/Lockman/0.7.0/documentation/lockman/)
 * [0.6.0](https://takeshishimada.github.io/Lockman/0.6.0/documentation/lockman/)
@@ -173,35 +173,35 @@ struct ProcessFeature {
 
 </details>
 
-文档中有许多文章可以帮助您更好地使用该库：
+Il existe plusieurs articles dans la documentation qui peuvent vous être utiles pour vous familiariser avec la bibliothèque :
 
-### 基础知识
-* [入门指南](https://takeshishimada.github.io/Lockman/main/documentation/lockman/gettingstarted) - 了解如何将 Lockman 集成到您的 TCA 应用程序中
-* [边界概述](https://takeshishimada.github.io/Lockman/main/documentation/lockman/boundaryoverview) - 理解 Lockman 中的边界概念
-* [锁定](https://takeshishimada.github.io/Lockman/main/documentation/lockman/lock) - 理解锁定机制
-* [解锁](https://takeshishimada.github.io/Lockman/main/documentation/lockman/unlock) - 理解解锁机制
-* [选择策略](https://takeshishimada.github.io/Lockman/main/documentation/lockman/choosingstrategy) - 为您的用例选择合适的策略
-* [配置](https://takeshishimada.github.io/Lockman/main/documentation/lockman/configuration) - 根据应用程序需求配置 Lockman
-* [错误处理](https://takeshishimada.github.io/Lockman/main/documentation/lockman/errorhandling) - 了解常见的错误处理模式
-* [调试指南](https://takeshishimada.github.io/Lockman/main/documentation/lockman/debuggingguide) - 调试应用程序中与 Lockman 相关的问题
+### Essentiels
+* [Démarrage](https://takeshishimada.github.io/Lockman/main/documentation/lockman/gettingstarted) - Apprenez à intégrer Lockman dans votre application TCA
+* [Vue d'Ensemble des Limites](https://takeshishimada.github.io/Lockman/main/documentation/lockman/boundaryoverview) - Comprendre le concept de limites dans Lockman
+* [Verrouillage](https://takeshishimada.github.io/Lockman/main/documentation/lockman/lock) - Comprendre le mécanisme de verrouillage
+* [Déverrouillage](https://takeshishimada.github.io/Lockman/main/documentation/lockman/unlock) - Comprendre le mécanisme de déverrouillage
+* [Choisir une Stratégie](https://takeshishimada.github.io/Lockman/main/documentation/lockman/choosingstrategy) - Sélectionnez la bonne stratégie pour votre cas d'utilisation
+* [Configuration](https://takeshishimada.github.io/Lockman/main/documentation/lockman/configuration) - Configurez Lockman pour les besoins de votre application
+* [Gestion des Erreurs](https://takeshishimada.github.io/Lockman/main/documentation/lockman/errorhandling) - Apprenez les modèles courants de gestion des erreurs
+* [Guide de Débogage](https://takeshishimada.github.io/Lockman/main/documentation/lockman/debuggingguide) - Déboguez les problèmes liés à Lockman dans votre application
 
-### 策略
-* [Single Execution Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/singleexecutionstrategy) - 防止重复执行
-* [Priority Based Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/prioritybasedstrategy) - 基于优先级的控制
-* [Concurrency Limited Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/concurrencylimitedstrategy) - 限制并发执行
-* [Group Coordination Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/groupcoordinationstrategy) - 协调相关动作
-* [Dynamic Condition Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/dynamicconditionstrategy) - 动态运行时控制
-* [Composite Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/compositestrategy) - 组合多种策略
+### Stratégies
+* [Single Execution Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/singleexecutionstrategy) - Empêcher l'exécution en double
+* [Priority Based Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/prioritybasedstrategy) - Contrôle basé sur la priorité
+* [Concurrency Limited Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/concurrencylimitedstrategy) - Limiter les exécutions concurrentes
+* [Group Coordination Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/groupcoordinationstrategy) - Coordonner les actions liées
+* [Dynamic Condition Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/dynamicconditionstrategy) - Contrôle dynamique à l'exécution
+* [Composite Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/compositestrategy) - Combiner plusieurs stratégies
 
-注：文档仅提供英文版本。
+Note : La documentation est disponible uniquement en anglais.
 
-## 安装
+## Installation
 
-Lockman 可以使用 [Swift Package Manager](https://swift.org/package-manager/) 进行安装。
+Lockman peut être installé en utilisant [Swift Package Manager](https://swift.org/package-manager/).
 
 ### Xcode
 
-在 Xcode 中，选择 File → Add Package Dependencies 并输入以下 URL：
+Dans Xcode, sélectionnez File → Add Package Dependencies et entrez l'URL suivante :
 
 ```
 https://github.com/takeshishimada/Lockman
@@ -209,7 +209,7 @@ https://github.com/takeshishimada/Lockman
 
 ### Package.swift
 
-将依赖项添加到您的 Package.swift 文件中：
+Ajoutez la dépendance à votre fichier Package.swift :
 
 ```swift
 dependencies: [
@@ -217,7 +217,7 @@ dependencies: [
 ]
 ```
 
-将依赖项添加到您的目标中：
+Ajoutez la dépendance à votre cible :
 
 ```swift
 .target(
@@ -228,16 +228,16 @@ dependencies: [
 )
 ```
 
-### 系统要求
+### Configuration Requise
 
-| 平台      | 最低版本 |
-|----------|---------|
-| iOS      | 13.0    |
-| macOS    | 10.15   |
-| tvOS     | 13.0    |
-| watchOS  | 6.0     |
+| Plateforme | Version Minimale |
+|------------|------------------|
+| iOS        | 13.0             |
+| macOS      | 10.15            |
+| tvOS       | 13.0             |
+| watchOS    | 6.0              |
 
-### 版本兼容性
+### Compatibilité des Versions
 
 | Lockman | The Composable Architecture |
 |---------|----------------------------|
@@ -246,7 +246,7 @@ dependencies: [
 | 0.9.0   | 1.18.0                     |
 
 <details>
-<summary>其他版本</summary>
+<summary>Autres versions</summary>
 
 | Lockman | The Composable Architecture |
 |---------|----------------------------|
@@ -262,20 +262,20 @@ dependencies: [
 
 </details>
 
-## 社区
+## Communauté
 
-### 讨论和帮助
+### Discussion et Aide
 
-可以在 [GitHub Discussions](https://github.com/takeshishimada/Lockman/discussions) 上进行问题讨论。
+Les questions et discussions peuvent être tenues sur [GitHub Discussions](https://github.com/takeshishimada/Lockman/discussions).
 
-### 错误报告
+### Rapports de Bogues
 
-如果发现错误，请在 [Issues](https://github.com/takeshishimada/Lockman/issues) 上报告。
+Si vous trouvez un bogue, veuillez le signaler sur [Issues](https://github.com/takeshishimada/Lockman/issues).
 
-### 贡献
+### Contribution
 
-如果您想为该库做出贡献，请创建一个 PR 并附上相关链接！
+Si vous souhaitez contribuer à la bibliothèque, veuillez ouvrir une PR avec un lien vers celle-ci !
 
-## 许可证
+## Licence
 
-本库基于 MIT 许可证发布。详情请参阅 [LICENSE](./LICENSE) 文件。
+Cette bibliothèque est publiée sous la licence MIT. Consultez le fichier [LICENSE](./LICENSE) pour plus de détails.

--- a/Docs/README_it.md
+++ b/Docs/README_it.md
@@ -1,58 +1,58 @@
-<img src="Lockman.png" alt="Lockman Logo" width="400">
+<img src="../Lockman.png" alt="Lockman Logo" width="400">
 
 [![CI](https://github.com/takeshishimada/Lockman/workflows/CI/badge.svg)](https://github.com/takeshishimada/Lockman/actions?query=workflow%3ACI)
 [![Swift](https://img.shields.io/badge/Swift-5.9%20%7C%205.10%20%7C%206.0-ED523F.svg?style=flat)](https://swift.org/download/)
 [![Platforms](https://img.shields.io/badge/Platforms-iOS%20%7C%20macOS%20%7C%20tvOS%20%7C%20watchOS%20%7C%20Mac%20Catalyst-333333.svg?style=flat)](https://developer.apple.com/)
 
-[English](README.md) | [日本語](README_ja.md) | [简体中文](README_zh-CN.md) | [繁體中文](README_zh-TW.md) | [Español](README_es.md) | [Français](README_fr.md) | [Deutsch](README_de.md) | [한국어](README_ko.md) | [Português](README_pt-BR.md) | [Italiano](README_it.md)
+[English](../README.md) | [日本語](README_ja.md) | [简体中文](README_zh-CN.md) | [繁體中文](README_zh-TW.md) | [Español](README_es.md) | [Français](README_fr.md) | [Deutsch](README_de.md) | [한국어](README_ko.md) | [Português](README_pt-BR.md) | [Italiano](README_it.md)
 
-Lockman ist eine Swift-Bibliothek, die Probleme bei der Kontrolle konkurrierender Aktionen in The Composable Architecture (TCA) Anwendungen löst, mit Fokus auf Reaktionsfähigkeit, Transparenz und deklaratives Design.
+Lockman è una libreria Swift che risolve i problemi di controllo delle azioni concorrenti nelle applicazioni The Composable Architecture (TCA), con reattività, trasparenza e design dichiarativo in mente.
 
-* [Design-Philosophie](#design-philosophie)
-* [Überblick](#überblick)
-* [Grundlegendes Beispiel](#grundlegendes-beispiel)
-* [Installation](#installation)
-* [Community](#community)
+* [Filosofia di Design](#filosofia-di-design)
+* [Panoramica](#panoramica)
+* [Esempio Base](#esempio-base)
+* [Installazione](#installazione)
+* [Comunità](#comunità)
 
-## Design-Philosophie
+## Filosofia di Design
 
-### Designing Fluid Interfaces Prinzipien
+### Principi di Designing Fluid Interfaces
 
-Die Präsentation "Designing Fluid Interfaces" der WWDC18 stellte Prinzipien für außergewöhnliche Schnittstellen vor:
+"Designing Fluid Interfaces" della WWDC18 ha presentato principi per interfacce eccezionali:
 
-* **Sofortige Reaktion und kontinuierliche Umleitung** - Reaktionsfähigkeit, die nicht einmal 10ms Verzögerung toleriert
-* **Eins-zu-Eins-Bewegung zwischen Berührung und Inhalt** - Inhalt folgt dem Finger während Ziehvorgängen
-* **Kontinuierliches Feedback** - Sofortige Reaktion auf alle Interaktionen
-* **Parallele Gestenerkennung** - Gleichzeitige Erkennung mehrerer Gesten
-* **Räumliche Konsistenz** - Beibehaltung der Positionskonsistenz während Animationen
-* **Leichte Interaktionen, verstärkte Ausgabe** - Große Effekte aus kleinen Eingaben
+* **Risposta Immediata e Reindirizzamento Continuo** - Reattività che non permette nemmeno 10ms di ritardo
+* **Movimento di Tocco e Contenuto Uno-a-Uno** - Il contenuto segue il dito durante le operazioni di trascinamento
+* **Feedback Continuo** - Reazione immediata a tutte le interazioni
+* **Rilevamento di Gesti Paralleli** - Riconoscimento di più gesti simultaneamente
+* **Coerenza Spaziale** - Mantenimento della coerenza di posizione durante le animazioni
+* **Interazioni Leggere, Output Amplificato** - Grandi effetti da piccoli input
 
-### Traditionelle Herausforderungen
+### Sfide Tradizionali
 
-Die traditionelle UI-Entwicklung löste Probleme, indem sie gleichzeitige Tasteneingaben und doppelte Ausführungen einfach verbot. Diese Ansätze wurden zu Faktoren, die die Benutzererfahrung im modernen flüssigen Interface-Design behindern.
+Lo sviluppo tradizionale dell'UI ha risolto i problemi semplicemente proibendo pressioni simultanee di pulsanti ed esecuzioni duplicate. Questi approcci sono diventati fattori che ostacolano l'esperienza utente nel moderno design di interfacce fluide.
 
-Benutzer erwarten eine Form von Feedback, auch wenn sie gleichzeitig Tasten drücken. Es ist entscheidend, die sofortige Reaktion auf UI-Ebene klar von der angemessenen gegenseitigen Ausschlusskontrolle auf Geschäftslogikebene zu trennen.
+Gli utenti si aspettano qualche forma di feedback anche quando premono i pulsanti simultaneamente. È cruciale separare chiaramente la risposta immediata al livello UI dal controllo appropriato di esclusione reciproca al livello della logica di business.
 
-## Überblick
+## Panoramica
 
-Lockman bietet die folgenden Kontrollstrategien zur Lösung häufiger Probleme in der Anwendungsentwicklung:
+Lockman fornisce le seguenti strategie di controllo per affrontare problemi comuni nello sviluppo di app:
 
-* **Single Execution**: Verhindert doppelte Ausführung derselben Aktion
-* **Priority Based**: Prioritätsbasierte Aktionskontrolle und -stornierung
-* **Group Coordination**: Gruppenkontrolle über Leader/Member-Rollen
-* **Dynamic Condition**: Dynamische Kontrolle basierend auf Ausführungsbedingungen
-* **Concurrency Limited**: Begrenzt die Anzahl gleichzeitiger Ausführungen pro Gruppe
-* **Composite Strategy**: Kombination mehrerer Strategien
+* **Esecuzione Singola**: Previene l'esecuzione duplicata della stessa azione
+* **Basata su Priorità**: Controllo e cancellazione delle azioni basata su priorità
+* **Coordinamento di Gruppo**: Controllo di gruppo attraverso ruoli leader/membro
+* **Condizione Dinamica**: Controllo dinamico basato su condizioni runtime
+* **Concorrenza Limitata**: Limita il numero di esecuzioni concorrenti per gruppo
+* **Strategia Composita**: Combinazione di più strategie
 
-## Beispiele
+## Esempi
 
-| Single Execution Strategy | Priority Based Strategy | Concurrency Limited Strategy |
-|--------------------------|------------------------|------------------------------|
-| ![Single Execution Strategy](Sources/Lockman/Documentation.docc/images/01-SingleExecutionStrategy.gif) | ![Priority Based Strategy](Sources/Lockman/Documentation.docc/images/02-PriorityBasedStrategy.gif) | ![Concurrency Limited Strategy](Sources/Lockman/Documentation.docc/images/03-ConcurrencyLimitedStrategy.gif) |
+| Strategia di Esecuzione Singola | Strategia Basata su Priorità | Strategia di Concorrenza Limitata |
+|----------------------------------|------------------------------|-----------------------------------|
+| ![Strategia di Esecuzione Singola](../Sources/Lockman/Documentation.docc/images/01-SingleExecutionStrategy.gif) | ![Strategia Basata su Priorità](../Sources/Lockman/Documentation.docc/images/02-PriorityBasedStrategy.gif) | ![Strategia di Concorrenza Limitata](../Sources/Lockman/Documentation.docc/images/03-ConcurrencyLimitedStrategy.gif) |
 
-## Code-Beispiel
+## Esempio di Codice
 
-So implementieren Sie eine Funktion, die doppelte Prozessausführung mit dem `@LockmanSingleExecution` Makro verhindert:
+Ecco come implementare una funzionalità che previene l'esecuzione duplicata di processi usando il macro `@LockmanSingleExecution`:
 
 ```swift
 import ComposableArchitecture
@@ -129,9 +129,9 @@ struct ProcessFeature {
 }
 ```
 
-Die `withLock` Methode stellt sicher, dass `startProcessButtonTapped` nicht ausgeführt wird, während die Verarbeitung läuft, wodurch doppelte Operationen verhindert werden, auch wenn der Benutzer mehrmals auf die Schaltfläche drückt.
+Il metodo `withLock` garantisce che `startProcessButtonTapped` non verrà eseguito mentre l'elaborazione è in corso, prevenendo operazioni duplicate anche se l'utente tocca il pulsante più volte.
 
-### Debug-Ausgabe Beispiel
+### Esempio di Output di Debug
 
 ```
 ✅ [Lockman] canLock succeeded - Strategy: SingleExecution, BoundaryId: process, Info: LockmanSingleExecutionInfo(actionId: 'startProcessButtonTapped', uniqueId: 7BFC785A-3D25-4722-B9BC-A3A63A7F49FC, mode: boundary)
@@ -152,9 +152,9 @@ Die `withLock` Methode stellt sicher, dass `startProcessButtonTapped` nicht ausg
 └─────────────────┴──────────────────┴──────────────────────────────────────┴─────────────────┘
 ```
 
-## Dokumentation
+## Documentazione
 
-Die Dokumentation für veröffentlichte Versionen und `main` ist hier verfügbar:
+La documentazione per le release e `main` è disponibile qui:
 
 * [`main`](https://takeshishimada.github.io/Lockman/main/documentation/lockman/)
 * [0.11.0](https://takeshishimada.github.io/Lockman/0.11.0/documentation/lockman/)
@@ -163,7 +163,7 @@ Die Dokumentation für veröffentlichte Versionen und `main` ist hier verfügbar
 * [0.8.0](https://takeshishimada.github.io/Lockman/0.8.0/documentation/lockman/)
 
 <details>
-<summary>Weitere Versionen</summary>
+<summary>Altre versioni</summary>
 
 * [0.7.0](https://takeshishimada.github.io/Lockman/0.7.0/documentation/lockman/)
 * [0.6.0](https://takeshishimada.github.io/Lockman/0.6.0/documentation/lockman/)
@@ -173,35 +173,35 @@ Die Dokumentation für veröffentlichte Versionen und `main` ist hier verfügbar
 
 </details>
 
-Es gibt mehrere Artikel in der Dokumentation, die Ihnen beim Einstieg in die Bibliothek helfen können:
+Ci sono numerosi articoli nella documentazione che potresti trovare utili mentre prendi confidenza con la libreria:
 
-### Grundlagen
-* [Erste Schritte](https://takeshishimada.github.io/Lockman/main/documentation/lockman/gettingstarted) - Lernen Sie, wie Sie Lockman in Ihre TCA-Anwendung integrieren
-* [Boundary-Überblick](https://takeshishimada.github.io/Lockman/main/documentation/lockman/boundaryoverview) - Verstehen Sie das Boundary-Konzept in Lockman
-* [Sperren](https://takeshishimada.github.io/Lockman/main/documentation/lockman/lock) - Verstehen Sie den Sperrmechanismus
-* [Entsperren](https://takeshishimada.github.io/Lockman/main/documentation/lockman/unlock) - Verstehen Sie den Entsperrmechanismus
-* [Eine Strategie wählen](https://takeshishimada.github.io/Lockman/main/documentation/lockman/choosingstrategy) - Wählen Sie die richtige Strategie für Ihren Anwendungsfall
-* [Konfiguration](https://takeshishimada.github.io/Lockman/main/documentation/lockman/configuration) - Konfigurieren Sie Lockman für Ihre Anwendungsanforderungen
-* [Fehlerbehandlung](https://takeshishimada.github.io/Lockman/main/documentation/lockman/errorhandling) - Lernen Sie gängige Fehlerbehandlungsmuster
-* [Debugging-Leitfaden](https://takeshishimada.github.io/Lockman/main/documentation/lockman/debuggingguide) - Debuggen Sie Lockman-bezogene Probleme in Ihrer Anwendung
+### Essenziali
+* [Iniziare](https://takeshishimada.github.io/Lockman/main/documentation/lockman/gettingstarted) - Impara come integrare Lockman nella tua applicazione TCA
+* [Panoramica dei Confini](https://takeshishimada.github.io/Lockman/main/documentation/lockman/boundaryoverview) - Comprendi il concetto di confini in Lockman
+* [Lock](https://takeshishimada.github.io/Lockman/main/documentation/lockman/lock) - Comprendere il meccanismo di blocco
+* [Unlock](https://takeshishimada.github.io/Lockman/main/documentation/lockman/unlock) - Comprendere il meccanismo di sblocco
+* [Scegliere una Strategia](https://takeshishimada.github.io/Lockman/main/documentation/lockman/choosingstrategy) - Seleziona la strategia giusta per il tuo caso d'uso
+* [Configurazione](https://takeshishimada.github.io/Lockman/main/documentation/lockman/configuration) - Configura Lockman per le esigenze della tua applicazione
+* [Gestione degli Errori](https://takeshishimada.github.io/Lockman/main/documentation/lockman/errorhandling) - Impara i pattern comuni di gestione degli errori
+* [Guida al Debug](https://takeshishimada.github.io/Lockman/main/documentation/lockman/debuggingguide) - Esegui il debug dei problemi relativi a Lockman nella tua applicazione
 
-### Strategien
-* [Single Execution Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/singleexecutionstrategy) - Doppelte Ausführung verhindern
-* [Priority Based Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/prioritybasedstrategy) - Prioritätsbasierte Kontrolle
-* [Concurrency Limited Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/concurrencylimitedstrategy) - Gleichzeitige Ausführungen begrenzen
-* [Group Coordination Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/groupcoordinationstrategy) - Verwandte Aktionen koordinieren
-* [Dynamic Condition Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/dynamicconditionstrategy) - Dynamische Laufzeitkontrolle
-* [Composite Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/compositestrategy) - Mehrere Strategien kombinieren
+### Strategie
+* [Strategia di Esecuzione Singola](https://takeshishimada.github.io/Lockman/main/documentation/lockman/singleexecutionstrategy) - Previene l'esecuzione duplicata
+* [Strategia Basata su Priorità](https://takeshishimada.github.io/Lockman/main/documentation/lockman/prioritybasedstrategy) - Controllo basato su priorità
+* [Strategia di Concorrenza Limitata](https://takeshishimada.github.io/Lockman/main/documentation/lockman/concurrencylimitedstrategy) - Limita le esecuzioni concorrenti
+* [Strategia di Coordinamento di Gruppo](https://takeshishimada.github.io/Lockman/main/documentation/lockman/groupcoordinationstrategy) - Coordina le azioni correlate
+* [Strategia di Condizione Dinamica](https://takeshishimada.github.io/Lockman/main/documentation/lockman/dynamicconditionstrategy) - Controllo dinamico runtime
+* [Strategia Composita](https://takeshishimada.github.io/Lockman/main/documentation/lockman/compositestrategy) - Combina più strategie
 
-Hinweis: Die Dokumentation ist nur auf Englisch verfügbar.
+Nota: La documentazione è disponibile solo in inglese.
 
-## Installation
+## Installazione
 
-Lockman kann über den [Swift Package Manager](https://swift.org/package-manager/) installiert werden.
+Lockman può essere installato usando [Swift Package Manager](https://swift.org/package-manager/).
 
 ### Xcode
 
-Wählen Sie in Xcode File → Add Package Dependencies und geben Sie die folgende URL ein:
+In Xcode, seleziona File → Add Package Dependencies e inserisci il seguente URL:
 
 ```
 https://github.com/takeshishimada/Lockman
@@ -209,7 +209,7 @@ https://github.com/takeshishimada/Lockman
 
 ### Package.swift
 
-Fügen Sie die Abhängigkeit zu Ihrer Package.swift-Datei hinzu:
+Aggiungi la dipendenza al tuo file Package.swift:
 
 ```swift
 dependencies: [
@@ -217,7 +217,7 @@ dependencies: [
 ]
 ```
 
-Fügen Sie die Abhängigkeit zu Ihrem Target hinzu:
+Aggiungi la dipendenza al tuo target:
 
 ```swift
 .target(
@@ -228,16 +228,16 @@ Fügen Sie die Abhängigkeit zu Ihrem Target hinzu:
 )
 ```
 
-### Anforderungen
+### Requisiti
 
-| Plattform | Mindestversion |
-|-----------|----------------|
-| iOS       | 13.0           |
-| macOS     | 10.15          |
-| tvOS      | 13.0           |
-| watchOS   | 6.0            |
+| Piattaforma | Versione Minima |
+|-------------|-----------------|
+| iOS         | 13.0            |
+| macOS       | 10.15           |
+| tvOS        | 13.0            |
+| watchOS     | 6.0             |
 
-### Versionskompatibilität
+### Compatibilità delle Versioni
 
 | Lockman | The Composable Architecture |
 |---------|----------------------------|
@@ -246,7 +246,7 @@ Fügen Sie die Abhängigkeit zu Ihrem Target hinzu:
 | 0.9.0   | 1.18.0                     |
 
 <details>
-<summary>Weitere Versionen</summary>
+<summary>Altre versioni</summary>
 
 | Lockman | The Composable Architecture |
 |---------|----------------------------|
@@ -262,20 +262,20 @@ Fügen Sie die Abhängigkeit zu Ihrem Target hinzu:
 
 </details>
 
-## Community
+## Comunità
 
-### Diskussion und Hilfe
+### Discussione e Aiuto
 
-Fragen und Diskussionen können in [GitHub Discussions](https://github.com/takeshishimada/Lockman/discussions) geführt werden.
+Domande e discussioni possono essere tenute su [GitHub Discussions](https://github.com/takeshishimada/Lockman/discussions).
 
-### Fehlerberichte
+### Segnalazioni di Bug
 
-Wenn Sie einen Fehler finden, melden Sie ihn bitte unter [Issues](https://github.com/takeshishimada/Lockman/issues).
+Se trovi un bug, per favore segnalalo su [Issues](https://github.com/takeshishimada/Lockman/issues).
 
-### Beitragen
+### Contribuire
 
-Wenn Sie zur Bibliothek beitragen möchten, öffnen Sie bitte eine PR mit einem Link dazu!
+Se desideri contribuire alla libreria, per favore apri una PR con un link ad essa!
 
-## Lizenz
+## Licenza
 
-Diese Bibliothek wird unter der MIT-Lizenz veröffentlicht. Siehe [LICENSE](./LICENSE) Datei für Details.
+Questa libreria è rilasciata sotto licenza MIT. Vedi il file [LICENSE](./LICENSE) per i dettagli.

--- a/Docs/README_ja.md
+++ b/Docs/README_ja.md
@@ -1,10 +1,10 @@
-<img src="Lockman.png" alt="Lockman Logo" width="400">
+<img src="../Lockman.png" alt="Lockman Logo" width="400">
 
 [![CI](https://github.com/takeshishimada/Lockman/workflows/CI/badge.svg)](https://github.com/takeshishimada/Lockman/actions?query=workflow%3ACI)
 [![Swift](https://img.shields.io/badge/Swift-5.9%20%7C%205.10%20%7C%206.0-ED523F.svg?style=flat)](https://swift.org/download/)
 [![Platforms](https://img.shields.io/badge/Platforms-iOS%20%7C%20macOS%20%7C%20tvOS%20%7C%20watchOS%20%7C%20Mac%20Catalyst-333333.svg?style=flat)](https://developer.apple.com/)
 
-[English](README.md) | [日本語](README_ja.md) | [简体中文](README_zh-CN.md) | [繁體中文](README_zh-TW.md) | [Español](README_es.md) | [Français](README_fr.md) | [Deutsch](README_de.md) | [한국어](README_ko.md) | [Português](README_pt-BR.md) | [Italiano](README_it.md)
+[English](../README.md) | [日本語](README_ja.md) | [简体中文](README_zh-CN.md) | [繁體中文](README_zh-TW.md) | [Español](README_es.md) | [Français](README_fr.md) | [Deutsch](README_de.md) | [한국어](README_ko.md) | [Português](README_pt-BR.md) | [Italiano](README_it.md)
 
 LockmanはThe Composable Architecture（TCA）アプリケーションにおける並行アクションの制御問題を解決するSwiftライブラリです。応答性、透明性、宣言的設計を重視しています。
 
@@ -48,7 +48,7 @@ Lockmanは以下の制御戦略を提供し、実際のアプリ開発で頻繁�
 
 | Single Execution Strategy | Priority Based Strategy | Concurrency Limited Strategy |
 |--------------------------|------------------------|------------------------------|
-| ![Single Execution Strategy](Sources/Lockman/Documentation.docc/images/01-SingleExecutionStrategy.gif) | ![Priority Based Strategy](Sources/Lockman/Documentation.docc/images/02-PriorityBasedStrategy.gif) | ![Concurrency Limited Strategy](Sources/Lockman/Documentation.docc/images/03-ConcurrencyLimitedStrategy.gif) |
+| ![Single Execution Strategy](../Sources/Lockman/Documentation.docc/images/01-SingleExecutionStrategy.gif) | ![Priority Based Strategy](../Sources/Lockman/Documentation.docc/images/02-PriorityBasedStrategy.gif) | ![Concurrency Limited Strategy](../Sources/Lockman/Documentation.docc/images/03-ConcurrencyLimitedStrategy.gif) |
 
 ## コード例
 

--- a/Docs/README_ko.md
+++ b/Docs/README_ko.md
@@ -1,58 +1,58 @@
-<img src="Lockman.png" alt="Lockman Logo" width="400">
+<img src="../Lockman.png" alt="Lockman Logo" width="400">
 
 [![CI](https://github.com/takeshishimada/Lockman/workflows/CI/badge.svg)](https://github.com/takeshishimada/Lockman/actions?query=workflow%3ACI)
 [![Swift](https://img.shields.io/badge/Swift-5.9%20%7C%205.10%20%7C%206.0-ED523F.svg?style=flat)](https://swift.org/download/)
 [![Platforms](https://img.shields.io/badge/Platforms-iOS%20%7C%20macOS%20%7C%20tvOS%20%7C%20watchOS%20%7C%20Mac%20Catalyst-333333.svg?style=flat)](https://developer.apple.com/)
 
-[English](README.md) | [日本語](README_ja.md) | [简体中文](README_zh-CN.md) | [繁體中文](README_zh-TW.md) | [Español](README_es.md) | [Français](README_fr.md) | [Deutsch](README_de.md) | [한국어](README_ko.md) | [Português](README_pt-BR.md) | [Italiano](README_it.md)
+[English](../README.md) | [日本語](README_ja.md) | [简体中文](README_zh-CN.md) | [繁體中文](README_zh-TW.md) | [Español](README_es.md) | [Français](README_fr.md) | [Deutsch](README_de.md) | [한국어](README_ko.md) | [Português](README_pt-BR.md) | [Italiano](README_it.md)
 
-Lockman è una libreria Swift che risolve i problemi di controllo delle azioni concorrenti nelle applicazioni The Composable Architecture (TCA), con reattività, trasparenza e design dichiarativo in mente.
+Lockman은 The Composable Architecture (TCA) 애플리케이션에서 동시 액션 제어 문제를 해결하는 Swift 라이브러리로, 반응성, 투명성, 선언적 설계에 중점을 둡니다.
 
-* [Filosofia di Design](#filosofia-di-design)
-* [Panoramica](#panoramica)
-* [Esempio Base](#esempio-base)
-* [Installazione](#installazione)
-* [Comunità](#comunità)
+* [설계 철학](#설계-철학)
+* [개요](#개요)
+* [기본 예제](#기본-예제)
+* [설치](#설치)
+* [커뮤니티](#커뮤니티)
 
-## Filosofia di Design
+## 설계 철학
 
-### Principi di Designing Fluid Interfaces
+### Designing Fluid Interfaces 원칙
 
-"Designing Fluid Interfaces" della WWDC18 ha presentato principi per interfacce eccezionali:
+WWDC18의 "Designing Fluid Interfaces" 프레젠테이션은 뛰어난 인터페이스를 위한 원칙을 제시했습니다:
 
-* **Risposta Immediata e Reindirizzamento Continuo** - Reattività che non permette nemmeno 10ms di ritardo
-* **Movimento di Tocco e Contenuto Uno-a-Uno** - Il contenuto segue il dito durante le operazioni di trascinamento
-* **Feedback Continuo** - Reazione immediata a tutte le interazioni
-* **Rilevamento di Gesti Paralleli** - Riconoscimento di più gesti simultaneamente
-* **Coerenza Spaziale** - Mantenimento della coerenza di posizione durante le animazioni
-* **Interazioni Leggere, Output Amplificato** - Grandi effetti da piccoli input
+* **즉각적인 응답과 지속적인 리디렉션** - 10ms의 지연도 허용하지 않는 반응성
+* **터치와 콘텐츠 간의 일대일 움직임** - 드래그 작업 중 콘텐츠가 손가락을 따라감
+* **지속적인 피드백** - 모든 상호작용에 대한 즉각적인 반응
+* **병렬 제스처 감지** - 여러 제스처를 동시에 인식
+* **공간적 일관성** - 애니메이션 중 위치 일관성 유지
+* **가벼운 상호작용, 증폭된 출력** - 작은 입력에서 큰 효과
 
-### Sfide Tradizionali
+### 기존의 과제
 
-Lo sviluppo tradizionale dell'UI ha risolto i problemi semplicemente proibendo pressioni simultanee di pulsanti ed esecuzioni duplicate. Questi approcci sono diventati fattori che ostacolano l'esperienza utente nel moderno design di interfacce fluide.
+기존 UI 개발은 단순히 동시 버튼 누름과 중복 실행을 금지하여 문제를 해결했습니다. 이러한 접근 방식은 현대적인 유동적 인터페이스 설계에서 사용자 경험을 저해하는 요인이 되었습니다.
 
-Gli utenti si aspettano qualche forma di feedback anche quando premono i pulsanti simultaneamente. È cruciale separare chiaramente la risposta immediata al livello UI dal controllo appropriato di esclusione reciproca al livello della logica di business.
+사용자는 동시에 버튼을 누르더라도 어떤 형태의 피드백을 기대합니다. UI 레이어에서의 즉각적인 응답과 비즈니스 로직 레이어에서의 적절한 상호 배제 제어를 명확히 분리하는 것이 중요합니다.
 
-## Panoramica
+## 개요
 
-Lockman fornisce le seguenti strategie di controllo per affrontare problemi comuni nello sviluppo di app:
+Lockman은 애플리케이션 개발의 일반적인 문제를 해결하기 위해 다음과 같은 제어 전략을 제공합니다:
 
-* **Esecuzione Singola**: Previene l'esecuzione duplicata della stessa azione
-* **Basata su Priorità**: Controllo e cancellazione delle azioni basata su priorità
-* **Coordinamento di Gruppo**: Controllo di gruppo attraverso ruoli leader/membro
-* **Condizione Dinamica**: Controllo dinamico basato su condizioni runtime
-* **Concorrenza Limitata**: Limita il numero di esecuzioni concorrenti per gruppo
-* **Strategia Composita**: Combinazione di più strategie
+* **Single Execution**: 동일한 액션의 중복 실행 방지
+* **Priority Based**: 우선순위 기반 액션 제어 및 취소
+* **Group Coordination**: 리더/멤버 역할을 통한 그룹 제어
+* **Dynamic Condition**: 실행 조건에 기반한 동적 제어
+* **Concurrency Limited**: 그룹당 동시 실행 수 제한
+* **Composite Strategy**: 여러 전략 조합
 
-## Esempi
+## 예제
 
-| Strategia di Esecuzione Singola | Strategia Basata su Priorità | Strategia di Concorrenza Limitata |
-|----------------------------------|------------------------------|-----------------------------------|
-| ![Strategia di Esecuzione Singola](Sources/Lockman/Documentation.docc/images/01-SingleExecutionStrategy.gif) | ![Strategia Basata su Priorità](Sources/Lockman/Documentation.docc/images/02-PriorityBasedStrategy.gif) | ![Strategia di Concorrenza Limitata](Sources/Lockman/Documentation.docc/images/03-ConcurrencyLimitedStrategy.gif) |
+| Single Execution Strategy | Priority Based Strategy | Concurrency Limited Strategy |
+|--------------------------|------------------------|------------------------------|
+| ![Single Execution Strategy](../Sources/Lockman/Documentation.docc/images/01-SingleExecutionStrategy.gif) | ![Priority Based Strategy](../Sources/Lockman/Documentation.docc/images/02-PriorityBasedStrategy.gif) | ![Concurrency Limited Strategy](../Sources/Lockman/Documentation.docc/images/03-ConcurrencyLimitedStrategy.gif) |
 
-## Esempio di Codice
+## 코드 예제
 
-Ecco come implementare una funzionalità che previene l'esecuzione duplicata di processi usando il macro `@LockmanSingleExecution`:
+`@LockmanSingleExecution` 매크로를 사용하여 프로세스의 중복 실행을 방지하는 기능을 구현하는 방법입니다:
 
 ```swift
 import ComposableArchitecture
@@ -129,9 +129,9 @@ struct ProcessFeature {
 }
 ```
 
-Il metodo `withLock` garantisce che `startProcessButtonTapped` non verrà eseguito mentre l'elaborazione è in corso, prevenendo operazioni duplicate anche se l'utente tocca il pulsante più volte.
+`withLock` 메서드는 처리가 진행 중일 때 `startProcessButtonTapped`가 실행되지 않도록 보장하여, 사용자가 버튼을 여러 번 눌러도 중복 작업을 방지합니다.
 
-### Esempio di Output di Debug
+### 디버그 출력 예제
 
 ```
 ✅ [Lockman] canLock succeeded - Strategy: SingleExecution, BoundaryId: process, Info: LockmanSingleExecutionInfo(actionId: 'startProcessButtonTapped', uniqueId: 7BFC785A-3D25-4722-B9BC-A3A63A7F49FC, mode: boundary)
@@ -152,9 +152,9 @@ Il metodo `withLock` garantisce che `startProcessButtonTapped` non verrà esegui
 └─────────────────┴──────────────────┴──────────────────────────────────────┴─────────────────┘
 ```
 
-## Documentazione
+## 문서
 
-La documentazione per le release e `main` è disponibile qui:
+출시된 버전과 `main`에 대한 문서는 여기에서 사용할 수 있습니다:
 
 * [`main`](https://takeshishimada.github.io/Lockman/main/documentation/lockman/)
 * [0.11.0](https://takeshishimada.github.io/Lockman/0.11.0/documentation/lockman/)
@@ -163,7 +163,7 @@ La documentazione per le release e `main` è disponibile qui:
 * [0.8.0](https://takeshishimada.github.io/Lockman/0.8.0/documentation/lockman/)
 
 <details>
-<summary>Altre versioni</summary>
+<summary>다른 버전</summary>
 
 * [0.7.0](https://takeshishimada.github.io/Lockman/0.7.0/documentation/lockman/)
 * [0.6.0](https://takeshishimada.github.io/Lockman/0.6.0/documentation/lockman/)
@@ -173,35 +173,35 @@ La documentazione per le release e `main` è disponibile qui:
 
 </details>
 
-Ci sono numerosi articoli nella documentazione che potresti trovare utili mentre prendi confidenza con la libreria:
+라이브러리에 익숙해지는 데 도움이 될 수 있는 여러 문서가 있습니다:
 
-### Essenziali
-* [Iniziare](https://takeshishimada.github.io/Lockman/main/documentation/lockman/gettingstarted) - Impara come integrare Lockman nella tua applicazione TCA
-* [Panoramica dei Confini](https://takeshishimada.github.io/Lockman/main/documentation/lockman/boundaryoverview) - Comprendi il concetto di confini in Lockman
-* [Lock](https://takeshishimada.github.io/Lockman/main/documentation/lockman/lock) - Comprendere il meccanismo di blocco
-* [Unlock](https://takeshishimada.github.io/Lockman/main/documentation/lockman/unlock) - Comprendere il meccanismo di sblocco
-* [Scegliere una Strategia](https://takeshishimada.github.io/Lockman/main/documentation/lockman/choosingstrategy) - Seleziona la strategia giusta per il tuo caso d'uso
-* [Configurazione](https://takeshishimada.github.io/Lockman/main/documentation/lockman/configuration) - Configura Lockman per le esigenze della tua applicazione
-* [Gestione degli Errori](https://takeshishimada.github.io/Lockman/main/documentation/lockman/errorhandling) - Impara i pattern comuni di gestione degli errori
-* [Guida al Debug](https://takeshishimada.github.io/Lockman/main/documentation/lockman/debuggingguide) - Esegui il debug dei problemi relativi a Lockman nella tua applicazione
+### 필수 사항
+* [시작하기](https://takeshishimada.github.io/Lockman/main/documentation/lockman/gettingstarted) - TCA 애플리케이션에 Lockman을 통합하는 방법 알아보기
+* [Boundary 개요](https://takeshishimada.github.io/Lockman/main/documentation/lockman/boundaryoverview) - Lockman의 boundary 개념 이해하기
+* [잠금](https://takeshishimada.github.io/Lockman/main/documentation/lockman/lock) - 잠금 메커니즘 이해하기
+* [잠금 해제](https://takeshishimada.github.io/Lockman/main/documentation/lockman/unlock) - 잠금 해제 메커니즘 이해하기
+* [전략 선택](https://takeshishimada.github.io/Lockman/main/documentation/lockman/choosingstrategy) - 사용 사례에 맞는 전략 선택하기
+* [구성](https://takeshishimada.github.io/Lockman/main/documentation/lockman/configuration) - 애플리케이션 요구 사항에 맞게 Lockman 구성하기
+* [오류 처리](https://takeshishimada.github.io/Lockman/main/documentation/lockman/errorhandling) - 일반적인 오류 처리 패턴 알아보기
+* [디버깅 가이드](https://takeshishimada.github.io/Lockman/main/documentation/lockman/debuggingguide) - 애플리케이션에서 Lockman 관련 문제 디버깅하기
 
-### Strategie
-* [Strategia di Esecuzione Singola](https://takeshishimada.github.io/Lockman/main/documentation/lockman/singleexecutionstrategy) - Previene l'esecuzione duplicata
-* [Strategia Basata su Priorità](https://takeshishimada.github.io/Lockman/main/documentation/lockman/prioritybasedstrategy) - Controllo basato su priorità
-* [Strategia di Concorrenza Limitata](https://takeshishimada.github.io/Lockman/main/documentation/lockman/concurrencylimitedstrategy) - Limita le esecuzioni concorrenti
-* [Strategia di Coordinamento di Gruppo](https://takeshishimada.github.io/Lockman/main/documentation/lockman/groupcoordinationstrategy) - Coordina le azioni correlate
-* [Strategia di Condizione Dinamica](https://takeshishimada.github.io/Lockman/main/documentation/lockman/dynamicconditionstrategy) - Controllo dinamico runtime
-* [Strategia Composita](https://takeshishimada.github.io/Lockman/main/documentation/lockman/compositestrategy) - Combina più strategie
+### 전략
+* [Single Execution Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/singleexecutionstrategy) - 중복 실행 방지
+* [Priority Based Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/prioritybasedstrategy) - 우선순위 기반 제어
+* [Concurrency Limited Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/concurrencylimitedstrategy) - 동시 실행 제한
+* [Group Coordination Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/groupcoordinationstrategy) - 관련 액션 조정
+* [Dynamic Condition Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/dynamicconditionstrategy) - 동적 런타임 제어
+* [Composite Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/compositestrategy) - 여러 전략 결합
 
-Nota: La documentazione è disponibile solo in inglese.
+참고: 문서는 영어로만 제공됩니다.
 
-## Installazione
+## 설치
 
-Lockman può essere installato usando [Swift Package Manager](https://swift.org/package-manager/).
+Lockman은 [Swift Package Manager](https://swift.org/package-manager/)를 사용하여 설치할 수 있습니다.
 
 ### Xcode
 
-In Xcode, seleziona File → Add Package Dependencies e inserisci il seguente URL:
+Xcode에서 File → Add Package Dependencies를 선택하고 다음 URL을 입력하세요:
 
 ```
 https://github.com/takeshishimada/Lockman
@@ -209,7 +209,7 @@ https://github.com/takeshishimada/Lockman
 
 ### Package.swift
 
-Aggiungi la dipendenza al tuo file Package.swift:
+Package.swift 파일에 종속성을 추가하세요:
 
 ```swift
 dependencies: [
@@ -217,7 +217,7 @@ dependencies: [
 ]
 ```
 
-Aggiungi la dipendenza al tuo target:
+타겟에 종속성을 추가하세요:
 
 ```swift
 .target(
@@ -228,16 +228,16 @@ Aggiungi la dipendenza al tuo target:
 )
 ```
 
-### Requisiti
+### 요구 사항
 
-| Piattaforma | Versione Minima |
-|-------------|-----------------|
-| iOS         | 13.0            |
-| macOS       | 10.15           |
-| tvOS        | 13.0            |
-| watchOS     | 6.0             |
+| 플랫폼  | 최소 버전 |
+|---------|-----------|
+| iOS     | 13.0      |
+| macOS   | 10.15     |
+| tvOS    | 13.0      |
+| watchOS | 6.0       |
 
-### Compatibilità delle Versioni
+### 버전 호환성
 
 | Lockman | The Composable Architecture |
 |---------|----------------------------|
@@ -246,7 +246,7 @@ Aggiungi la dipendenza al tuo target:
 | 0.9.0   | 1.18.0                     |
 
 <details>
-<summary>Altre versioni</summary>
+<summary>다른 버전</summary>
 
 | Lockman | The Composable Architecture |
 |---------|----------------------------|
@@ -262,20 +262,20 @@ Aggiungi la dipendenza al tuo target:
 
 </details>
 
-## Comunità
+## 커뮤니티
 
-### Discussione e Aiuto
+### 토론 및 도움말
 
-Domande e discussioni possono essere tenute su [GitHub Discussions](https://github.com/takeshishimada/Lockman/discussions).
+질문과 토론은 [GitHub Discussions](https://github.com/takeshishimada/Lockman/discussions)에서 진행할 수 있습니다.
 
-### Segnalazioni di Bug
+### 버그 보고
 
-Se trovi un bug, per favore segnalalo su [Issues](https://github.com/takeshishimada/Lockman/issues).
+버그를 발견하면 [Issues](https://github.com/takeshishimada/Lockman/issues)에 보고해 주세요.
 
-### Contribuire
+### 기여
 
-Se desideri contribuire alla libreria, per favore apri una PR con un link ad essa!
+라이브러리에 기여하고 싶으시면 링크와 함께 PR을 열어주세요!
 
-## Licenza
+## 라이선스
 
-Questa libreria è rilasciata sotto licenza MIT. Vedi il file [LICENSE](./LICENSE) per i dettagli.
+이 라이브러리는 MIT 라이선스로 출시되었습니다. 자세한 내용은 [LICENSE](./LICENSE) 파일을 참조하세요.

--- a/Docs/README_pt-BR.md
+++ b/Docs/README_pt-BR.md
@@ -1,58 +1,58 @@
-<img src="Lockman.png" alt="Lockman Logo" width="400">
+<img src="../Lockman.png" alt="Lockman Logo" width="400">
 
 [![CI](https://github.com/takeshishimada/Lockman/workflows/CI/badge.svg)](https://github.com/takeshishimada/Lockman/actions?query=workflow%3ACI)
 [![Swift](https://img.shields.io/badge/Swift-5.9%20%7C%205.10%20%7C%206.0-ED523F.svg?style=flat)](https://swift.org/download/)
 [![Platforms](https://img.shields.io/badge/Platforms-iOS%20%7C%20macOS%20%7C%20tvOS%20%7C%20watchOS%20%7C%20Mac%20Catalyst-333333.svg?style=flat)](https://developer.apple.com/)
 
-[English](README.md) | [日本語](README_ja.md) | [简体中文](README_zh-CN.md) | [繁體中文](README_zh-TW.md) | [Español](README_es.md) | [Français](README_fr.md) | [Deutsch](README_de.md) | [한국어](README_ko.md) | [Português](README_pt-BR.md) | [Italiano](README_it.md)
+[English](../README.md) | [日本語](README_ja.md) | [简体中文](README_zh-CN.md) | [繁體中文](README_zh-TW.md) | [Español](README_es.md) | [Français](README_fr.md) | [Deutsch](README_de.md) | [한국어](README_ko.md) | [Português](README_pt-BR.md) | [Italiano](README_it.md)
 
-Lockman es una biblioteca Swift que resuelve problemas de control de acciones concurrentes en aplicaciones The Composable Architecture (TCA), con énfasis en la capacidad de respuesta, transparencia y diseño declarativo.
+Lockman é uma biblioteca Swift que resolve problemas de controle de ações concorrentes em aplicações The Composable Architecture (TCA), com responsividade, transparência e design declarativo em mente.
 
-* [Filosofía de Diseño](#filosofía-de-diseño)
-* [Descripción General](#descripción-general)
-* [Ejemplo Básico](#ejemplo-básico)
-* [Instalación](#instalación)
-* [Comunidad](#comunidad)
+* [Filosofia de Design](#filosofia-de-design)
+* [Visão Geral](#visão-geral)
+* [Exemplo Básico](#exemplo-básico)
+* [Instalação](#instalação)
+* [Comunidade](#comunidade)
 
-## Filosofía de Diseño
+## Filosofia de Design
 
-### Principios de Designing Fluid Interfaces
+### Princípios de Designing Fluid Interfaces
 
-La charla "Designing Fluid Interfaces" de WWDC18 presentó principios para interfaces excepcionales:
+O "Designing Fluid Interfaces" da WWDC18 apresentou princípios para interfaces excepcionais:
 
-* **Respuesta Inmediata y Redirección Continua** - Capacidad de respuesta que no permite ni 10ms de retraso
-* **Movimiento Uno a Uno de Toque y Contenido** - El contenido sigue al dedo durante las operaciones de arrastre
-* **Retroalimentación Continua** - Reacción inmediata a todas las interacciones
-* **Detección de Gestos en Paralelo** - Reconocimiento de múltiples gestos simultáneamente
-* **Consistencia Espacial** - Mantenimiento de la consistencia de posición durante las animaciones
-* **Interacciones Ligeras, Salida Amplificada** - Grandes efectos a partir de pequeñas entradas
+* **Resposta Imediata e Redirecionamento Contínuo** - Responsividade que não permite nem 10ms de atraso
+* **Movimento de Toque e Conteúdo Um-para-Um** - O conteúdo segue o dedo durante operações de arraste
+* **Feedback Contínuo** - Reação imediata a todas as interações
+* **Detecção de Gestos Paralelos** - Reconhecendo múltiplos gestos simultaneamente
+* **Consistência Espacial** - Mantendo consistência de posição durante animações
+* **Interações Leves, Saída Amplificada** - Grandes efeitos a partir de pequenas entradas
 
-### Desafíos Tradicionales
+### Desafios Tradicionais
 
-El desarrollo tradicional de UI ha resuelto problemas simplemente prohibiendo presionar botones simultáneamente y ejecuciones duplicadas. Estos enfoques se han convertido en factores que obstaculizan la experiencia del usuario en el diseño moderno de interfaces fluidas.
+O desenvolvimento tradicional de UI resolveu problemas simplesmente proibindo pressionamentos simultâneos de botões e execuções duplicadas. Essas abordagens se tornaram fatores que prejudicam a experiência do usuário no design moderno de interfaces fluidas.
 
-Los usuarios esperan alguna forma de retroalimentación incluso al presionar botones simultáneamente. Es crucial separar claramente la respuesta inmediata en la capa de UI del control de exclusión mutua apropiado en la capa de lógica de negocio.
+Os usuários esperam algum tipo de feedback mesmo ao pressionar botões simultaneamente. É crucial separar claramente a resposta imediata na camada de UI do controle apropriado de exclusão mútua na camada de lógica de negócios.
 
-## Descripción General
+## Visão Geral
 
-Lockman proporciona las siguientes estrategias de control para abordar problemas comunes en el desarrollo de aplicaciones:
+Lockman fornece as seguintes estratégias de controle para abordar problemas comuns no desenvolvimento de aplicativos:
 
-* **Single Execution**: Previene la ejecución duplicada de la misma acción
-* **Priority Based**: Control y cancelación de acciones basado en prioridad
-* **Group Coordination**: Control de grupo mediante roles de líder/miembro
-* **Dynamic Condition**: Control dinámico basado en condiciones de tiempo de ejecución
-* **Concurrency Limited**: Limita el número de ejecuciones concurrentes por grupo
-* **Composite Strategy**: Combinación de múltiples estrategias
+* **Execução Única**: Previne execução duplicada da mesma ação
+* **Baseado em Prioridade**: Controle e cancelamento de ação baseado em prioridade
+* **Coordenação de Grupo**: Controle de grupo através de papéis líder/membro
+* **Condição Dinâmica**: Controle dinâmico baseado em condições de tempo de execução
+* **Concorrência Limitada**: Limita o número de execuções concorrentes por grupo
+* **Estratégia Composta**: Combinação de múltiplas estratégias
 
-## Ejemplos
+## Exemplos
 
-| Single Execution Strategy | Priority Based Strategy | Concurrency Limited Strategy |
-|--------------------------|------------------------|------------------------------|
-| ![Single Execution Strategy](Sources/Lockman/Documentation.docc/images/01-SingleExecutionStrategy.gif) | ![Priority Based Strategy](Sources/Lockman/Documentation.docc/images/02-PriorityBasedStrategy.gif) | ![Concurrency Limited Strategy](Sources/Lockman/Documentation.docc/images/03-ConcurrencyLimitedStrategy.gif) |
+| Estratégia de Execução Única | Estratégia Baseada em Prioridade | Estratégia de Concorrência Limitada |
+|------------------------------|----------------------------------|-------------------------------------|
+| ![Estratégia de Execução Única](../Sources/Lockman/Documentation.docc/images/01-SingleExecutionStrategy.gif) | ![Estratégia Baseada em Prioridade](../Sources/Lockman/Documentation.docc/images/02-PriorityBasedStrategy.gif) | ![Estratégia de Concorrência Limitada](../Sources/Lockman/Documentation.docc/images/03-ConcurrencyLimitedStrategy.gif) |
 
-## Ejemplo de Código
+## Exemplo de Código
 
-Aquí se muestra cómo implementar una función que previene la ejecución duplicada de procesos usando el macro `@LockmanSingleExecution`:
+Veja como implementar um recurso que previne execução duplicada de processos usando o macro `@LockmanSingleExecution`:
 
 ```swift
 import ComposableArchitecture
@@ -129,9 +129,9 @@ struct ProcessFeature {
 }
 ```
 
-El método `withLock` asegura que `startProcessButtonTapped` no se ejecute mientras el procesamiento está en curso, previniendo operaciones duplicadas incluso si el usuario toca el botón múltiples veces.
+O método `withLock` garante que `startProcessButtonTapped` não será executado enquanto o processamento estiver em andamento, prevenindo operações duplicadas mesmo se o usuário tocar o botão várias vezes.
 
-### Ejemplo de Salida de Depuración
+### Exemplo de Saída de Debug
 
 ```
 ✅ [Lockman] canLock succeeded - Strategy: SingleExecution, BoundaryId: process, Info: LockmanSingleExecutionInfo(actionId: 'startProcessButtonTapped', uniqueId: 7BFC785A-3D25-4722-B9BC-A3A63A7F49FC, mode: boundary)
@@ -152,9 +152,9 @@ El método `withLock` asegura que `startProcessButtonTapped` no se ejecute mient
 └─────────────────┴──────────────────┴──────────────────────────────────────┴─────────────────┘
 ```
 
-## Documentación
+## Documentação
 
-La documentación para las versiones publicadas y `main` está disponible aquí:
+A documentação para lançamentos e `main` estão disponíveis aqui:
 
 * [`main`](https://takeshishimada.github.io/Lockman/main/documentation/lockman/)
 * [0.11.0](https://takeshishimada.github.io/Lockman/0.11.0/documentation/lockman/)
@@ -163,7 +163,7 @@ La documentación para las versiones publicadas y `main` está disponible aquí:
 * [0.8.0](https://takeshishimada.github.io/Lockman/0.8.0/documentation/lockman/)
 
 <details>
-<summary>Otras versiones</summary>
+<summary>Outras versões</summary>
 
 * [0.7.0](https://takeshishimada.github.io/Lockman/0.7.0/documentation/lockman/)
 * [0.6.0](https://takeshishimada.github.io/Lockman/0.6.0/documentation/lockman/)
@@ -173,35 +173,35 @@ La documentación para las versiones publicadas y `main` está disponible aquí:
 
 </details>
 
-Hay varios artículos en la documentación que pueden resultarte útiles a medida que te familiarizas con la biblioteca:
+Existem vários artigos na documentação que você pode achar úteis à medida que se familiariza com a biblioteca:
 
-### Esenciales
-* [Primeros Pasos](https://takeshishimada.github.io/Lockman/main/documentation/lockman/gettingstarted) - Aprende cómo integrar Lockman en tu aplicación TCA
-* [Descripción General de Límites](https://takeshishimada.github.io/Lockman/main/documentation/lockman/boundaryoverview) - Comprende el concepto de límites en Lockman
-* [Bloqueo](https://takeshishimada.github.io/Lockman/main/documentation/lockman/lock) - Comprensión del mecanismo de bloqueo
-* [Desbloqueo](https://takeshishimada.github.io/Lockman/main/documentation/lockman/unlock) - Comprensión del mecanismo de desbloqueo
-* [Elegir una Estrategia](https://takeshishimada.github.io/Lockman/main/documentation/lockman/choosingstrategy) - Selecciona la estrategia correcta para tu caso de uso
-* [Configuración](https://takeshishimada.github.io/Lockman/main/documentation/lockman/configuration) - Configura Lockman para las necesidades de tu aplicación
-* [Manejo de Errores](https://takeshishimada.github.io/Lockman/main/documentation/lockman/errorhandling) - Aprende sobre patrones comunes de manejo de errores
-* [Guía de Depuración](https://takeshishimada.github.io/Lockman/main/documentation/lockman/debuggingguide) - Depura problemas relacionados con Lockman en tu aplicación
+### Essenciais
+* [Começando](https://takeshishimada.github.io/Lockman/main/documentation/lockman/gettingstarted) - Aprenda como integrar Lockman em sua aplicação TCA
+* [Visão Geral de Limites](https://takeshishimada.github.io/Lockman/main/documentation/lockman/boundaryoverview) - Entenda o conceito de limites em Lockman
+* [Bloquear](https://takeshishimada.github.io/Lockman/main/documentation/lockman/lock) - Entendendo o mecanismo de bloqueio
+* [Desbloquear](https://takeshishimada.github.io/Lockman/main/documentation/lockman/unlock) - Entendendo o mecanismo de desbloqueio
+* [Escolhendo uma Estratégia](https://takeshishimada.github.io/Lockman/main/documentation/lockman/choosingstrategy) - Selecione a estratégia certa para seu caso de uso
+* [Configuração](https://takeshishimada.github.io/Lockman/main/documentation/lockman/configuration) - Configure Lockman para as necessidades de sua aplicação
+* [Tratamento de Erros](https://takeshishimada.github.io/Lockman/main/documentation/lockman/errorhandling) - Aprenda sobre padrões comuns de tratamento de erros
+* [Guia de Depuração](https://takeshishimada.github.io/Lockman/main/documentation/lockman/debuggingguide) - Depure problemas relacionados ao Lockman em sua aplicação
 
-### Estrategias
-* [Single Execution Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/singleexecutionstrategy) - Prevenir ejecución duplicada
-* [Priority Based Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/prioritybasedstrategy) - Control basado en prioridad
-* [Concurrency Limited Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/concurrencylimitedstrategy) - Limitar ejecuciones concurrentes
-* [Group Coordination Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/groupcoordinationstrategy) - Coordinar acciones relacionadas
-* [Dynamic Condition Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/dynamicconditionstrategy) - Control dinámico en tiempo de ejecución
-* [Composite Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/compositestrategy) - Combinar múltiples estrategias
+### Estratégias
+* [Estratégia de Execução Única](https://takeshishimada.github.io/Lockman/main/documentation/lockman/singleexecutionstrategy) - Previne execução duplicada
+* [Estratégia Baseada em Prioridade](https://takeshishimada.github.io/Lockman/main/documentation/lockman/prioritybasedstrategy) - Controle baseado em prioridade
+* [Estratégia de Concorrência Limitada](https://takeshishimada.github.io/Lockman/main/documentation/lockman/concurrencylimitedstrategy) - Limita execuções concorrentes
+* [Estratégia de Coordenação de Grupo](https://takeshishimada.github.io/Lockman/main/documentation/lockman/groupcoordinationstrategy) - Coordena ações relacionadas
+* [Estratégia de Condição Dinâmica](https://takeshishimada.github.io/Lockman/main/documentation/lockman/dynamicconditionstrategy) - Controle dinâmico em tempo de execução
+* [Estratégia Composta](https://takeshishimada.github.io/Lockman/main/documentation/lockman/compositestrategy) - Combina múltiplas estratégias
 
-Nota: La documentación está disponible solo en inglés.
+Nota: A documentação está disponível apenas em inglês.
 
-## Instalación
+## Instalação
 
-Lockman se puede instalar usando [Swift Package Manager](https://swift.org/package-manager/).
+Lockman pode ser instalado usando [Swift Package Manager](https://swift.org/package-manager/).
 
 ### Xcode
 
-En Xcode, selecciona File → Add Package Dependencies e ingresa la siguiente URL:
+No Xcode, selecione File → Add Package Dependencies e insira a seguinte URL:
 
 ```
 https://github.com/takeshishimada/Lockman
@@ -209,7 +209,7 @@ https://github.com/takeshishimada/Lockman
 
 ### Package.swift
 
-Agrega la dependencia a tu archivo Package.swift:
+Adicione a dependência ao seu arquivo Package.swift:
 
 ```swift
 dependencies: [
@@ -217,7 +217,7 @@ dependencies: [
 ]
 ```
 
-Agrega la dependencia a tu objetivo:
+Adicione a dependência ao seu alvo:
 
 ```swift
 .target(
@@ -230,14 +230,14 @@ Agrega la dependencia a tu objetivo:
 
 ### Requisitos
 
-| Plataforma | Versión Mínima |
-|------------|----------------|
-| iOS        | 13.0           |
-| macOS      | 10.15          |
-| tvOS       | 13.0           |
-| watchOS    | 6.0            |
+| Plataforma | Versão Mínima |
+|------------|---------------|
+| iOS        | 13.0          |
+| macOS      | 10.15         |
+| tvOS       | 13.0          |
+| watchOS    | 6.0           |
 
-### Compatibilidad de Versiones
+### Compatibilidade de Versão
 
 | Lockman | The Composable Architecture |
 |---------|----------------------------|
@@ -246,7 +246,7 @@ Agrega la dependencia a tu objetivo:
 | 0.9.0   | 1.18.0                     |
 
 <details>
-<summary>Otras versiones</summary>
+<summary>Outras versões</summary>
 
 | Lockman | The Composable Architecture |
 |---------|----------------------------|
@@ -262,20 +262,20 @@ Agrega la dependencia a tu objetivo:
 
 </details>
 
-## Comunidad
+## Comunidade
 
-### Discusión y Ayuda
+### Discussão e Ajuda
 
-Las preguntas y discusiones se pueden realizar en [GitHub Discussions](https://github.com/takeshishimada/Lockman/discussions).
+Perguntas e discussões podem ser realizadas no [GitHub Discussions](https://github.com/takeshishimada/Lockman/discussions).
 
-### Reporte de Errores
+### Relatórios de Bugs
 
-Si encuentras un error, por favor repórtalo en [Issues](https://github.com/takeshishimada/Lockman/issues).
+Se você encontrar um bug, por favor reporte em [Issues](https://github.com/takeshishimada/Lockman/issues).
 
-### Contribuir
+### Contribuindo
 
-¡Si deseas contribuir a la biblioteca, abre un PR con un enlace a él!
+Se você gostaria de contribuir para a biblioteca, por favor abra um PR com um link para ele!
 
-## Licencia
+## Licença
 
-Esta biblioteca se publica bajo la licencia MIT. Consulta el archivo [LICENSE](./LICENSE) para más detalles.
+Esta biblioteca é lançada sob a Licença MIT. Veja o arquivo [LICENSE](./LICENSE) para detalhes.

--- a/Docs/README_zh-CN.md
+++ b/Docs/README_zh-CN.md
@@ -1,58 +1,58 @@
-<img src="Lockman.png" alt="Lockman Logo" width="400">
+<img src="../Lockman.png" alt="Lockman Logo" width="400">
 
 [![CI](https://github.com/takeshishimada/Lockman/workflows/CI/badge.svg)](https://github.com/takeshishimada/Lockman/actions?query=workflow%3ACI)
 [![Swift](https://img.shields.io/badge/Swift-5.9%20%7C%205.10%20%7C%206.0-ED523F.svg?style=flat)](https://swift.org/download/)
 [![Platforms](https://img.shields.io/badge/Platforms-iOS%20%7C%20macOS%20%7C%20tvOS%20%7C%20watchOS%20%7C%20Mac%20Catalyst-333333.svg?style=flat)](https://developer.apple.com/)
 
-[English](README.md) | [日本語](README_ja.md) | [简体中文](README_zh-CN.md) | [繁體中文](README_zh-TW.md) | [Español](README_es.md) | [Français](README_fr.md) | [Deutsch](README_de.md) | [한국어](README_ko.md) | [Português](README_pt-BR.md) | [Italiano](README_it.md)
+[English](../README.md) | [日本語](README_ja.md) | [简体中文](README_zh-CN.md) | [繁體中文](README_zh-TW.md) | [Español](README_es.md) | [Français](README_fr.md) | [Deutsch](README_de.md) | [한국어](README_ko.md) | [Português](README_pt-BR.md) | [Italiano](README_it.md)
 
-Lockman est une bibliothèque Swift qui résout les problèmes de contrôle des actions concurrentes dans les applications The Composable Architecture (TCA), en mettant l'accent sur la réactivité, la transparence et la conception déclarative.
+Lockman 是一个 Swift 库，旨在解决 The Composable Architecture (TCA) 应用程序中的并发动作控制问题，注重响应性、透明性和声明式设计。
 
-* [Philosophie de Conception](#philosophie-de-conception)
-* [Vue d'Ensemble](#vue-densemble)
-* [Exemple de Base](#exemple-de-base)
-* [Installation](#installation)
-* [Communauté](#communauté)
+* [设计理念](#设计理念)
+* [概述](#概述)
+* [基本示例](#基本示例)
+* [安装](#安装)
+* [社区](#社区)
 
-## Philosophie de Conception
+## 设计理念
 
-### Principes de Designing Fluid Interfaces
+### Designing Fluid Interfaces 原则
 
-La présentation "Designing Fluid Interfaces" de WWDC18 a présenté des principes pour des interfaces exceptionnelles :
+WWDC18 的"Designing Fluid Interfaces"提出了卓越界面的原则：
 
-* **Réponse Immédiate et Redirection Continue** - Une réactivité qui ne tolère pas même 10ms de délai
-* **Mouvement Un-à-Un entre le Toucher et le Contenu** - Le contenu suit le doigt pendant les opérations de glissement
-* **Retour d'Information Continu** - Réaction immédiate à toutes les interactions
-* **Détection de Gestes en Parallèle** - Reconnaissance de plusieurs gestes simultanément
-* **Cohérence Spatiale** - Maintien de la cohérence de position pendant les animations
-* **Interactions Légères, Sortie Amplifiée** - Grands effets à partir de petites entrées
+* **即时响应和持续重定向** - 不允许有 10 毫秒延迟的响应性
+* **一对一的触摸和内容移动** - 拖动操作时内容跟随手指
+* **持续反馈** - 对所有交互的即时反应
+* **并行手势检测** - 同时识别多个手势
+* **空间一致性** - 动画期间保持位置一致性
+* **轻量级交互，放大输出** - 小输入产生大效果
 
-### Défis Traditionnels
+### 传统挑战
 
-Le développement d'interface utilisateur traditionnel a résolu les problèmes en interdisant simplement les pressions simultanées de boutons et les exécutions en double. Ces approches sont devenues des facteurs qui entravent l'expérience utilisateur dans la conception moderne d'interfaces fluides.
+传统 UI 开发通过简单地禁止同时按下按钮和重复执行来解决问题。这些方法已成为现代流畅界面设计中阻碍用户体验的因素。
 
-Les utilisateurs attendent une forme de retour d'information même lorsqu'ils appuient simultanément sur des boutons. Il est crucial de séparer clairement la réponse immédiate au niveau de la couche UI du contrôle d'exclusion mutuelle approprié au niveau de la couche de logique métier.
+用户期望即使同时按下按钮也能获得某种形式的反馈。在 UI 层的即时响应与业务逻辑层的适当互斥控制之间进行清晰分离至关重要。
 
-## Vue d'Ensemble
+## 概述
 
-Lockman fournit les stratégies de contrôle suivantes pour résoudre les problèmes courants dans le développement d'applications :
+Lockman 提供以下控制策略来解决应用开发中的常见问题：
 
-* **Single Execution** : Empêche l'exécution en double de la même action
-* **Priority Based** : Contrôle et annulation d'actions basés sur la priorité
-* **Group Coordination** : Contrôle de groupe via les rôles leader/membre
-* **Dynamic Condition** : Contrôle dynamique basé sur les conditions d'exécution
-* **Concurrency Limited** : Limite le nombre d'exécutions concurrentes par groupe
-* **Composite Strategy** : Combinaison de plusieurs stratégies
+* **Single Execution**：防止相同动作的重复执行
+* **Priority Based**：基于优先级的动作控制和取消
+* **Group Coordination**：通过领导者/成员角色进行组控制
+* **Dynamic Condition**：基于运行时条件的动态控制
+* **Concurrency Limited**：限制每组的并发执行数量
+* **Composite Strategy**：多种策略的组合
 
-## Exemples
+## 示例
 
 | Single Execution Strategy | Priority Based Strategy | Concurrency Limited Strategy |
 |--------------------------|------------------------|------------------------------|
-| ![Single Execution Strategy](Sources/Lockman/Documentation.docc/images/01-SingleExecutionStrategy.gif) | ![Priority Based Strategy](Sources/Lockman/Documentation.docc/images/02-PriorityBasedStrategy.gif) | ![Concurrency Limited Strategy](Sources/Lockman/Documentation.docc/images/03-ConcurrencyLimitedStrategy.gif) |
+| ![Single Execution Strategy](../Sources/Lockman/Documentation.docc/images/01-SingleExecutionStrategy.gif) | ![Priority Based Strategy](../Sources/Lockman/Documentation.docc/images/02-PriorityBasedStrategy.gif) | ![Concurrency Limited Strategy](../Sources/Lockman/Documentation.docc/images/03-ConcurrencyLimitedStrategy.gif) |
 
-## Exemple de Code
+## 代码示例
 
-Voici comment implémenter une fonctionnalité qui empêche l'exécution en double de processus en utilisant la macro `@LockmanSingleExecution` :
+以下是如何使用 `@LockmanSingleExecution` 宏实现防止进程重复执行的功能：
 
 ```swift
 import ComposableArchitecture
@@ -129,9 +129,9 @@ struct ProcessFeature {
 }
 ```
 
-La méthode `withLock` garantit que `startProcessButtonTapped` ne s'exécutera pas pendant que le traitement est en cours, empêchant les opérations en double même si l'utilisateur appuie plusieurs fois sur le bouton.
+`withLock` 方法确保在处理进行中时不会执行 `startProcessButtonTapped`，即使用户多次点击按钮也能防止重复操作。
 
-### Exemple de Sortie de Débogage
+### 调试输出示例
 
 ```
 ✅ [Lockman] canLock succeeded - Strategy: SingleExecution, BoundaryId: process, Info: LockmanSingleExecutionInfo(actionId: 'startProcessButtonTapped', uniqueId: 7BFC785A-3D25-4722-B9BC-A3A63A7F49FC, mode: boundary)
@@ -152,9 +152,9 @@ La méthode `withLock` garantit que `startProcessButtonTapped` ne s'exécutera p
 └─────────────────┴──────────────────┴──────────────────────────────────────┴─────────────────┘
 ```
 
-## Documentation
+## 文档
 
-La documentation pour les versions publiées et `main` est disponible ici :
+发布版本和 `main` 分支的文档可在此处获取：
 
 * [`main`](https://takeshishimada.github.io/Lockman/main/documentation/lockman/)
 * [0.11.0](https://takeshishimada.github.io/Lockman/0.11.0/documentation/lockman/)
@@ -163,7 +163,7 @@ La documentation pour les versions publiées et `main` est disponible ici :
 * [0.8.0](https://takeshishimada.github.io/Lockman/0.8.0/documentation/lockman/)
 
 <details>
-<summary>Autres versions</summary>
+<summary>其他版本</summary>
 
 * [0.7.0](https://takeshishimada.github.io/Lockman/0.7.0/documentation/lockman/)
 * [0.6.0](https://takeshishimada.github.io/Lockman/0.6.0/documentation/lockman/)
@@ -173,35 +173,35 @@ La documentation pour les versions publiées et `main` est disponible ici :
 
 </details>
 
-Il existe plusieurs articles dans la documentation qui peuvent vous être utiles pour vous familiariser avec la bibliothèque :
+文档中有许多文章可以帮助您更好地使用该库：
 
-### Essentiels
-* [Démarrage](https://takeshishimada.github.io/Lockman/main/documentation/lockman/gettingstarted) - Apprenez à intégrer Lockman dans votre application TCA
-* [Vue d'Ensemble des Limites](https://takeshishimada.github.io/Lockman/main/documentation/lockman/boundaryoverview) - Comprendre le concept de limites dans Lockman
-* [Verrouillage](https://takeshishimada.github.io/Lockman/main/documentation/lockman/lock) - Comprendre le mécanisme de verrouillage
-* [Déverrouillage](https://takeshishimada.github.io/Lockman/main/documentation/lockman/unlock) - Comprendre le mécanisme de déverrouillage
-* [Choisir une Stratégie](https://takeshishimada.github.io/Lockman/main/documentation/lockman/choosingstrategy) - Sélectionnez la bonne stratégie pour votre cas d'utilisation
-* [Configuration](https://takeshishimada.github.io/Lockman/main/documentation/lockman/configuration) - Configurez Lockman pour les besoins de votre application
-* [Gestion des Erreurs](https://takeshishimada.github.io/Lockman/main/documentation/lockman/errorhandling) - Apprenez les modèles courants de gestion des erreurs
-* [Guide de Débogage](https://takeshishimada.github.io/Lockman/main/documentation/lockman/debuggingguide) - Déboguez les problèmes liés à Lockman dans votre application
+### 基础知识
+* [入门指南](https://takeshishimada.github.io/Lockman/main/documentation/lockman/gettingstarted) - 了解如何将 Lockman 集成到您的 TCA 应用程序中
+* [边界概述](https://takeshishimada.github.io/Lockman/main/documentation/lockman/boundaryoverview) - 理解 Lockman 中的边界概念
+* [锁定](https://takeshishimada.github.io/Lockman/main/documentation/lockman/lock) - 理解锁定机制
+* [解锁](https://takeshishimada.github.io/Lockman/main/documentation/lockman/unlock) - 理解解锁机制
+* [选择策略](https://takeshishimada.github.io/Lockman/main/documentation/lockman/choosingstrategy) - 为您的用例选择合适的策略
+* [配置](https://takeshishimada.github.io/Lockman/main/documentation/lockman/configuration) - 根据应用程序需求配置 Lockman
+* [错误处理](https://takeshishimada.github.io/Lockman/main/documentation/lockman/errorhandling) - 了解常见的错误处理模式
+* [调试指南](https://takeshishimada.github.io/Lockman/main/documentation/lockman/debuggingguide) - 调试应用程序中与 Lockman 相关的问题
 
-### Stratégies
-* [Single Execution Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/singleexecutionstrategy) - Empêcher l'exécution en double
-* [Priority Based Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/prioritybasedstrategy) - Contrôle basé sur la priorité
-* [Concurrency Limited Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/concurrencylimitedstrategy) - Limiter les exécutions concurrentes
-* [Group Coordination Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/groupcoordinationstrategy) - Coordonner les actions liées
-* [Dynamic Condition Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/dynamicconditionstrategy) - Contrôle dynamique à l'exécution
-* [Composite Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/compositestrategy) - Combiner plusieurs stratégies
+### 策略
+* [Single Execution Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/singleexecutionstrategy) - 防止重复执行
+* [Priority Based Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/prioritybasedstrategy) - 基于优先级的控制
+* [Concurrency Limited Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/concurrencylimitedstrategy) - 限制并发执行
+* [Group Coordination Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/groupcoordinationstrategy) - 协调相关动作
+* [Dynamic Condition Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/dynamicconditionstrategy) - 动态运行时控制
+* [Composite Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/compositestrategy) - 组合多种策略
 
-Note : La documentation est disponible uniquement en anglais.
+注：文档仅提供英文版本。
 
-## Installation
+## 安装
 
-Lockman peut être installé en utilisant [Swift Package Manager](https://swift.org/package-manager/).
+Lockman 可以使用 [Swift Package Manager](https://swift.org/package-manager/) 进行安装。
 
 ### Xcode
 
-Dans Xcode, sélectionnez File → Add Package Dependencies et entrez l'URL suivante :
+在 Xcode 中，选择 File → Add Package Dependencies 并输入以下 URL：
 
 ```
 https://github.com/takeshishimada/Lockman
@@ -209,7 +209,7 @@ https://github.com/takeshishimada/Lockman
 
 ### Package.swift
 
-Ajoutez la dépendance à votre fichier Package.swift :
+将依赖项添加到您的 Package.swift 文件中：
 
 ```swift
 dependencies: [
@@ -217,7 +217,7 @@ dependencies: [
 ]
 ```
 
-Ajoutez la dépendance à votre cible :
+将依赖项添加到您的目标中：
 
 ```swift
 .target(
@@ -228,16 +228,16 @@ Ajoutez la dépendance à votre cible :
 )
 ```
 
-### Configuration Requise
+### 系统要求
 
-| Plateforme | Version Minimale |
-|------------|------------------|
-| iOS        | 13.0             |
-| macOS      | 10.15            |
-| tvOS       | 13.0             |
-| watchOS    | 6.0              |
+| 平台      | 最低版本 |
+|----------|---------|
+| iOS      | 13.0    |
+| macOS    | 10.15   |
+| tvOS     | 13.0    |
+| watchOS  | 6.0     |
 
-### Compatibilité des Versions
+### 版本兼容性
 
 | Lockman | The Composable Architecture |
 |---------|----------------------------|
@@ -246,7 +246,7 @@ Ajoutez la dépendance à votre cible :
 | 0.9.0   | 1.18.0                     |
 
 <details>
-<summary>Autres versions</summary>
+<summary>其他版本</summary>
 
 | Lockman | The Composable Architecture |
 |---------|----------------------------|
@@ -262,20 +262,20 @@ Ajoutez la dépendance à votre cible :
 
 </details>
 
-## Communauté
+## 社区
 
-### Discussion et Aide
+### 讨论和帮助
 
-Les questions et discussions peuvent être tenues sur [GitHub Discussions](https://github.com/takeshishimada/Lockman/discussions).
+可以在 [GitHub Discussions](https://github.com/takeshishimada/Lockman/discussions) 上进行问题讨论。
 
-### Rapports de Bogues
+### 错误报告
 
-Si vous trouvez un bogue, veuillez le signaler sur [Issues](https://github.com/takeshishimada/Lockman/issues).
+如果发现错误，请在 [Issues](https://github.com/takeshishimada/Lockman/issues) 上报告。
 
-### Contribution
+### 贡献
 
-Si vous souhaitez contribuer à la bibliothèque, veuillez ouvrir une PR avec un lien vers celle-ci !
+如果您想为该库做出贡献，请创建一个 PR 并附上相关链接！
 
-## Licence
+## 许可证
 
-Cette bibliothèque est publiée sous la licence MIT. Consultez le fichier [LICENSE](./LICENSE) pour plus de détails.
+本库基于 MIT 许可证发布。详情请参阅 [LICENSE](./LICENSE) 文件。

--- a/Docs/README_zh-TW.md
+++ b/Docs/README_zh-TW.md
@@ -1,10 +1,10 @@
-<img src="Lockman.png" alt="Lockman Logo" width="400">
+<img src="../Lockman.png" alt="Lockman Logo" width="400">
 
 [![CI](https://github.com/takeshishimada/Lockman/workflows/CI/badge.svg)](https://github.com/takeshishimada/Lockman/actions?query=workflow%3ACI)
 [![Swift](https://img.shields.io/badge/Swift-5.9%20%7C%205.10%20%7C%206.0-ED523F.svg?style=flat)](https://swift.org/download/)
 [![Platforms](https://img.shields.io/badge/Platforms-iOS%20%7C%20macOS%20%7C%20tvOS%20%7C%20watchOS%20%7C%20Mac%20Catalyst-333333.svg?style=flat)](https://developer.apple.com/)
 
-[English](README.md) | [日本語](README_ja.md) | [简体中文](README_zh-CN.md) | [繁體中文](README_zh-TW.md) | [Español](README_es.md) | [Français](README_fr.md) | [Deutsch](README_de.md) | [한국어](README_ko.md) | [Português](README_pt-BR.md) | [Italiano](README_it.md)
+[English](../README.md) | [日本語](README_ja.md) | [简体中文](README_zh-CN.md) | [繁體中文](README_zh-TW.md) | [Español](README_es.md) | [Français](README_fr.md) | [Deutsch](README_de.md) | [한국어](README_ko.md) | [Português](README_pt-BR.md) | [Italiano](README_it.md)
 
 Lockman 是一個 Swift 函式庫，旨在解決 The Composable Architecture (TCA) 應用程式中的並行動作控制問題，著重於回應性、透明性和宣告式設計。
 
@@ -48,7 +48,7 @@ Lockman 提供以下控制策略來解決應用程式開發中的常見問題：
 
 | Single Execution Strategy | Priority Based Strategy | Concurrency Limited Strategy |
 |--------------------------|------------------------|------------------------------|
-| ![Single Execution Strategy](Sources/Lockman/Documentation.docc/images/01-SingleExecutionStrategy.gif) | ![Priority Based Strategy](Sources/Lockman/Documentation.docc/images/02-PriorityBasedStrategy.gif) | ![Concurrency Limited Strategy](Sources/Lockman/Documentation.docc/images/03-ConcurrencyLimitedStrategy.gif) |
+| ![Single Execution Strategy](../Sources/Lockman/Documentation.docc/images/01-SingleExecutionStrategy.gif) | ![Priority Based Strategy](../Sources/Lockman/Documentation.docc/images/02-PriorityBasedStrategy.gif) | ![Concurrency Limited Strategy](../Sources/Lockman/Documentation.docc/images/03-ConcurrencyLimitedStrategy.gif) |
 
 ## 程式碼範例
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Swift](https://img.shields.io/badge/Swift-5.9%20%7C%205.10%20%7C%206.0-ED523F.svg?style=flat)](https://swift.org/download/)
 [![Platforms](https://img.shields.io/badge/Platforms-iOS%20%7C%20macOS%20%7C%20tvOS%20%7C%20watchOS%20%7C%20Mac%20Catalyst-333333.svg?style=flat)](https://developer.apple.com/)
 
-[English](README.md) | [日本語](README_ja.md) | [简体中文](README_zh-CN.md) | [繁體中文](README_zh-TW.md) | [Español](README_es.md) | [Français](README_fr.md) | [Deutsch](README_de.md) | [한국어](README_ko.md) | [Português](README_pt-BR.md) | [Italiano](README_it.md)
+[English](README.md) | [日本語](Docs/README_ja.md) | [简体中文](Docs/README_zh-CN.md) | [繁體中文](Docs/README_zh-TW.md) | [Español](Docs/README_es.md) | [Français](Docs/README_fr.md) | [Deutsch](Docs/README_de.md) | [한국어](Docs/README_ko.md) | [Português](Docs/README_pt-BR.md) | [Italiano](Docs/README_it.md)
 
 Lockman is a Swift library that solves concurrent action control issues in The Composable Architecture (TCA) applications, with responsiveness, transparency, and declarative design in mind.
 


### PR DESCRIPTION
## Summary
- 言語別のREADMEファイルを整理して`Docs/`ディレクトリに移動
- プロジェクトのルートディレクトリをクリーンに保つ
- 他のディレクトリ（`Sources/`, `Tests/`, `Examples/`等）と命名規則を統一

## Changes
- すべての言語別README（`README_*.md`）を`Docs/`ディレクトリに移動
- メインの`README.md`の言語リンクを`Docs/`を指すように更新
- 移動したファイル内のリンクを修正：
  - ロゴ画像パス: `../Lockman.png`
  - 英語版へのリンク: `../README.md`
  - 例の画像パス: `../Sources/Lockman/Documentation.docc/images/...`

## Test plan
- [x] すべての言語リンクが正しく動作することを確認
- [x] 画像が正しく表示されることを確認
- [x] GitHub上でREADMEが正しく表示されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)