### PR TITLE
fix: add Foundation import for Swift 5.10 compatibility

### DIFF
--- a/Docs/README_de.md
+++ b/Docs/README_de.md
@@ -158,15 +158,15 @@ Die Dokumentation für veröffentlichte Versionen und `main` ist hier verfügbar
 
 * [`main`](https://takeshishimada.github.io/Lockman/main/documentation/lockman/)
 * [0.13.0](https://takeshishimada.github.io/Lockman/0.13.0/documentation/lockman/)
+
+<details>
+<summary>Weitere Versionen</summary>
+
 * [0.12.0](https://takeshishimada.github.io/Lockman/0.12.0/documentation/lockman/)
 * [0.11.0](https://takeshishimada.github.io/Lockman/0.11.0/documentation/lockman/)
 * [0.10.0](https://takeshishimada.github.io/Lockman/0.10.0/documentation/lockman/)
 * [0.9.0](https://takeshishimada.github.io/Lockman/0.9.0/documentation/lockman/)
 * [0.8.0](https://takeshishimada.github.io/Lockman/0.8.0/documentation/lockman/)
-
-<details>
-<summary>Weitere Versionen</summary>
-
 * [0.7.0](https://takeshishimada.github.io/Lockman/0.7.0/documentation/lockman/)
 * [0.6.0](https://takeshishimada.github.io/Lockman/0.6.0/documentation/lockman/)
 * [0.5.0](https://takeshishimada.github.io/Lockman/0.5.0/documentation/lockman/)

--- a/Docs/README_es.md
+++ b/Docs/README_es.md
@@ -158,15 +158,15 @@ La documentación para las versiones publicadas y `main` está disponible aquí:
 
 * [`main`](https://takeshishimada.github.io/Lockman/main/documentation/lockman/)
 * [0.13.0](https://takeshishimada.github.io/Lockman/0.13.0/documentation/lockman/)
+
+<details>
+<summary>Otras versiones</summary>
+
 * [0.12.0](https://takeshishimada.github.io/Lockman/0.12.0/documentation/lockman/)
 * [0.11.0](https://takeshishimada.github.io/Lockman/0.11.0/documentation/lockman/)
 * [0.10.0](https://takeshishimada.github.io/Lockman/0.10.0/documentation/lockman/)
 * [0.9.0](https://takeshishimada.github.io/Lockman/0.9.0/documentation/lockman/)
 * [0.8.0](https://takeshishimada.github.io/Lockman/0.8.0/documentation/lockman/)
-
-<details>
-<summary>Otras versiones</summary>
-
 * [0.7.0](https://takeshishimada.github.io/Lockman/0.7.0/documentation/lockman/)
 * [0.6.0](https://takeshishimada.github.io/Lockman/0.6.0/documentation/lockman/)
 * [0.5.0](https://takeshishimada.github.io/Lockman/0.5.0/documentation/lockman/)

--- a/Docs/README_fr.md
+++ b/Docs/README_fr.md
@@ -158,15 +158,15 @@ La documentation pour les versions publiées et `main` est disponible ici :
 
 * [`main`](https://takeshishimada.github.io/Lockman/main/documentation/lockman/)
 * [0.13.0](https://takeshishimada.github.io/Lockman/0.13.0/documentation/lockman/)
+
+<details>
+<summary>Autres versions</summary>
+
 * [0.12.0](https://takeshishimada.github.io/Lockman/0.12.0/documentation/lockman/)
 * [0.11.0](https://takeshishimada.github.io/Lockman/0.11.0/documentation/lockman/)
 * [0.10.0](https://takeshishimada.github.io/Lockman/0.10.0/documentation/lockman/)
 * [0.9.0](https://takeshishimada.github.io/Lockman/0.9.0/documentation/lockman/)
 * [0.8.0](https://takeshishimada.github.io/Lockman/0.8.0/documentation/lockman/)
-
-<details>
-<summary>Autres versions</summary>
-
 * [0.7.0](https://takeshishimada.github.io/Lockman/0.7.0/documentation/lockman/)
 * [0.6.0](https://takeshishimada.github.io/Lockman/0.6.0/documentation/lockman/)
 * [0.5.0](https://takeshishimada.github.io/Lockman/0.5.0/documentation/lockman/)

--- a/Docs/README_it.md
+++ b/Docs/README_it.md
@@ -158,15 +158,15 @@ La documentazione per le release e `main` è disponibile qui:
 
 * [`main`](https://takeshishimada.github.io/Lockman/main/documentation/lockman/)
 * [0.13.0](https://takeshishimada.github.io/Lockman/0.13.0/documentation/lockman/)
+
+<details>
+<summary>Altre versioni</summary>
+
 * [0.12.0](https://takeshishimada.github.io/Lockman/0.12.0/documentation/lockman/)
 * [0.11.0](https://takeshishimada.github.io/Lockman/0.11.0/documentation/lockman/)
 * [0.10.0](https://takeshishimada.github.io/Lockman/0.10.0/documentation/lockman/)
 * [0.9.0](https://takeshishimada.github.io/Lockman/0.9.0/documentation/lockman/)
 * [0.8.0](https://takeshishimada.github.io/Lockman/0.8.0/documentation/lockman/)
-
-<details>
-<summary>Altre versioni</summary>
-
 * [0.7.0](https://takeshishimada.github.io/Lockman/0.7.0/documentation/lockman/)
 * [0.6.0](https://takeshishimada.github.io/Lockman/0.6.0/documentation/lockman/)
 * [0.5.0](https://takeshishimada.github.io/Lockman/0.5.0/documentation/lockman/)

--- a/Docs/README_ja.md
+++ b/Docs/README_ja.md
@@ -158,15 +158,15 @@ struct ProcessFeature {
 
 * [`main`](https://takeshishimada.github.io/Lockman/main/documentation/lockman/)
 * [0.13.0](https://takeshishimada.github.io/Lockman/0.13.0/documentation/lockman/)
+
+<details>
+<summary>その他のバージョン</summary>
+
 * [0.12.0](https://takeshishimada.github.io/Lockman/0.12.0/documentation/lockman/)
 * [0.11.0](https://takeshishimada.github.io/Lockman/0.11.0/documentation/lockman/)
 * [0.10.0](https://takeshishimada.github.io/Lockman/0.10.0/documentation/lockman/)
 * [0.9.0](https://takeshishimada.github.io/Lockman/0.9.0/documentation/lockman/)
 * [0.8.0](https://takeshishimada.github.io/Lockman/0.8.0/documentation/lockman/)
-
-<details>
-<summary>その他のバージョン</summary>
-
 * [0.7.0](https://takeshishimada.github.io/Lockman/0.7.0/documentation/lockman/)
 * [0.6.0](https://takeshishimada.github.io/Lockman/0.6.0/documentation/lockman/)
 * [0.5.0](https://takeshishimada.github.io/Lockman/0.5.0/documentation/lockman/)

--- a/Docs/README_ko.md
+++ b/Docs/README_ko.md
@@ -158,15 +158,15 @@ struct ProcessFeature {
 
 * [`main`](https://takeshishimada.github.io/Lockman/main/documentation/lockman/)
 * [0.13.0](https://takeshishimada.github.io/Lockman/0.13.0/documentation/lockman/)
+
+<details>
+<summary>다른 버전</summary>
+
 * [0.12.0](https://takeshishimada.github.io/Lockman/0.12.0/documentation/lockman/)
 * [0.11.0](https://takeshishimada.github.io/Lockman/0.11.0/documentation/lockman/)
 * [0.10.0](https://takeshishimada.github.io/Lockman/0.10.0/documentation/lockman/)
 * [0.9.0](https://takeshishimada.github.io/Lockman/0.9.0/documentation/lockman/)
 * [0.8.0](https://takeshishimada.github.io/Lockman/0.8.0/documentation/lockman/)
-
-<details>
-<summary>다른 버전</summary>
-
 * [0.7.0](https://takeshishimada.github.io/Lockman/0.7.0/documentation/lockman/)
 * [0.6.0](https://takeshishimada.github.io/Lockman/0.6.0/documentation/lockman/)
 * [0.5.0](https://takeshishimada.github.io/Lockman/0.5.0/documentation/lockman/)

--- a/Docs/README_pt-BR.md
+++ b/Docs/README_pt-BR.md
@@ -158,15 +158,15 @@ A documentação para lançamentos e `main` estão disponíveis aqui:
 
 * [`main`](https://takeshishimada.github.io/Lockman/main/documentation/lockman/)
 * [0.13.0](https://takeshishimada.github.io/Lockman/0.13.0/documentation/lockman/)
+
+<details>
+<summary>Outras versões</summary>
+
 * [0.12.0](https://takeshishimada.github.io/Lockman/0.12.0/documentation/lockman/)
 * [0.11.0](https://takeshishimada.github.io/Lockman/0.11.0/documentation/lockman/)
 * [0.10.0](https://takeshishimada.github.io/Lockman/0.10.0/documentation/lockman/)
 * [0.9.0](https://takeshishimada.github.io/Lockman/0.9.0/documentation/lockman/)
 * [0.8.0](https://takeshishimada.github.io/Lockman/0.8.0/documentation/lockman/)
-
-<details>
-<summary>Outras versões</summary>
-
 * [0.7.0](https://takeshishimada.github.io/Lockman/0.7.0/documentation/lockman/)
 * [0.6.0](https://takeshishimada.github.io/Lockman/0.6.0/documentation/lockman/)
 * [0.5.0](https://takeshishimada.github.io/Lockman/0.5.0/documentation/lockman/)

--- a/Docs/README_zh-CN.md
+++ b/Docs/README_zh-CN.md
@@ -158,15 +158,15 @@ struct ProcessFeature {
 
 * [`main`](https://takeshishimada.github.io/Lockman/main/documentation/lockman/)
 * [0.13.0](https://takeshishimada.github.io/Lockman/0.13.0/documentation/lockman/)
+
+<details>
+<summary>其他版本</summary>
+
 * [0.12.0](https://takeshishimada.github.io/Lockman/0.12.0/documentation/lockman/)
 * [0.11.0](https://takeshishimada.github.io/Lockman/0.11.0/documentation/lockman/)
 * [0.10.0](https://takeshishimada.github.io/Lockman/0.10.0/documentation/lockman/)
 * [0.9.0](https://takeshishimada.github.io/Lockman/0.9.0/documentation/lockman/)
 * [0.8.0](https://takeshishimada.github.io/Lockman/0.8.0/documentation/lockman/)
-
-<details>
-<summary>其他版本</summary>
-
 * [0.7.0](https://takeshishimada.github.io/Lockman/0.7.0/documentation/lockman/)
 * [0.6.0](https://takeshishimada.github.io/Lockman/0.6.0/documentation/lockman/)
 * [0.5.0](https://takeshishimada.github.io/Lockman/0.5.0/documentation/lockman/)

--- a/Docs/README_zh-TW.md
+++ b/Docs/README_zh-TW.md
@@ -158,15 +158,15 @@ struct ProcessFeature {
 
 * [`main`](https://takeshishimada.github.io/Lockman/main/documentation/lockman/)
 * [0.13.0](https://takeshishimada.github.io/Lockman/0.13.0/documentation/lockman/)
+
+<details>
+<summary>其他版本</summary>
+
 * [0.12.0](https://takeshishimada.github.io/Lockman/0.12.0/documentation/lockman/)
 * [0.11.0](https://takeshishimada.github.io/Lockman/0.11.0/documentation/lockman/)
 * [0.10.0](https://takeshishimada.github.io/Lockman/0.10.0/documentation/lockman/)
 * [0.9.0](https://takeshishimada.github.io/Lockman/0.9.0/documentation/lockman/)
 * [0.8.0](https://takeshishimada.github.io/Lockman/0.8.0/documentation/lockman/)
-
-<details>
-<summary>其他版本</summary>
-
 * [0.7.0](https://takeshishimada.github.io/Lockman/0.7.0/documentation/lockman/)
 * [0.6.0](https://takeshishimada.github.io/Lockman/0.6.0/documentation/lockman/)
 * [0.5.0](https://takeshishimada.github.io/Lockman/0.5.0/documentation/lockman/)

--- a/README.md
+++ b/README.md
@@ -158,15 +158,15 @@ The documentation for releases and `main` are available here:
 
 * [`main`](https://takeshishimada.github.io/Lockman/main/documentation/lockman/)
 * [0.13.0](https://takeshishimada.github.io/Lockman/0.13.0/documentation/lockman/)
+
+<details>
+<summary>Other versions</summary>
+
 * [0.12.0](https://takeshishimada.github.io/Lockman/0.12.0/documentation/lockman/)
 * [0.11.0](https://takeshishimada.github.io/Lockman/0.11.0/documentation/lockman/)
 * [0.10.0](https://takeshishimada.github.io/Lockman/0.10.0/documentation/lockman/)
 * [0.9.0](https://takeshishimada.github.io/Lockman/0.9.0/documentation/lockman/)
 * [0.8.0](https://takeshishimada.github.io/Lockman/0.8.0/documentation/lockman/)
-
-<details>
-<summary>Other versions</summary>
-
 * [0.7.0](https://takeshishimada.github.io/Lockman/0.7.0/documentation/lockman/)
 * [0.6.0](https://takeshishimada.github.io/Lockman/0.6.0/documentation/lockman/)
 * [0.5.0](https://takeshishimada.github.io/Lockman/0.5.0/documentation/lockman/)

--- a/Sources/LockmanMacros/LockmanCompositeStrategyMacro.swift
+++ b/Sources/LockmanMacros/LockmanCompositeStrategyMacro.swift
@@ -1,3 +1,4 @@
+import Foundation
 import SwiftCompilerPlugin
 import SwiftSyntax
 import SwiftSyntaxBuilder


### PR DESCRIPTION
## Summary
- Fix Swift Package Index build error for Swift 5.10
- Add missing Foundation import to LockmanCompositeStrategyMacro.swift

## Changes
- Added `import Foundation` to fix `trimmingCharacters` method not found error

## Context
Swift Package Index build was failing for Swift 5.10 iOS with the error:
```
error: value of type 'String' has no member 'trimmingCharacters'
```

This is because Swift 5.10 requires explicit Foundation import to use String's trimmingCharacters method.

## Test Plan
- [x] Local build passes
- [ ] Swift Package Index build should pass after merge

🤖 Generated with [Claude Code](https://claude.ai/code)