### PR TITLE
feat: add unlockOption property to LockmanAction protocol

### DIFF
--- a/CLAUDE_WIP.md
+++ b/CLAUDE_WIP.md
@@ -1,0 +1,60 @@
+# CLAUDE_WIP.md - Work In Progress Tasks
+
+## Lockman v1.0 Roadmap
+
+### Feature 1: Add unlockOption to LockmanAction
+- Add `unlockOption` property to LockmanAction protocol
+- Use action's setting when not specified in withLock/lock()
+- Default value is `.immediate` (from `LockmanManager.config.defaultUnlockOption`)
+- Priority order:
+  1. Explicitly specified in withLock/lock() → Highest priority
+  2. Action's unlockOption → Next priority
+  3. config.defaultUnlockOption → Lowest priority
+
+### Feature 2: Argument Label Change (Breaking Change)
+- Change `id` → `boundaryId` in all Lockman APIs
+- Affected: withLock, lock(), and related methods
+- Acceptable as breaking change for v1.0
+
+### Feature 3: Reducer-level Locking (.lock() method)
+- Enable using existing `run` methods without modification
+- Only actions implementing LockmanAction protocol are locked
+
+**Interface Specification:**
+```swift
+public extension Reducer {
+    func lock(
+        boundaryId: any LockmanBoundaryId,
+        cancelIDs: [any LockmanBoundaryId] = [],
+        unlockOption: UnlockOption = .immediate,
+        onLockFailed: (@Sendable (Action) -> Void)? = nil,
+        onDynamicCondition: (@Sendable (State, Action, Set<LockmanBoundaryId>) -> LockingStrategy)? = nil
+    ) -> LockmanReducer<Self>
+}
+```
+
+### Feature 4: Effect-level .lock() method
+- Method chain alternative to withLock
+- Strategy is obtained from LockmanAction (no need to specify)
+
+**Interface Specification:**
+```swift
+extension Effect {
+    func lock(
+        boundaryId: any LockmanBoundaryId,
+        unlockOption: UnlockOption? = nil,
+        handleCancellationErrors: Bool = true
+    ) -> Effect<Action>
+}
+```
+
+## Implementation Order
+1. Feature 2 (argument label change) - Foundation for other features
+2. Feature 1 (add unlockOption) - Used by features 3 and 4
+3. Feature 3 (Reducer.lock())
+4. Feature 4 (Effect.lock())
+
+## Notes
+- All features target v1.0 release
+- Feature 2 is a breaking change, acceptable for major version
+- Features 3 and 4 provide more ergonomic APIs while maintaining compatibility with existing withLock

--- a/Sources/Lockman/Composable/Effect+Lockman.swift
+++ b/Sources/Lockman/Composable/Effect+Lockman.swift
@@ -56,7 +56,7 @@ extension Effect {
     withLockCommon(
       action: action,
       cancelID: cancelID,
-      unlockOption: unlockOption ?? LockmanManager.config.defaultUnlockOption,
+      unlockOption: unlockOption ?? action.unlockOption,
       fileID: fileID,
       filePath: filePath,
       line: line,
@@ -157,7 +157,7 @@ extension Effect {
     withLockCommon(
       action: action,
       cancelID: cancelID,
-      unlockOption: unlockOption ?? LockmanManager.config.defaultUnlockOption,
+      unlockOption: unlockOption ?? action.unlockOption,
       fileID: fileID,
       filePath: filePath,
       line: line,
@@ -251,7 +251,7 @@ extension Effect {
         id: cancelID,
         info: lockmanInfo,
         strategy: strategy,
-        unlockOption: unlockOption ?? LockmanManager.config.defaultUnlockOption
+        unlockOption: unlockOption ?? action.unlockOption
       )
 
       // Create auto-unlock manager for guaranteed cleanup

--- a/Sources/Lockman/Core/Protocols/LockmanAction.swift
+++ b/Sources/Lockman/Core/Protocols/LockmanAction.swift
@@ -20,6 +20,21 @@
 /// }
 /// ```
 ///
+/// For custom unlock timing:
+/// ```swift
+/// struct TransitionAction: LockmanAction {
+///   typealias I = LockmanSingleExecutionInfo
+///
+///   let lockmanInfo = LockmanSingleExecutionInfo(
+///     actionId: "transition",
+///     mode: .boundary
+///   )
+///
+///   // Release lock after screen transition completes
+///   var unlockOption: LockmanUnlockOption { .transition }
+/// }
+/// ```
+///
 /// For custom or configured strategies:
 /// ```swift
 /// struct ConfiguredAction: LockmanAction {
@@ -43,4 +58,17 @@ public protocol LockmanAction: Sendable {
   /// This instance contains all the necessary data for the strategy to make
   /// locking decisions (e.g., action ID, priority, strategy ID, etc.).
   var lockmanInfo: I { get }
+
+  /// The unlock timing option for this action.
+  /// This specifies when the lock should be released after the action completes.
+  /// If not implemented, defaults to `LockmanManager.config.defaultUnlockOption`.
+  var unlockOption: LockmanUnlockOption { get }
+}
+
+// Default implementation for backward compatibility
+extension LockmanAction {
+  /// Default unlock option uses the global configuration setting.
+  public var unlockOption: LockmanUnlockOption {
+    LockmanManager.config.defaultUnlockOption
+  }
 }

--- a/Sources/Lockman/Documentation.docc/Configuration.md
+++ b/Sources/Lockman/Documentation.docc/Configuration.md
@@ -25,6 +25,11 @@ LockmanManager.config.defaultUnlockOption = .immediate
 - **`.transition`**: Release after platform-specific screen transition animation
 - **`.delayed(TimeInterval)`**: Release after the specified time interval
 
+**Priority order**:
+1. Explicitly specified in `withLock` call (highest priority)
+2. Action's `unlockOption` property (if implementing `LockmanAction`)
+3. `LockmanManager.config.defaultUnlockOption` (lowest priority)
+
 **Use cases**:
 - Unified release timing considering UI transitions
 - Consistent behavior settings across the application

--- a/Sources/Lockman/Documentation.docc/Lock.md
+++ b/Sources/Lockman/Documentation.docc/Lock.md
@@ -38,7 +38,7 @@ The most basic and recommended usage. Automatically manages lock acquisition and
 
 **Parameters:**
 - `priority`: Task priority (optional)
-- `unlockOption`: Lock release timing (optional, default is configured value)
+- `unlockOption`: Lock release timing (optional, uses priority order: withLock parameter > action's unlockOption > config default)
 - `handleCancellationErrors`: Handling of cancellation errors (optional, default is configured value)
 - `operation`: Processing to execute under exclusive control
 - `catch handler`: Error handler (optional)
@@ -96,4 +96,33 @@ Maintains the same lock while executing multiple Effects sequentially.
 - Maintains the same lock across multiple Effects
 - Suitable for transactional processing
 - If any one fails, the entire process is interrupted
+
+## UnlockOption Priority
+
+When determining the unlock timing, Lockman follows this priority order:
+
+1. **Explicitly specified in method call** (highest priority)
+   ```swift
+   .withLock(
+     unlockOption: .transition, // This takes precedence
+     operation: { send in /* ... */ },
+     action: action,
+     cancelID: cancelID
+   )
+   ```
+
+2. **Action's unlockOption property**
+   ```swift
+   struct MyAction: LockmanAction {
+     var unlockOption: LockmanUnlockOption { .mainRunLoop }
+     // ...
+   }
+   ```
+
+3. **Global configuration** (lowest priority)
+   ```swift
+   LockmanManager.config.defaultUnlockOption = .immediate
+   ```
+
+This allows flexible control from global defaults to action-specific and call-specific overrides.
 


### PR DESCRIPTION
## Summary
- Add `unlockOption` property to `LockmanAction` protocol for per-action unlock timing control
- Enable flexible unlock timing configuration with clear priority order

## Changes
- Add `unlockOption` property to `LockmanAction` protocol with default implementation
- Update `withLock` methods to use action's `unlockOption` in priority order:
  1. Explicitly specified in withLock call (highest priority)
  2. Action's unlockOption property
  3. LockmanManager.config.defaultUnlockOption (lowest priority)
- Update DocC documentation to explain the new priority system
- Add example showing custom unlock timing usage

## Example Usage
```swift
struct TransitionAction: LockmanAction {
  typealias I = LockmanSingleExecutionInfo
  
  let lockmanInfo = LockmanSingleExecutionInfo(
    actionId: "transition",
    mode: .boundary
  )
  
  // Release lock after screen transition completes
  var unlockOption: LockmanUnlockOption { .transition }
}
```

## Compatibility
- Fully backward compatible through default implementation
- Existing code continues to work without changes
- New functionality is opt-in per action

## Testing
- All existing tests pass
- Tested on macOS platform