### PR TITLE
docs: update version information for 0.13.0 release

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ Develop a library to implement exclusive control of user actions in application 
 - Swift versions: 6.0, 5.10, 5.9
 - Type-safe implementation
 - Single unified Lockman module, developed exclusively for TCA
-- Based on Composable Architecture 1.20.1
+- Based on Composable Architecture 1.20.2
 - When modifying Package.swift, you MUST also update Package@swift-6.0 to keep them in sync
 
 ## Documentation

--- a/Docs/README_de.md
+++ b/Docs/README_de.md
@@ -157,7 +157,9 @@ Die `withLock` Methode stellt sicher, dass `startProcessButtonTapped` nicht ausg
 Die Dokumentation für veröffentlichte Versionen und `main` ist hier verfügbar:
 
 * [`main`](https://takeshishimada.github.io/Lockman/main/documentation/lockman/)
+* [0.13.0](https://takeshishimada.github.io/Lockman/0.13.0/documentation/lockman/)
 * [0.12.0](https://takeshishimada.github.io/Lockman/0.12.0/documentation/lockman/)
+* [0.11.0](https://takeshishimada.github.io/Lockman/0.11.0/documentation/lockman/)
 * [0.10.0](https://takeshishimada.github.io/Lockman/0.10.0/documentation/lockman/)
 * [0.9.0](https://takeshishimada.github.io/Lockman/0.9.0/documentation/lockman/)
 * [0.8.0](https://takeshishimada.github.io/Lockman/0.8.0/documentation/lockman/)
@@ -213,7 +215,7 @@ Fügen Sie die Abhängigkeit zu Ihrer Package.swift-Datei hinzu:
 
 ```swift
 dependencies: [
-  .package(url: "https://github.com/takeshishimada/Lockman", from: "0.12.0")
+  .package(url: "https://github.com/takeshishimada/Lockman", from: "0.13.0")
 ]
 ```
 
@@ -241,16 +243,18 @@ Fügen Sie die Abhängigkeit zu Ihrem Target hinzu:
 
 | Lockman | The Composable Architecture |
 |---------|----------------------------|
-| 0.12.0  | 1.19.1                     |
+| 0.13.0  | 1.20.2                     |
+| 0.12.0  | 1.20.1                     |
+| 0.11.0  | 1.19.1                     |
 | 0.10.0  | 1.19.0                     |
 | 0.9.0   | 1.18.0                     |
+| 0.8.0   | 1.17.1                     |
 
 <details>
 <summary>Weitere Versionen</summary>
 
 | Lockman | The Composable Architecture |
 |---------|----------------------------|
-| 0.8.0   | 1.17.1                     |
 | 0.7.0   | 1.17.1                     |
 | 0.6.0   | 1.17.1                     |
 | 0.5.0   | 1.17.1                     |

--- a/Docs/README_es.md
+++ b/Docs/README_es.md
@@ -157,7 +157,9 @@ El método `withLock` asegura que `startProcessButtonTapped` no se ejecute mient
 La documentación para las versiones publicadas y `main` está disponible aquí:
 
 * [`main`](https://takeshishimada.github.io/Lockman/main/documentation/lockman/)
+* [0.13.0](https://takeshishimada.github.io/Lockman/0.13.0/documentation/lockman/)
 * [0.12.0](https://takeshishimada.github.io/Lockman/0.12.0/documentation/lockman/)
+* [0.11.0](https://takeshishimada.github.io/Lockman/0.11.0/documentation/lockman/)
 * [0.10.0](https://takeshishimada.github.io/Lockman/0.10.0/documentation/lockman/)
 * [0.9.0](https://takeshishimada.github.io/Lockman/0.9.0/documentation/lockman/)
 * [0.8.0](https://takeshishimada.github.io/Lockman/0.8.0/documentation/lockman/)
@@ -213,7 +215,7 @@ Agrega la dependencia a tu archivo Package.swift:
 
 ```swift
 dependencies: [
-  .package(url: "https://github.com/takeshishimada/Lockman", from: "0.12.0")
+  .package(url: "https://github.com/takeshishimada/Lockman", from: "0.13.0")
 ]
 ```
 
@@ -241,16 +243,18 @@ Agrega la dependencia a tu objetivo:
 
 | Lockman | The Composable Architecture |
 |---------|----------------------------|
-| 0.12.0  | 1.19.1                     |
+| 0.13.0  | 1.20.2                     |
+| 0.12.0  | 1.20.1                     |
+| 0.11.0  | 1.19.1                     |
 | 0.10.0  | 1.19.0                     |
 | 0.9.0   | 1.18.0                     |
+| 0.8.0   | 1.17.1                     |
 
 <details>
 <summary>Otras versiones</summary>
 
 | Lockman | The Composable Architecture |
 |---------|----------------------------|
-| 0.8.0   | 1.17.1                     |
 | 0.7.0   | 1.17.1                     |
 | 0.6.0   | 1.17.1                     |
 | 0.5.0   | 1.17.1                     |

--- a/Docs/README_fr.md
+++ b/Docs/README_fr.md
@@ -157,7 +157,9 @@ La méthode `withLock` garantit que `startProcessButtonTapped` ne s'exécutera p
 La documentation pour les versions publiées et `main` est disponible ici :
 
 * [`main`](https://takeshishimada.github.io/Lockman/main/documentation/lockman/)
+* [0.13.0](https://takeshishimada.github.io/Lockman/0.13.0/documentation/lockman/)
 * [0.12.0](https://takeshishimada.github.io/Lockman/0.12.0/documentation/lockman/)
+* [0.11.0](https://takeshishimada.github.io/Lockman/0.11.0/documentation/lockman/)
 * [0.10.0](https://takeshishimada.github.io/Lockman/0.10.0/documentation/lockman/)
 * [0.9.0](https://takeshishimada.github.io/Lockman/0.9.0/documentation/lockman/)
 * [0.8.0](https://takeshishimada.github.io/Lockman/0.8.0/documentation/lockman/)
@@ -213,7 +215,7 @@ Ajoutez la dépendance à votre fichier Package.swift :
 
 ```swift
 dependencies: [
-  .package(url: "https://github.com/takeshishimada/Lockman", from: "0.12.0")
+  .package(url: "https://github.com/takeshishimada/Lockman", from: "0.13.0")
 ]
 ```
 
@@ -241,16 +243,18 @@ Ajoutez la dépendance à votre cible :
 
 | Lockman | The Composable Architecture |
 |---------|----------------------------|
-| 0.12.0  | 1.19.1                     |
+| 0.13.0  | 1.20.2                     |
+| 0.12.0  | 1.20.1                     |
+| 0.11.0  | 1.19.1                     |
 | 0.10.0  | 1.19.0                     |
 | 0.9.0   | 1.18.0                     |
+| 0.8.0   | 1.17.1                     |
 
 <details>
 <summary>Autres versions</summary>
 
 | Lockman | The Composable Architecture |
 |---------|----------------------------|
-| 0.8.0   | 1.17.1                     |
 | 0.7.0   | 1.17.1                     |
 | 0.6.0   | 1.17.1                     |
 | 0.5.0   | 1.17.1                     |

--- a/Docs/README_it.md
+++ b/Docs/README_it.md
@@ -157,7 +157,9 @@ Il metodo `withLock` garantisce che `startProcessButtonTapped` non verrà esegui
 La documentazione per le release e `main` è disponibile qui:
 
 * [`main`](https://takeshishimada.github.io/Lockman/main/documentation/lockman/)
+* [0.13.0](https://takeshishimada.github.io/Lockman/0.13.0/documentation/lockman/)
 * [0.12.0](https://takeshishimada.github.io/Lockman/0.12.0/documentation/lockman/)
+* [0.11.0](https://takeshishimada.github.io/Lockman/0.11.0/documentation/lockman/)
 * [0.10.0](https://takeshishimada.github.io/Lockman/0.10.0/documentation/lockman/)
 * [0.9.0](https://takeshishimada.github.io/Lockman/0.9.0/documentation/lockman/)
 * [0.8.0](https://takeshishimada.github.io/Lockman/0.8.0/documentation/lockman/)
@@ -213,7 +215,7 @@ Aggiungi la dipendenza al tuo file Package.swift:
 
 ```swift
 dependencies: [
-  .package(url: "https://github.com/takeshishimada/Lockman", from: "0.12.0")
+  .package(url: "https://github.com/takeshishimada/Lockman", from: "0.13.0")
 ]
 ```
 
@@ -241,16 +243,18 @@ Aggiungi la dipendenza al tuo target:
 
 | Lockman | The Composable Architecture |
 |---------|----------------------------|
-| 0.12.0  | 1.19.1                     |
+| 0.13.0  | 1.20.2                     |
+| 0.12.0  | 1.20.1                     |
+| 0.11.0  | 1.19.1                     |
 | 0.10.0  | 1.19.0                     |
 | 0.9.0   | 1.18.0                     |
+| 0.8.0   | 1.17.1                     |
 
 <details>
 <summary>Altre versioni</summary>
 
 | Lockman | The Composable Architecture |
 |---------|----------------------------|
-| 0.8.0   | 1.17.1                     |
 | 0.7.0   | 1.17.1                     |
 | 0.6.0   | 1.17.1                     |
 | 0.5.0   | 1.17.1                     |

--- a/Docs/README_ja.md
+++ b/Docs/README_ja.md
@@ -157,7 +157,9 @@ struct ProcessFeature {
 リリース版とmainのドキュメントはこちらで利用できます：
 
 * [`main`](https://takeshishimada.github.io/Lockman/main/documentation/lockman/)
+* [0.13.0](https://takeshishimada.github.io/Lockman/0.13.0/documentation/lockman/)
 * [0.12.0](https://takeshishimada.github.io/Lockman/0.12.0/documentation/lockman/)
+* [0.11.0](https://takeshishimada.github.io/Lockman/0.11.0/documentation/lockman/)
 * [0.10.0](https://takeshishimada.github.io/Lockman/0.10.0/documentation/lockman/)
 * [0.9.0](https://takeshishimada.github.io/Lockman/0.9.0/documentation/lockman/)
 * [0.8.0](https://takeshishimada.github.io/Lockman/0.8.0/documentation/lockman/)
@@ -211,7 +213,7 @@ Package.swiftファイルに依存関係を追加：
 
 ```swift
 dependencies: [
-  .package(url: "https://github.com/takeshishimada/Lockman", from: "0.12.0")
+  .package(url: "https://github.com/takeshishimada/Lockman", from: "0.13.0")
 ]
 ```
 
@@ -239,16 +241,18 @@ dependencies: [
 
 | Lockman | The Composable Architecture |
 |---------|----------------------------|
-| 0.12.0  | 1.19.1                     |
+| 0.13.0  | 1.20.2                     |
+| 0.12.0  | 1.20.1                     |
+| 0.11.0  | 1.19.1                     |
 | 0.10.0  | 1.19.0                     |
 | 0.9.0   | 1.18.0                     |
+| 0.8.0   | 1.17.1                     |
 
 <details>
 <summary>その他のバージョン</summary>
 
 | Lockman | The Composable Architecture |
 |---------|----------------------------|
-| 0.8.0   | 1.17.1                     |
 | 0.7.0   | 1.17.1                     |
 | 0.6.0   | 1.17.1                     |
 | 0.5.0   | 1.17.1                     |

--- a/Docs/README_ko.md
+++ b/Docs/README_ko.md
@@ -157,7 +157,9 @@ struct ProcessFeature {
 출시된 버전과 `main`에 대한 문서는 여기에서 사용할 수 있습니다:
 
 * [`main`](https://takeshishimada.github.io/Lockman/main/documentation/lockman/)
+* [0.13.0](https://takeshishimada.github.io/Lockman/0.13.0/documentation/lockman/)
 * [0.12.0](https://takeshishimada.github.io/Lockman/0.12.0/documentation/lockman/)
+* [0.11.0](https://takeshishimada.github.io/Lockman/0.11.0/documentation/lockman/)
 * [0.10.0](https://takeshishimada.github.io/Lockman/0.10.0/documentation/lockman/)
 * [0.9.0](https://takeshishimada.github.io/Lockman/0.9.0/documentation/lockman/)
 * [0.8.0](https://takeshishimada.github.io/Lockman/0.8.0/documentation/lockman/)
@@ -213,7 +215,7 @@ Package.swift 파일에 종속성을 추가하세요:
 
 ```swift
 dependencies: [
-  .package(url: "https://github.com/takeshishimada/Lockman", from: "0.12.0")
+  .package(url: "https://github.com/takeshishimada/Lockman", from: "0.13.0")
 ]
 ```
 
@@ -241,16 +243,18 @@ dependencies: [
 
 | Lockman | The Composable Architecture |
 |---------|----------------------------|
-| 0.12.0  | 1.19.1                     |
+| 0.13.0  | 1.20.2                     |
+| 0.12.0  | 1.20.1                     |
+| 0.11.0  | 1.19.1                     |
 | 0.10.0  | 1.19.0                     |
 | 0.9.0   | 1.18.0                     |
+| 0.8.0   | 1.17.1                     |
 
 <details>
 <summary>다른 버전</summary>
 
 | Lockman | The Composable Architecture |
 |---------|----------------------------|
-| 0.8.0   | 1.17.1                     |
 | 0.7.0   | 1.17.1                     |
 | 0.6.0   | 1.17.1                     |
 | 0.5.0   | 1.17.1                     |

--- a/Docs/README_pt-BR.md
+++ b/Docs/README_pt-BR.md
@@ -157,7 +157,9 @@ O método `withLock` garante que `startProcessButtonTapped` não será executado
 A documentação para lançamentos e `main` estão disponíveis aqui:
 
 * [`main`](https://takeshishimada.github.io/Lockman/main/documentation/lockman/)
+* [0.13.0](https://takeshishimada.github.io/Lockman/0.13.0/documentation/lockman/)
 * [0.12.0](https://takeshishimada.github.io/Lockman/0.12.0/documentation/lockman/)
+* [0.11.0](https://takeshishimada.github.io/Lockman/0.11.0/documentation/lockman/)
 * [0.10.0](https://takeshishimada.github.io/Lockman/0.10.0/documentation/lockman/)
 * [0.9.0](https://takeshishimada.github.io/Lockman/0.9.0/documentation/lockman/)
 * [0.8.0](https://takeshishimada.github.io/Lockman/0.8.0/documentation/lockman/)
@@ -213,7 +215,7 @@ Adicione a dependência ao seu arquivo Package.swift:
 
 ```swift
 dependencies: [
-  .package(url: "https://github.com/takeshishimada/Lockman", from: "0.12.0")
+  .package(url: "https://github.com/takeshishimada/Lockman", from: "0.13.0")
 ]
 ```
 
@@ -241,16 +243,18 @@ Adicione a dependência ao seu alvo:
 
 | Lockman | The Composable Architecture |
 |---------|----------------------------|
-| 0.12.0  | 1.19.1                     |
+| 0.13.0  | 1.20.2                     |
+| 0.12.0  | 1.20.1                     |
+| 0.11.0  | 1.19.1                     |
 | 0.10.0  | 1.19.0                     |
 | 0.9.0   | 1.18.0                     |
+| 0.8.0   | 1.17.1                     |
 
 <details>
 <summary>Outras versões</summary>
 
 | Lockman | The Composable Architecture |
 |---------|----------------------------|
-| 0.8.0   | 1.17.1                     |
 | 0.7.0   | 1.17.1                     |
 | 0.6.0   | 1.17.1                     |
 | 0.5.0   | 1.17.1                     |

--- a/Docs/README_zh-CN.md
+++ b/Docs/README_zh-CN.md
@@ -157,7 +157,9 @@ struct ProcessFeature {
 发布版本和 `main` 分支的文档可在此处获取：
 
 * [`main`](https://takeshishimada.github.io/Lockman/main/documentation/lockman/)
+* [0.13.0](https://takeshishimada.github.io/Lockman/0.13.0/documentation/lockman/)
 * [0.12.0](https://takeshishimada.github.io/Lockman/0.12.0/documentation/lockman/)
+* [0.11.0](https://takeshishimada.github.io/Lockman/0.11.0/documentation/lockman/)
 * [0.10.0](https://takeshishimada.github.io/Lockman/0.10.0/documentation/lockman/)
 * [0.9.0](https://takeshishimada.github.io/Lockman/0.9.0/documentation/lockman/)
 * [0.8.0](https://takeshishimada.github.io/Lockman/0.8.0/documentation/lockman/)
@@ -213,7 +215,7 @@ https://github.com/takeshishimada/Lockman
 
 ```swift
 dependencies: [
-  .package(url: "https://github.com/takeshishimada/Lockman", from: "0.12.0")
+  .package(url: "https://github.com/takeshishimada/Lockman", from: "0.13.0")
 ]
 ```
 
@@ -241,16 +243,18 @@ dependencies: [
 
 | Lockman | The Composable Architecture |
 |---------|----------------------------|
-| 0.12.0  | 1.19.1                     |
+| 0.13.0  | 1.20.2                     |
+| 0.12.0  | 1.20.1                     |
+| 0.11.0  | 1.19.1                     |
 | 0.10.0  | 1.19.0                     |
 | 0.9.0   | 1.18.0                     |
+| 0.8.0   | 1.17.1                     |
 
 <details>
 <summary>其他版本</summary>
 
 | Lockman | The Composable Architecture |
 |---------|----------------------------|
-| 0.8.0   | 1.17.1                     |
 | 0.7.0   | 1.17.1                     |
 | 0.6.0   | 1.17.1                     |
 | 0.5.0   | 1.17.1                     |

--- a/Docs/README_zh-TW.md
+++ b/Docs/README_zh-TW.md
@@ -157,7 +157,9 @@ struct ProcessFeature {
 發布版本和 `main` 分支的文件可在此處取得：
 
 * [`main`](https://takeshishimada.github.io/Lockman/main/documentation/lockman/)
+* [0.13.0](https://takeshishimada.github.io/Lockman/0.13.0/documentation/lockman/)
 * [0.12.0](https://takeshishimada.github.io/Lockman/0.12.0/documentation/lockman/)
+* [0.11.0](https://takeshishimada.github.io/Lockman/0.11.0/documentation/lockman/)
 * [0.10.0](https://takeshishimada.github.io/Lockman/0.10.0/documentation/lockman/)
 * [0.9.0](https://takeshishimada.github.io/Lockman/0.9.0/documentation/lockman/)
 * [0.8.0](https://takeshishimada.github.io/Lockman/0.8.0/documentation/lockman/)
@@ -213,7 +215,7 @@ https://github.com/takeshishimada/Lockman
 
 ```swift
 dependencies: [
-  .package(url: "https://github.com/takeshishimada/Lockman", from: "0.12.0")
+  .package(url: "https://github.com/takeshishimada/Lockman", from: "0.13.0")
 ]
 ```
 
@@ -241,16 +243,18 @@ dependencies: [
 
 | Lockman | The Composable Architecture |
 |---------|----------------------------|
-| 0.12.0  | 1.19.1                     |
+| 0.13.0  | 1.20.2                     |
+| 0.12.0  | 1.20.1                     |
+| 0.11.0  | 1.19.1                     |
 | 0.10.0  | 1.19.0                     |
 | 0.9.0   | 1.18.0                     |
+| 0.8.0   | 1.17.1                     |
 
 <details>
 <summary>其他版本</summary>
 
 | Lockman | The Composable Architecture |
 |---------|----------------------------|
-| 0.8.0   | 1.17.1                     |
 | 0.7.0   | 1.17.1                     |
 | 0.6.0   | 1.17.1                     |
 | 0.5.0   | 1.17.1                     |

--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ The `withLock` method ensures that `startProcessButtonTapped` won't execute whil
 The documentation for releases and `main` are available here:
 
 * [`main`](https://takeshishimada.github.io/Lockman/main/documentation/lockman/)
+* [0.13.0](https://takeshishimada.github.io/Lockman/0.13.0/documentation/lockman/)
 * [0.12.0](https://takeshishimada.github.io/Lockman/0.12.0/documentation/lockman/)
 * [0.11.0](https://takeshishimada.github.io/Lockman/0.11.0/documentation/lockman/)
 * [0.10.0](https://takeshishimada.github.io/Lockman/0.10.0/documentation/lockman/)
@@ -212,7 +213,7 @@ Add the dependency to your Package.swift file:
 
 ```swift
 dependencies: [
-  .package(url: "https://github.com/takeshishimada/Lockman", from: "0.12.0")
+  .package(url: "https://github.com/takeshishimada/Lockman", from: "0.13.0")
 ]
 ```
 
@@ -240,17 +241,18 @@ Add the dependency to your target:
 
 | Lockman | The Composable Architecture |
 |---------|----------------------------|
+| 0.13.0  | 1.20.2                     |
 | 0.12.0  | 1.20.1                     |
 | 0.11.0  | 1.19.1                     |
 | 0.10.0  | 1.19.0                     |
 | 0.9.0   | 1.18.0                     |
+| 0.8.0   | 1.17.1                     |
 
 <details>
 <summary>Other versions</summary>
 
 | Lockman | The Composable Architecture |
 |---------|----------------------------|
-| 0.8.0   | 1.17.1                     |
 | 0.7.0   | 1.17.1                     |
 | 0.6.0   | 1.17.1                     |
 | 0.5.0   | 1.17.1                     |

--- a/Sources/Lockman/Documentation.docc/GettingStarted.md
+++ b/Sources/Lockman/Documentation.docc/GettingStarted.md
@@ -12,7 +12,7 @@ To use Lockman in a Swift Package Manager project, add it to the dependencies in
 
 ```swift
 dependencies: [
-  .package(url: "https://github.com/takeshishimada/Lockman", from: "0.12.0")
+  .package(url: "https://github.com/takeshishimada/Lockman", from: "0.13.0")
 ]
 ```
 


### PR DESCRIPTION
## Summary
- Update documentation to reflect the 0.13.0 release
- Ensure version information is consistent across all README files

## Changes
- Added 0.13.0 to documentation links and version compatibility tables
- Updated TCA version reference from 1.20.1 to 1.20.2 in CLAUDE.md
- Updated installation example version from 0.12.0 to 0.13.0
- Reorganized version compatibility table:
  - Main table now shows versions 0.8.0 through 0.13.0
  - Older versions (0.7.0 and below) moved to "Other versions" section
- Applied consistent updates across all 10 README files (main + 9 localized versions)

## Files Updated
- `README.md` - Main English documentation
- `CLAUDE.md` - Project instructions
- `Docs/README_ja.md` - Japanese
- `Docs/README_zh-CN.md` - Simplified Chinese
- `Docs/README_zh-TW.md` - Traditional Chinese
- `Docs/README_es.md` - Spanish
- `Docs/README_fr.md` - French
- `Docs/README_de.md` - German
- `Docs/README_ko.md` - Korean
- `Docs/README_pt-BR.md` - Portuguese
- `Docs/README_it.md` - Italian

🤖 Generated with [Claude Code](https://claude.ai/code)