### PR TITLE
docs: remove 'Guide' from Debugging section title

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ There are a number of articles in the documentation that you may find helpful as
 * [Choosing a Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/choosingstrategy) - Select the right strategy for your use case
 * [Configuration](https://takeshishimada.github.io/Lockman/main/documentation/lockman/configuration) - Configure Lockman for your application's needs
 * [Error Handling](https://takeshishimada.github.io/Lockman/main/documentation/lockman/errorhandling) - Learn about common error handling patterns
-* [Debugging Guide](https://takeshishimada.github.io/Lockman/main/documentation/lockman/debuggingguide) - Debug Lockman-related issues in your application
+* [Debugging](https://takeshishimada.github.io/Lockman/main/documentation/lockman/debuggingguide) - Debug Lockman-related issues in your application
 
 ### Strategies
 * [Single Execution Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/singleexecutionstrategy) - Prevent duplicate execution


### PR DESCRIPTION
## Summary
- Simplified the "Debugging Guide" section title to just "Debugging" in README.md

## Changes
- Updated the documentation link title from "Debugging Guide" to "Debugging" for consistency and brevity

🤖 Generated with [Claude Code](https://claude.ai/code)