### PR TITLE
docs: improve DocC examples with ViewAction pattern and correct CompositeInfo usage

### DIFF
--- a/Sources/Lockman/Documentation.docc/ChoosingStrategy.md
+++ b/Sources/Lockman/Documentation.docc/ChoosingStrategy.md
@@ -12,13 +12,13 @@ Developers can select appropriate strategies based on the nature of processing u
 
 ```swift
 @LockmanSingleExecution
-enum Action {
+enum ViewAction {
 
 @LockmanPriorityBased  
-enum Action {
+enum ViewAction {
 
 @LockmanGroupCoordination
-enum Action {
+enum ViewAction {
 ```
 
 ## Combining Strategies
@@ -30,7 +30,7 @@ For complex requirements that cannot be addressed by a single strategy, you can 
   LockmanSingleExecutionStrategy.self,
   LockmanPriorityBasedStrategy.self
 )
-enum Action {
+enum ViewAction {
 ```
 
 ## Available Strategies

--- a/Sources/Lockman/Documentation.docc/CompositeStrategy.md
+++ b/Sources/Lockman/Documentation.docc/CompositeStrategy.md
@@ -98,9 +98,9 @@ enum Action {
 
 ```
 Strategy 1: SingleExecution(.action)
-Strategy 2: PriorityBased(.high(.exclusive))
+Strategy 2: PriorityBased(varies by action)
 
-Time: 0s  - normalSave request
+Time: 0s  - normalSave request (.low(.replaceable))
   Strategy 1: ✅ Success (no duplication)
   Strategy 2: ✅ Success (no priority issue)
   Result: ✅ Start execution
@@ -110,7 +110,7 @@ Time: 1s  - normalSave request (duplicate)
   Strategy 2: No check (failed at strategy 1)
   Result: ❌ Overall failure
 
-Time: 2s  - criticalSave request (high priority)
+Time: 2s  - criticalSave request (.high(.exclusive))
   Strategy 1: ✅ Success (different action)
   Strategy 2: ✅ Success (with preceding cancellation)
   Result: ✅ Start execution (cancel normalSave)
@@ -121,12 +121,12 @@ Time: 2s  - criticalSave request (high priority)
 ```
 Strategy 1: SingleExecution(.action)
 Strategy 2: PriorityBased(.low(.replaceable))  
-Strategy 3: ConcurrencyLimited(.limited(2))
+Strategy 3: ConcurrencyLimited(.limited(3))
 
-Current situation: 2 download processes running
+Current situation: 3 download processes running
 
-Time: 0s  - New download request
-  Strategy 1: ✅ Success (different file)
+Time: 0s  - New downloadFile request
+  Strategy 1: ✅ Success (no duplication)
   Strategy 2: ✅ Success (no priority issue)
   Strategy 3: ❌ Fail (concurrent execution limit reached)
   Result: ❌ Overall failure

--- a/Sources/Lockman/Documentation.docc/CompositeStrategy.md
+++ b/Sources/Lockman/Documentation.docc/CompositeStrategy.md
@@ -37,28 +37,37 @@ Lockman supports combinations of 2 to 5 strategies:
     LockmanSingleExecutionStrategy.self,
     LockmanPriorityBasedStrategy.self
 )
-enum Action {
+enum ViewAction {
     case criticalSave
     case normalSave
     
-    var lockmanInfoForStrategy1: LockmanSingleExecutionInfo {
-        LockmanSingleExecutionInfo(
-            actionId: actionName,
-            mode: .action
-        )
-    }
-    
-    var lockmanInfoForStrategy2: LockmanPriorityBasedInfo {
+    var lockmanInfo: LockmanCompositeInfo2<LockmanSingleExecutionInfo, LockmanPriorityBasedInfo> {
         switch self {
         case .criticalSave:
-            return LockmanPriorityBasedInfo(
-                actionId: actionName,
-                priority: .high(.exclusive)
+            return LockmanCompositeInfo2(
+                strategyId: strategyId,
+                actionId: actionId,
+                lockmanInfoForStrategy1: LockmanSingleExecutionInfo(
+                    actionId: actionId,
+                    mode: .action
+                ),
+                lockmanInfoForStrategy2: LockmanPriorityBasedInfo(
+                    actionId: actionId,
+                    priority: .high(.exclusive)
+                )
             )
         case .normalSave:
-            return LockmanPriorityBasedInfo(
-                actionId: actionName,
-                priority: .low(.replaceable)
+            return LockmanCompositeInfo2(
+                strategyId: strategyId,
+                actionId: actionId,
+                lockmanInfoForStrategy1: LockmanSingleExecutionInfo(
+                    actionId: actionId,
+                    mode: .action
+                ),
+                lockmanInfoForStrategy2: LockmanPriorityBasedInfo(
+                    actionId: actionId,
+                    priority: .low(.replaceable)
+                )
             )
         }
     }
@@ -76,25 +85,23 @@ enum Action {
 enum Action {
     case downloadFile
     
-    var lockmanInfoForStrategy1: LockmanSingleExecutionInfo {
-        LockmanSingleExecutionInfo(
-            actionId: actionName,
-            mode: .action // Prevent duplication
-        )
-    }
-    
-    var lockmanInfoForStrategy2: LockmanPriorityBasedInfo {
-        LockmanPriorityBasedInfo(
-            actionId: actionName,
-            priority: .low(.replaceable) // Priority control
-        )
-    }
-    
-    var lockmanInfoForStrategy3: LockmanConcurrencyLimitedInfo {
-        LockmanConcurrencyLimitedInfo(
-            actionId: actionName,
-            concurrencyId: "downloads",
-            limit: .limited(3) // Concurrent execution limit
+    var lockmanInfo: LockmanCompositeInfo3<LockmanSingleExecutionInfo, LockmanPriorityBasedInfo, LockmanConcurrencyLimitedInfo> {
+        LockmanCompositeInfo3(
+            strategyId: strategyId,
+            actionId: actionId,
+            lockmanInfoForStrategy1: LockmanSingleExecutionInfo(
+                actionId: actionId,
+                mode: .action // Prevent duplication
+            ),
+            lockmanInfoForStrategy2: LockmanPriorityBasedInfo(
+                actionId: actionId,
+                priority: .low(.replaceable) // Priority control
+            ),
+            lockmanInfoForStrategy3: LockmanConcurrencyLimitedInfo(
+                actionId: actionId,
+                concurrencyId: "downloads",
+                limit: .limited(3) // Concurrent execution limit
+            )
         )
     }
 }

--- a/Sources/Lockman/Documentation.docc/CompositeStrategy.md
+++ b/Sources/Lockman/Documentation.docc/CompositeStrategy.md
@@ -42,34 +42,20 @@ enum ViewAction {
     case normalSave
     
     var lockmanInfo: LockmanCompositeInfo2<LockmanSingleExecutionInfo, LockmanPriorityBasedInfo> {
-        switch self {
-        case .criticalSave:
-            return LockmanCompositeInfo2(
-                strategyId: strategyId,
-                actionId: actionId,
-                lockmanInfoForStrategy1: LockmanSingleExecutionInfo(
-                    actionId: actionId,
-                    mode: .action
-                ),
-                lockmanInfoForStrategy2: LockmanPriorityBasedInfo(
-                    actionId: actionId,
-                    priority: .high(.exclusive)
-                )
+        LockmanCompositeInfo2(
+            actionId: actionName,
+            lockmanInfoForStrategy1: LockmanSingleExecutionInfo(
+                actionId: actionName,
+                mode: .action
+            ),
+            lockmanInfoForStrategy2: LockmanPriorityBasedInfo(
+                actionId: actionName,
+                priority: switch self {
+                    case .criticalSave: .high(.exclusive)
+                    case .normalSave: .low(.replaceable)
+                }
             )
-        case .normalSave:
-            return LockmanCompositeInfo2(
-                strategyId: strategyId,
-                actionId: actionId,
-                lockmanInfoForStrategy1: LockmanSingleExecutionInfo(
-                    actionId: actionId,
-                    mode: .action
-                ),
-                lockmanInfoForStrategy2: LockmanPriorityBasedInfo(
-                    actionId: actionId,
-                    priority: .low(.replaceable)
-                )
-            )
-        }
+        )
     }
 }
 ```
@@ -87,18 +73,17 @@ enum Action {
     
     var lockmanInfo: LockmanCompositeInfo3<LockmanSingleExecutionInfo, LockmanPriorityBasedInfo, LockmanConcurrencyLimitedInfo> {
         LockmanCompositeInfo3(
-            strategyId: strategyId,
-            actionId: actionId,
+            actionId: actionName,
             lockmanInfoForStrategy1: LockmanSingleExecutionInfo(
-                actionId: actionId,
+                actionId: actionName,
                 mode: .action // Prevent duplication
             ),
             lockmanInfoForStrategy2: LockmanPriorityBasedInfo(
-                actionId: actionId,
+                actionId: actionName,
                 priority: .low(.replaceable) // Priority control
             ),
             lockmanInfoForStrategy3: LockmanConcurrencyLimitedInfo(
-                actionId: actionId,
+                actionId: actionName,
                 concurrencyId: "downloads",
                 limit: .limited(3) // Concurrent execution limit
             )

--- a/Sources/Lockman/Documentation.docc/ConcurrencyLimitedStrategy.md
+++ b/Sources/Lockman/Documentation.docc/ConcurrencyLimitedStrategy.md
@@ -65,7 +65,7 @@ LockmanConcurrencyLimitedInfo(
 
 ```swift
 @LockmanConcurrencyLimited
-enum Action {
+enum ViewAction {
     case downloadFile(URL)
     case uploadFile(URL)
     case processImage(UIImage)

--- a/Sources/Lockman/Documentation.docc/DynamicConditionStrategy.md
+++ b/Sources/Lockman/Documentation.docc/DynamicConditionStrategy.md
@@ -72,7 +72,7 @@ ReduceWithLock { state, action in
 
 ```swift
 @LockmanDynamicCondition
-enum Action {
+enum ViewAction {
     case transfer(amount: Double)
     case withdraw(amount: Double)
     

--- a/Sources/Lockman/Documentation.docc/GettingStarted.md
+++ b/Sources/Lockman/Documentation.docc/GettingStarted.md
@@ -58,19 +58,22 @@ struct ProcessFeature {
         var message = ""
     }
     
-    @LockmanSingleExecution
-    enum Action {
-        case startProcessButtonTapped
-        case processStart
-        case processCompleted
+    enum Action: ViewAction {
+        case view(View)
+        case internal(Internal)
         
-        var lockmanInfo: LockmanSingleExecutionInfo {
-            switch self {
-            case .startProcessButtonTapped:
+        @LockmanSingleExecution
+        enum View {
+            case startProcessButtonTapped
+            
+            var lockmanInfo: LockmanSingleExecutionInfo {
                 return .init(actionId: actionName, mode: .boundary)
-            case .processStart, .processCompleted:
-                return .init(actionId: actionName, mode: .none)
             }
+        }
+        
+        enum Internal {
+            case processStart
+            case processCompleted
         }
     }
 }

--- a/Sources/Lockman/Documentation.docc/GroupCoordinationStrategy.md
+++ b/Sources/Lockman/Documentation.docc/GroupCoordinationStrategy.md
@@ -92,7 +92,7 @@ LockmanGroupCoordinatedInfo(
 
 ```swift
 @LockmanGroupCoordination
-enum Action {
+enum ViewAction {
     case startDataSync
     case processChunk
     case showProgress

--- a/Sources/Lockman/Documentation.docc/PriorityBasedStrategy.md
+++ b/Sources/Lockman/Documentation.docc/PriorityBasedStrategy.md
@@ -60,7 +60,7 @@ LockmanPriorityBasedInfo(
 
 ```swift
 @LockmanPriorityBased
-enum Action {
+enum ViewAction {
     case emergencySync
     case normalSync
     case backgroundTask

--- a/Sources/Lockman/Documentation.docc/SingleExecutionStrategy.md
+++ b/Sources/Lockman/Documentation.docc/SingleExecutionStrategy.md
@@ -57,7 +57,7 @@ LockmanSingleExecutionInfo(
 
 ```swift
 @LockmanSingleExecution
-enum Action {
+enum ViewAction {
     case save
     case load
     


### PR DESCRIPTION
## Summary
- Update CompositeStrategy examples to use LockmanCompositeInfo2/3 with proper initialization
- Convert Getting Started example to ViewAction/InternalAction pattern
- Apply @LockmanAnnotation only to View actions, not Internal actions

## Changes
- CompositeStrategy.md: Fixed lockmanInfo property to use LockmanCompositeInfo2/3 instead of separate properties
- GettingStarted.md: Updated example to show proper ViewAction/InternalAction separation
- Multiple strategy files: Changed `enum Action` to `enum ViewAction` for consistency

## Notes
- Annotations are now applied only to View enums, not to Internal enums
- This aligns with best practices for TCA and Lockman usage

🤖 Generated with [Claude Code](https://claude.ai/code)