### PR TITLE
feat: add .spi.yml configuration for Swift Package Index

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -1,0 +1,12 @@
+version: 1
+builder:
+  configs:
+  - platform: ios
+    scheme: Lockman
+  - platform: macos-xcodebuild
+    scheme: Lockman
+  - platform: tvos
+    scheme: Lockman
+  - platform: watchos
+    scheme: Lockman
+  - documentation_targets: [Lockman]


### PR DESCRIPTION
## Summary
- Add Swift Package Index configuration file to fix build errors
- Specify build schemes for all supported platforms

## Problem
Swift Package Index builds were failing with the error:
```
the package at '/Users/admin/builder/Lockman' cannot be accessed
```

The build system was looking for the package at an incorrect path instead of the actual workspace location.

## Solution
Added `.spi.yml` configuration file with:
- Build scheme specification for iOS, macOS, tvOS, and watchOS
- Documentation target configuration
- Follows the same pattern as TCA's configuration

## References
- [TCA's .spi.yml](https://github.com/pointfreeco/swift-composable-architecture/blob/main/.spi.yml)
- [Swift Package Index Documentation](https://swiftpackageindex.com/docs)

## Test Plan
- [ ] Swift Package Index builds should pass after this PR is merged
- [ ] All platforms should build successfully

🤖 Generated with [Claude Code](https://claude.ai/code)