### PR TITLE
docs: unify terminology from concurrent control to exclusive control

### DIFF
--- a/Docs/README_es.md
+++ b/Docs/README_es.md
@@ -6,7 +6,7 @@
 
 [English](../README.md) | [日本語](README_ja.md) | [简体中文](README_zh-CN.md) | [繁體中文](README_zh-TW.md) | [Español](README_es.md) | [Français](README_fr.md) | [Deutsch](README_de.md) | [한국어](README_ko.md) | [Português](README_pt-BR.md) | [Italiano](README_it.md)
 
-Lockman es una biblioteca Swift que resuelve problemas de control de acciones concurrentes en aplicaciones The Composable Architecture (TCA), con énfasis en la capacidad de respuesta, transparencia y diseño declarativo.
+Lockman es una biblioteca Swift que resuelve problemas de control exclusivo de acciones en aplicaciones The Composable Architecture (TCA), con énfasis en la capacidad de respuesta, transparencia y diseño declarativo.
 
 * [Filosofía de Diseño](#filosofía-de-diseño)
 * [Descripción General](#descripción-general)

--- a/Docs/README_it.md
+++ b/Docs/README_it.md
@@ -6,7 +6,7 @@
 
 [English](../README.md) | [日本語](README_ja.md) | [简体中文](README_zh-CN.md) | [繁體中文](README_zh-TW.md) | [Español](README_es.md) | [Français](README_fr.md) | [Deutsch](README_de.md) | [한국어](README_ko.md) | [Português](README_pt-BR.md) | [Italiano](README_it.md)
 
-Lockman è una libreria Swift che risolve i problemi di controllo delle azioni concorrenti nelle applicazioni The Composable Architecture (TCA), con reattività, trasparenza e design dichiarativo in mente.
+Lockman è una libreria Swift che risolve i problemi di controllo esclusivo delle azioni nelle applicazioni The Composable Architecture (TCA), con reattività, trasparenza e design dichiarativo in mente.
 
 * [Filosofia di Design](#filosofia-di-design)
 * [Panoramica](#panoramica)

--- a/Docs/README_ja.md
+++ b/Docs/README_ja.md
@@ -6,7 +6,7 @@
 
 [English](../README.md) | [日本語](README_ja.md) | [简体中文](README_zh-CN.md) | [繁體中文](README_zh-TW.md) | [Español](README_es.md) | [Français](README_fr.md) | [Deutsch](README_de.md) | [한국어](README_ko.md) | [Português](README_pt-BR.md) | [Italiano](README_it.md)
 
-LockmanはThe Composable Architecture（TCA）アプリケーションにおける並行アクションの制御問題を解決するSwiftライブラリです。応答性、透明性、宣言的設計を重視しています。
+LockmanはThe Composable Architecture（TCA）アプリケーションにおける排他アクションの制御問題を解決するSwiftライブラリです。応答性、透明性、宣言的設計を重視しています。
 
 * [設計思想](#設計思想)
 * [概要](#概要)
@@ -41,7 +41,7 @@ Lockmanは以下の制御戦略を提供し、実際のアプリ開発で頻繁�
 * **Priority Based**: 優先度に基づくアクションの制御とキャンセル
 * **Group Coordination**: リーダー/メンバーの役割によるグループ制御
 * **Dynamic Condition**: 実行時条件による動的制御
-* **Concurrency Limited**: グループごとの並行実行数を制限
+* **Concurrency Limited**: グループごとの同時実行数を制限
 * **Composite Strategy**: 複数戦略の組み合わせ
 
 ## 例

--- a/Docs/README_pt-BR.md
+++ b/Docs/README_pt-BR.md
@@ -6,7 +6,7 @@
 
 [English](../README.md) | [日本語](README_ja.md) | [简体中文](README_zh-CN.md) | [繁體中文](README_zh-TW.md) | [Español](README_es.md) | [Français](README_fr.md) | [Deutsch](README_de.md) | [한국어](README_ko.md) | [Português](README_pt-BR.md) | [Italiano](README_it.md)
 
-Lockman é uma biblioteca Swift que resolve problemas de controle de ações concorrentes em aplicações The Composable Architecture (TCA), com responsividade, transparência e design declarativo em mente.
+Lockman é uma biblioteca Swift que resolve problemas de controle exclusivo de ações em aplicações The Composable Architecture (TCA), com responsividade, transparência e design declarativo em mente.
 
 * [Filosofia de Design](#filosofia-de-design)
 * [Visão Geral](#visão-geral)

--- a/Examples/Strategies/Strategies/00-Examples.swift
+++ b/Examples/Strategies/Strategies/00-Examples.swift
@@ -106,7 +106,7 @@ struct ExamplesView: View {
             Text("Lockman Strategy Examples")
               .font(.headline)
             Text(
-              "Lockman is a Swift library for controlling concurrent action execution. These examples demonstrate how to manage action execution using different strategy patterns."
+              "Lockman is a Swift library for controlling exclusive action execution. These examples demonstrate how to manage action execution using different strategy patterns."
             )
             .font(.caption)
             .foregroundColor(.secondary)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 [English](README.md) | [日本語](Docs/README_ja.md) | [简体中文](Docs/README_zh-CN.md) | [繁體中文](Docs/README_zh-TW.md) | [Español](Docs/README_es.md) | [Français](Docs/README_fr.md) | [Deutsch](Docs/README_de.md) | [한국어](Docs/README_ko.md) | [Português](Docs/README_pt-BR.md) | [Italiano](Docs/README_it.md)
 
-Lockman is a Swift library that solves concurrent action control issues in The Composable Architecture (TCA) applications, with responsiveness, transparency, and declarative design in mind.
+Lockman is a Swift library that solves exclusive action control issues in The Composable Architecture (TCA) applications, with responsiveness, transparency, and declarative design in mind.
 
 * [Design Philosophy](#design-philosophy)
 * [Overview](#overview)

--- a/Sources/Lockman/Core/Strategies/SingleExecutionStrategy/LockmanSingleExecutionInfo.swift
+++ b/Sources/Lockman/Core/Strategies/SingleExecutionStrategy/LockmanSingleExecutionInfo.swift
@@ -56,7 +56,7 @@ public struct LockmanSingleExecutionInfo: LockmanInfo, Sendable, Equatable {
   ///
   /// Controls how the strategy evaluates lock conflicts:
   /// - `.none`: No exclusive execution - all actions can run concurrently
-  /// - `.boundary`: Only one action per boundary - strictest concurrency control
+  /// - `.boundary`: Only one action per boundary - strictest exclusive control
   /// - `.action`: Only one instance of the same action - allows different actions to run concurrently
   ///
   /// Performance note: `.action` mode uses O(1) hash-based lookups for optimal performance

--- a/Sources/Lockman/Documentation.docc/Lockman.md
+++ b/Sources/Lockman/Documentation.docc/Lockman.md
@@ -23,7 +23,7 @@ Users expect some form of feedback even when pressing buttons simultaneously. It
 
 ## Overview
 
-Lockman provides a comprehensive solution for managing exclusive control over user actions in applications built with The Composable Architecture (TCA). It offers various strategies to handle concurrent operations, prevent duplicate executions, and maintain consistent application state.
+Lockman provides a comprehensive solution for managing exclusive control over user actions in applications built with The Composable Architecture (TCA). It offers various strategies to handle exclusive operations, prevent duplicate executions, and maintain consistent application state.
 
 ## Topics
 

--- a/Sources/Lockman/Documentation.docc/PriorityBasedStrategy.md
+++ b/Sources/Lockman/Documentation.docc/PriorityBasedStrategy.md
@@ -26,9 +26,9 @@ This strategy is used in situations where high-urgency processing or control bas
 - Not interrupted by other processing
 - Basic processing or temporary disabling
 
-### Concurrent Execution Control
+### Exclusive Execution Control
 
-Within the same priority level, control is based on the concurrent execution behavior setting of existing processing:
+Within the same priority level, control is based on the exclusive execution behavior setting of existing processing:
 
 **exclusive** - Exclusive Execution
 

--- a/Sources/Lockman/Documentation.docc/SingleExecutionStrategy.md
+++ b/Sources/Lockman/Documentation.docc/SingleExecutionStrategy.md
@@ -21,7 +21,7 @@ LockmanSingleExecutionInfo(
 )
 ```
 
-- Executes all processing concurrently without exclusive control
+- Executes all processing without exclusive control
 - Used when temporarily disabling lock functionality
 - Applied for behavior verification during debugging or testing
 


### PR DESCRIPTION
## Summary
- Unified terminology from "concurrent control" to "exclusive control" throughout the documentation
- Better represents Lockman's role in managing exclusive action control

## Changes
- README.md: "concurrent action control" → "exclusive action control"
- DocC documentation: "concurrent operations" → "exclusive operations"
- Source code comments: "concurrency control" → "exclusive control"
- All language README files updated for consistency
- Japanese README: "並行アクション" → "排他アクション", "並行実行数" → "同時実行数"
- Spanish README: "acciones concurrentes" → "control exclusivo de acciones"
- Italian README: "azioni concorrenti" → "controllo esclusivo delle azioni"
- Portuguese README: "ações concorrentes" → "controle exclusivo de ações"

## Note
- Benchmarks/README.md: "concurrent actions" was not changed as it's technically appropriate in the performance measurement context

🤖 Generated with [Claude Code](https://claude.ai/code)