### PR TITLE
chore: release version 0.12.0

### DIFF
--- a/Docs/README_de.md
+++ b/Docs/README_de.md
@@ -157,7 +157,7 @@ Die `withLock` Methode stellt sicher, dass `startProcessButtonTapped` nicht ausg
 Die Dokumentation für veröffentlichte Versionen und `main` ist hier verfügbar:
 
 * [`main`](https://takeshishimada.github.io/Lockman/main/documentation/lockman/)
-* [0.11.0](https://takeshishimada.github.io/Lockman/0.11.0/documentation/lockman/)
+* [0.12.0](https://takeshishimada.github.io/Lockman/0.12.0/documentation/lockman/)
 * [0.10.0](https://takeshishimada.github.io/Lockman/0.10.0/documentation/lockman/)
 * [0.9.0](https://takeshishimada.github.io/Lockman/0.9.0/documentation/lockman/)
 * [0.8.0](https://takeshishimada.github.io/Lockman/0.8.0/documentation/lockman/)
@@ -213,7 +213,7 @@ Fügen Sie die Abhängigkeit zu Ihrer Package.swift-Datei hinzu:
 
 ```swift
 dependencies: [
-  .package(url: "https://github.com/takeshishimada/Lockman", from: "0.11.0")
+  .package(url: "https://github.com/takeshishimada/Lockman", from: "0.12.0")
 ]
 ```
 
@@ -241,7 +241,7 @@ Fügen Sie die Abhängigkeit zu Ihrem Target hinzu:
 
 | Lockman | The Composable Architecture |
 |---------|----------------------------|
-| 0.11.0  | 1.19.1                     |
+| 0.12.0  | 1.19.1                     |
 | 0.10.0  | 1.19.0                     |
 | 0.9.0   | 1.18.0                     |
 

--- a/Docs/README_es.md
+++ b/Docs/README_es.md
@@ -157,7 +157,7 @@ El método `withLock` asegura que `startProcessButtonTapped` no se ejecute mient
 La documentación para las versiones publicadas y `main` está disponible aquí:
 
 * [`main`](https://takeshishimada.github.io/Lockman/main/documentation/lockman/)
-* [0.11.0](https://takeshishimada.github.io/Lockman/0.11.0/documentation/lockman/)
+* [0.12.0](https://takeshishimada.github.io/Lockman/0.12.0/documentation/lockman/)
 * [0.10.0](https://takeshishimada.github.io/Lockman/0.10.0/documentation/lockman/)
 * [0.9.0](https://takeshishimada.github.io/Lockman/0.9.0/documentation/lockman/)
 * [0.8.0](https://takeshishimada.github.io/Lockman/0.8.0/documentation/lockman/)
@@ -213,7 +213,7 @@ Agrega la dependencia a tu archivo Package.swift:
 
 ```swift
 dependencies: [
-  .package(url: "https://github.com/takeshishimada/Lockman", from: "0.11.0")
+  .package(url: "https://github.com/takeshishimada/Lockman", from: "0.12.0")
 ]
 ```
 
@@ -241,7 +241,7 @@ Agrega la dependencia a tu objetivo:
 
 | Lockman | The Composable Architecture |
 |---------|----------------------------|
-| 0.11.0  | 1.19.1                     |
+| 0.12.0  | 1.19.1                     |
 | 0.10.0  | 1.19.0                     |
 | 0.9.0   | 1.18.0                     |
 

--- a/Docs/README_fr.md
+++ b/Docs/README_fr.md
@@ -157,7 +157,7 @@ La méthode `withLock` garantit que `startProcessButtonTapped` ne s'exécutera p
 La documentation pour les versions publiées et `main` est disponible ici :
 
 * [`main`](https://takeshishimada.github.io/Lockman/main/documentation/lockman/)
-* [0.11.0](https://takeshishimada.github.io/Lockman/0.11.0/documentation/lockman/)
+* [0.12.0](https://takeshishimada.github.io/Lockman/0.12.0/documentation/lockman/)
 * [0.10.0](https://takeshishimada.github.io/Lockman/0.10.0/documentation/lockman/)
 * [0.9.0](https://takeshishimada.github.io/Lockman/0.9.0/documentation/lockman/)
 * [0.8.0](https://takeshishimada.github.io/Lockman/0.8.0/documentation/lockman/)
@@ -213,7 +213,7 @@ Ajoutez la dépendance à votre fichier Package.swift :
 
 ```swift
 dependencies: [
-  .package(url: "https://github.com/takeshishimada/Lockman", from: "0.11.0")
+  .package(url: "https://github.com/takeshishimada/Lockman", from: "0.12.0")
 ]
 ```
 
@@ -241,7 +241,7 @@ Ajoutez la dépendance à votre cible :
 
 | Lockman | The Composable Architecture |
 |---------|----------------------------|
-| 0.11.0  | 1.19.1                     |
+| 0.12.0  | 1.19.1                     |
 | 0.10.0  | 1.19.0                     |
 | 0.9.0   | 1.18.0                     |
 

--- a/Docs/README_it.md
+++ b/Docs/README_it.md
@@ -157,7 +157,7 @@ Il metodo `withLock` garantisce che `startProcessButtonTapped` non verrà esegui
 La documentazione per le release e `main` è disponibile qui:
 
 * [`main`](https://takeshishimada.github.io/Lockman/main/documentation/lockman/)
-* [0.11.0](https://takeshishimada.github.io/Lockman/0.11.0/documentation/lockman/)
+* [0.12.0](https://takeshishimada.github.io/Lockman/0.12.0/documentation/lockman/)
 * [0.10.0](https://takeshishimada.github.io/Lockman/0.10.0/documentation/lockman/)
 * [0.9.0](https://takeshishimada.github.io/Lockman/0.9.0/documentation/lockman/)
 * [0.8.0](https://takeshishimada.github.io/Lockman/0.8.0/documentation/lockman/)
@@ -213,7 +213,7 @@ Aggiungi la dipendenza al tuo file Package.swift:
 
 ```swift
 dependencies: [
-  .package(url: "https://github.com/takeshishimada/Lockman", from: "0.11.0")
+  .package(url: "https://github.com/takeshishimada/Lockman", from: "0.12.0")
 ]
 ```
 
@@ -241,7 +241,7 @@ Aggiungi la dipendenza al tuo target:
 
 | Lockman | The Composable Architecture |
 |---------|----------------------------|
-| 0.11.0  | 1.19.1                     |
+| 0.12.0  | 1.19.1                     |
 | 0.10.0  | 1.19.0                     |
 | 0.9.0   | 1.18.0                     |
 

--- a/Docs/README_ja.md
+++ b/Docs/README_ja.md
@@ -157,7 +157,7 @@ struct ProcessFeature {
 リリース版とmainのドキュメントはこちらで利用できます：
 
 * [`main`](https://takeshishimada.github.io/Lockman/main/documentation/lockman/)
-* [0.11.0](https://takeshishimada.github.io/Lockman/0.11.0/documentation/lockman/)
+* [0.12.0](https://takeshishimada.github.io/Lockman/0.12.0/documentation/lockman/)
 * [0.10.0](https://takeshishimada.github.io/Lockman/0.10.0/documentation/lockman/)
 * [0.9.0](https://takeshishimada.github.io/Lockman/0.9.0/documentation/lockman/)
 * [0.8.0](https://takeshishimada.github.io/Lockman/0.8.0/documentation/lockman/)
@@ -211,7 +211,7 @@ Package.swiftファイルに依存関係を追加：
 
 ```swift
 dependencies: [
-  .package(url: "https://github.com/takeshishimada/Lockman", from: "0.11.0")
+  .package(url: "https://github.com/takeshishimada/Lockman", from: "0.12.0")
 ]
 ```
 
@@ -239,7 +239,7 @@ dependencies: [
 
 | Lockman | The Composable Architecture |
 |---------|----------------------------|
-| 0.11.0  | 1.19.1                     |
+| 0.12.0  | 1.19.1                     |
 | 0.10.0  | 1.19.0                     |
 | 0.9.0   | 1.18.0                     |
 

--- a/Docs/README_ko.md
+++ b/Docs/README_ko.md
@@ -157,7 +157,7 @@ struct ProcessFeature {
 출시된 버전과 `main`에 대한 문서는 여기에서 사용할 수 있습니다:
 
 * [`main`](https://takeshishimada.github.io/Lockman/main/documentation/lockman/)
-* [0.11.0](https://takeshishimada.github.io/Lockman/0.11.0/documentation/lockman/)
+* [0.12.0](https://takeshishimada.github.io/Lockman/0.12.0/documentation/lockman/)
 * [0.10.0](https://takeshishimada.github.io/Lockman/0.10.0/documentation/lockman/)
 * [0.9.0](https://takeshishimada.github.io/Lockman/0.9.0/documentation/lockman/)
 * [0.8.0](https://takeshishimada.github.io/Lockman/0.8.0/documentation/lockman/)
@@ -213,7 +213,7 @@ Package.swift 파일에 종속성을 추가하세요:
 
 ```swift
 dependencies: [
-  .package(url: "https://github.com/takeshishimada/Lockman", from: "0.11.0")
+  .package(url: "https://github.com/takeshishimada/Lockman", from: "0.12.0")
 ]
 ```
 
@@ -241,7 +241,7 @@ dependencies: [
 
 | Lockman | The Composable Architecture |
 |---------|----------------------------|
-| 0.11.0  | 1.19.1                     |
+| 0.12.0  | 1.19.1                     |
 | 0.10.0  | 1.19.0                     |
 | 0.9.0   | 1.18.0                     |
 

--- a/Docs/README_pt-BR.md
+++ b/Docs/README_pt-BR.md
@@ -157,7 +157,7 @@ O método `withLock` garante que `startProcessButtonTapped` não será executado
 A documentação para lançamentos e `main` estão disponíveis aqui:
 
 * [`main`](https://takeshishimada.github.io/Lockman/main/documentation/lockman/)
-* [0.11.0](https://takeshishimada.github.io/Lockman/0.11.0/documentation/lockman/)
+* [0.12.0](https://takeshishimada.github.io/Lockman/0.12.0/documentation/lockman/)
 * [0.10.0](https://takeshishimada.github.io/Lockman/0.10.0/documentation/lockman/)
 * [0.9.0](https://takeshishimada.github.io/Lockman/0.9.0/documentation/lockman/)
 * [0.8.0](https://takeshishimada.github.io/Lockman/0.8.0/documentation/lockman/)
@@ -213,7 +213,7 @@ Adicione a dependência ao seu arquivo Package.swift:
 
 ```swift
 dependencies: [
-  .package(url: "https://github.com/takeshishimada/Lockman", from: "0.11.0")
+  .package(url: "https://github.com/takeshishimada/Lockman", from: "0.12.0")
 ]
 ```
 
@@ -241,7 +241,7 @@ Adicione a dependência ao seu alvo:
 
 | Lockman | The Composable Architecture |
 |---------|----------------------------|
-| 0.11.0  | 1.19.1                     |
+| 0.12.0  | 1.19.1                     |
 | 0.10.0  | 1.19.0                     |
 | 0.9.0   | 1.18.0                     |
 

--- a/Docs/README_zh-CN.md
+++ b/Docs/README_zh-CN.md
@@ -157,7 +157,7 @@ struct ProcessFeature {
 发布版本和 `main` 分支的文档可在此处获取：
 
 * [`main`](https://takeshishimada.github.io/Lockman/main/documentation/lockman/)
-* [0.11.0](https://takeshishimada.github.io/Lockman/0.11.0/documentation/lockman/)
+* [0.12.0](https://takeshishimada.github.io/Lockman/0.12.0/documentation/lockman/)
 * [0.10.0](https://takeshishimada.github.io/Lockman/0.10.0/documentation/lockman/)
 * [0.9.0](https://takeshishimada.github.io/Lockman/0.9.0/documentation/lockman/)
 * [0.8.0](https://takeshishimada.github.io/Lockman/0.8.0/documentation/lockman/)
@@ -213,7 +213,7 @@ https://github.com/takeshishimada/Lockman
 
 ```swift
 dependencies: [
-  .package(url: "https://github.com/takeshishimada/Lockman", from: "0.11.0")
+  .package(url: "https://github.com/takeshishimada/Lockman", from: "0.12.0")
 ]
 ```
 
@@ -241,7 +241,7 @@ dependencies: [
 
 | Lockman | The Composable Architecture |
 |---------|----------------------------|
-| 0.11.0  | 1.19.1                     |
+| 0.12.0  | 1.19.1                     |
 | 0.10.0  | 1.19.0                     |
 | 0.9.0   | 1.18.0                     |
 

--- a/Docs/README_zh-TW.md
+++ b/Docs/README_zh-TW.md
@@ -157,7 +157,7 @@ struct ProcessFeature {
 發布版本和 `main` 分支的文件可在此處取得：
 
 * [`main`](https://takeshishimada.github.io/Lockman/main/documentation/lockman/)
-* [0.11.0](https://takeshishimada.github.io/Lockman/0.11.0/documentation/lockman/)
+* [0.12.0](https://takeshishimada.github.io/Lockman/0.12.0/documentation/lockman/)
 * [0.10.0](https://takeshishimada.github.io/Lockman/0.10.0/documentation/lockman/)
 * [0.9.0](https://takeshishimada.github.io/Lockman/0.9.0/documentation/lockman/)
 * [0.8.0](https://takeshishimada.github.io/Lockman/0.8.0/documentation/lockman/)
@@ -213,7 +213,7 @@ https://github.com/takeshishimada/Lockman
 
 ```swift
 dependencies: [
-  .package(url: "https://github.com/takeshishimada/Lockman", from: "0.11.0")
+  .package(url: "https://github.com/takeshishimada/Lockman", from: "0.12.0")
 ]
 ```
 
@@ -241,7 +241,7 @@ dependencies: [
 
 | Lockman | The Composable Architecture |
 |---------|----------------------------|
-| 0.11.0  | 1.19.1                     |
+| 0.12.0  | 1.19.1                     |
 | 0.10.0  | 1.19.0                     |
 | 0.9.0   | 1.18.0                     |
 

--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ The `withLock` method ensures that `startProcessButtonTapped` won't execute whil
 The documentation for releases and `main` are available here:
 
 * [`main`](https://takeshishimada.github.io/Lockman/main/documentation/lockman/)
+* [0.12.0](https://takeshishimada.github.io/Lockman/0.12.0/documentation/lockman/)
 * [0.11.0](https://takeshishimada.github.io/Lockman/0.11.0/documentation/lockman/)
 * [0.10.0](https://takeshishimada.github.io/Lockman/0.10.0/documentation/lockman/)
 * [0.9.0](https://takeshishimada.github.io/Lockman/0.9.0/documentation/lockman/)
@@ -211,7 +212,7 @@ Add the dependency to your Package.swift file:
 
 ```swift
 dependencies: [
-  .package(url: "https://github.com/takeshishimada/Lockman", from: "0.11.0")
+  .package(url: "https://github.com/takeshishimada/Lockman", from: "0.12.0")
 ]
 ```
 
@@ -239,6 +240,7 @@ Add the dependency to your target:
 
 | Lockman | The Composable Architecture |
 |---------|----------------------------|
+| 0.12.0  | 1.20.1                     |
 | 0.11.0  | 1.19.1                     |
 | 0.10.0  | 1.19.0                     |
 | 0.9.0   | 1.18.0                     |

--- a/Sources/Lockman/Documentation.docc/GettingStarted.md
+++ b/Sources/Lockman/Documentation.docc/GettingStarted.md
@@ -12,7 +12,7 @@ To use Lockman in a Swift Package Manager project, add it to the dependencies in
 
 ```swift
 dependencies: [
-  .package(url: "https://github.com/takeshishimada/Lockman", from: "0.11.0")
+  .package(url: "https://github.com/takeshishimada/Lockman", from: "0.12.0")
 ]
 ```
 


### PR DESCRIPTION
## Release 0.12.0

### Summary
This release includes TCA 1.20.1 update, documentation improvements, and enhanced DocC examples.

### Changes

#### Features
- feat: update TCA to version 1.20.1 (#107)
- feat: add GitHub issue templates (#106)

#### Documentation
- docs: improve DocC examples with ViewAction pattern and correct CompositeInfo usage (#111)
- docs: unify terminology from concurrent control to exclusive control (#109)
- docs: remove 'Guide' from Debugging section title (#108)
- docs: organize README files into Docs directory (#104)

#### Maintenance
- chore: remove coverage.xcresult directory and add to .gitignore (#105)

### Breaking Changes
None

### Compatibility
- Swift: 5.9, 5.10, 6.0
- TCA: 1.20.1
- Platforms: iOS, macOS, tvOS, watchOS, Mac Catalyst

🤖 Generated with [Claude Code](https://claude.ai/code)