### PR TITLE
docs: update version information for 0.13.1 release

### DIFF
--- a/Docs/README_de.md
+++ b/Docs/README_de.md
@@ -215,7 +215,7 @@ Fügen Sie die Abhängigkeit zu Ihrer Package.swift-Datei hinzu:
 
 ```swift
 dependencies: [
-  .package(url: "https://github.com/takeshishimada/Lockman", from: "0.13.0")
+  .package(url: "https://github.com/takeshishimada/Lockman", from: "0.13.1")
 ]
 ```
 
@@ -243,6 +243,7 @@ Fügen Sie die Abhängigkeit zu Ihrem Target hinzu:
 
 | Lockman | The Composable Architecture |
 |---------|----------------------------|
+| 0.13.1  | 1.20.2                     |
 | 0.13.0  | 1.20.2                     |
 | 0.12.0  | 1.20.1                     |
 | 0.11.0  | 1.19.1                     |

--- a/Docs/README_es.md
+++ b/Docs/README_es.md
@@ -215,7 +215,7 @@ Agrega la dependencia a tu archivo Package.swift:
 
 ```swift
 dependencies: [
-  .package(url: "https://github.com/takeshishimada/Lockman", from: "0.13.0")
+  .package(url: "https://github.com/takeshishimada/Lockman", from: "0.13.1")
 ]
 ```
 
@@ -243,6 +243,7 @@ Agrega la dependencia a tu objetivo:
 
 | Lockman | The Composable Architecture |
 |---------|----------------------------|
+| 0.13.1  | 1.20.2                     |
 | 0.13.0  | 1.20.2                     |
 | 0.12.0  | 1.20.1                     |
 | 0.11.0  | 1.19.1                     |

--- a/Docs/README_fr.md
+++ b/Docs/README_fr.md
@@ -215,7 +215,7 @@ Ajoutez la dépendance à votre fichier Package.swift :
 
 ```swift
 dependencies: [
-  .package(url: "https://github.com/takeshishimada/Lockman", from: "0.13.0")
+  .package(url: "https://github.com/takeshishimada/Lockman", from: "0.13.1")
 ]
 ```
 
@@ -243,6 +243,7 @@ Ajoutez la dépendance à votre cible :
 
 | Lockman | The Composable Architecture |
 |---------|----------------------------|
+| 0.13.1  | 1.20.2                     |
 | 0.13.0  | 1.20.2                     |
 | 0.12.0  | 1.20.1                     |
 | 0.11.0  | 1.19.1                     |

--- a/Docs/README_it.md
+++ b/Docs/README_it.md
@@ -215,7 +215,7 @@ Aggiungi la dipendenza al tuo file Package.swift:
 
 ```swift
 dependencies: [
-  .package(url: "https://github.com/takeshishimada/Lockman", from: "0.13.0")
+  .package(url: "https://github.com/takeshishimada/Lockman", from: "0.13.1")
 ]
 ```
 
@@ -243,6 +243,7 @@ Aggiungi la dipendenza al tuo target:
 
 | Lockman | The Composable Architecture |
 |---------|----------------------------|
+| 0.13.1  | 1.20.2                     |
 | 0.13.0  | 1.20.2                     |
 | 0.12.0  | 1.20.1                     |
 | 0.11.0  | 1.19.1                     |

--- a/Docs/README_ja.md
+++ b/Docs/README_ja.md
@@ -213,7 +213,7 @@ Package.swiftファイルに依存関係を追加：
 
 ```swift
 dependencies: [
-  .package(url: "https://github.com/takeshishimada/Lockman", from: "0.13.0")
+  .package(url: "https://github.com/takeshishimada/Lockman", from: "0.13.1")
 ]
 ```
 
@@ -241,6 +241,7 @@ dependencies: [
 
 | Lockman | The Composable Architecture |
 |---------|----------------------------|
+| 0.13.1  | 1.20.2                     |
 | 0.13.0  | 1.20.2                     |
 | 0.12.0  | 1.20.1                     |
 | 0.11.0  | 1.19.1                     |

--- a/Docs/README_ko.md
+++ b/Docs/README_ko.md
@@ -215,7 +215,7 @@ Package.swift 파일에 종속성을 추가하세요:
 
 ```swift
 dependencies: [
-  .package(url: "https://github.com/takeshishimada/Lockman", from: "0.13.0")
+  .package(url: "https://github.com/takeshishimada/Lockman", from: "0.13.1")
 ]
 ```
 
@@ -243,6 +243,7 @@ dependencies: [
 
 | Lockman | The Composable Architecture |
 |---------|----------------------------|
+| 0.13.1  | 1.20.2                     |
 | 0.13.0  | 1.20.2                     |
 | 0.12.0  | 1.20.1                     |
 | 0.11.0  | 1.19.1                     |

--- a/Docs/README_pt-BR.md
+++ b/Docs/README_pt-BR.md
@@ -215,7 +215,7 @@ Adicione a dependência ao seu arquivo Package.swift:
 
 ```swift
 dependencies: [
-  .package(url: "https://github.com/takeshishimada/Lockman", from: "0.13.0")
+  .package(url: "https://github.com/takeshishimada/Lockman", from: "0.13.1")
 ]
 ```
 
@@ -243,6 +243,7 @@ Adicione a dependência ao seu alvo:
 
 | Lockman | The Composable Architecture |
 |---------|----------------------------|
+| 0.13.1  | 1.20.2                     |
 | 0.13.0  | 1.20.2                     |
 | 0.12.0  | 1.20.1                     |
 | 0.11.0  | 1.19.1                     |

--- a/Docs/README_zh-CN.md
+++ b/Docs/README_zh-CN.md
@@ -215,7 +215,7 @@ https://github.com/takeshishimada/Lockman
 
 ```swift
 dependencies: [
-  .package(url: "https://github.com/takeshishimada/Lockman", from: "0.13.0")
+  .package(url: "https://github.com/takeshishimada/Lockman", from: "0.13.1")
 ]
 ```
 
@@ -243,6 +243,7 @@ dependencies: [
 
 | Lockman | The Composable Architecture |
 |---------|----------------------------|
+| 0.13.1  | 1.20.2                     |
 | 0.13.0  | 1.20.2                     |
 | 0.12.0  | 1.20.1                     |
 | 0.11.0  | 1.19.1                     |

--- a/Docs/README_zh-TW.md
+++ b/Docs/README_zh-TW.md
@@ -215,7 +215,7 @@ https://github.com/takeshishimada/Lockman
 
 ```swift
 dependencies: [
-  .package(url: "https://github.com/takeshishimada/Lockman", from: "0.13.0")
+  .package(url: "https://github.com/takeshishimada/Lockman", from: "0.13.1")
 ]
 ```
 
@@ -243,6 +243,7 @@ dependencies: [
 
 | Lockman | The Composable Architecture |
 |---------|----------------------------|
+| 0.13.1  | 1.20.2                     |
 | 0.13.0  | 1.20.2                     |
 | 0.12.0  | 1.20.1                     |
 | 0.11.0  | 1.19.1                     |

--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ Add the dependency to your Package.swift file:
 
 ```swift
 dependencies: [
-  .package(url: "https://github.com/takeshishimada/Lockman", from: "0.13.0")
+  .package(url: "https://github.com/takeshishimada/Lockman", from: "0.13.1")
 ]
 ```
 
@@ -241,6 +241,7 @@ Add the dependency to your target:
 
 | Lockman | The Composable Architecture |
 |---------|----------------------------|
+| 0.13.1  | 1.20.2                     |
 | 0.13.0  | 1.20.2                     |
 | 0.12.0  | 1.20.1                     |
 | 0.11.0  | 1.19.1                     |

--- a/Sources/Lockman/Documentation.docc/GettingStarted.md
+++ b/Sources/Lockman/Documentation.docc/GettingStarted.md
@@ -12,7 +12,7 @@ To use Lockman in a Swift Package Manager project, add it to the dependencies in
 
 ```swift
 dependencies: [
-  .package(url: "https://github.com/takeshishimada/Lockman", from: "0.13.0")
+  .package(url: "https://github.com/takeshishimada/Lockman", from: "0.13.1")
 ]
 ```
 


### PR DESCRIPTION
## Summary
- Update version references from 0.13.0 to 0.13.1 in all documentation
- Add 0.13.1 to version compatibility table

## Changes
- Update package dependency version in README and all translations
- Update package dependency version in DocC GettingStarted.md
- Add 0.13.1 entry to version compatibility table (keeping 0.13.0 for reference)

## Note
Documentation links remain pointing to 0.13.0 as DocC was not generated for the 0.13.1 release.

🤖 Generated with [Claude Code](https://claude.ai/code)