### PR TITLE
fix: correct scheme name in .spi.yml for Swift Package Index builds

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -2,11 +2,11 @@ version: 1
 builder:
   configs:
   - platform: ios
-    scheme: Lockman
+    scheme: Lockman-Package
   - platform: macos-xcodebuild
-    scheme: Lockman
+    scheme: Lockman-Package
   - platform: tvos
-    scheme: Lockman
+    scheme: Lockman-Package
   - platform: watchos
-    scheme: Lockman
+    scheme: Lockman-Package
   - documentation_targets: [Lockman]


### PR DESCRIPTION
## Summary
- Fixed Swift Package Index build failures by correcting the scheme name in `.spi.yml`
- Changed scheme name from `Lockman` to `Lockman-Package` for all platforms

## Problem
The Swift Package Index builds were failing with "No build command" error. Investigation revealed that the scheme name `Lockman` specified in `.spi.yml` did not exist. The actual scheme name generated by Swift Package Manager is `Lockman-Package`.

## Solution
Updated all platform configurations in `.spi.yml` to use the correct scheme name `Lockman-Package`.

## Build Error Links
- [iOS build failure](https://swiftpackageindex.com/builds/8A090257-72B3-4232-81C9-1D022D9FA821)
- [macOS build failure](https://swiftpackageindex.com/builds/4C070650-1F06-4E74-B106-D0D6EF1F9F2B)

🤖 Generated with [Claude Code](https://claude.ai/code)