### PR TITLE
docs: add session start analysis rule and reference to CLAUDE_WIP.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,16 @@
 # CLAUDE.md
 
+## Session Start Analysis
+When starting a new session for Lockman development, you MUST first analyze the core source files in the Sources directory:
+1. Read and understand the main implementation files in Sources/Lockman/
+2. Pay special attention to protocol definitions, public APIs, and core functionality
+3. This ensures consistency with existing code patterns and architecture
+
 ## Purpose
 Develop a library to implement exclusive control of user actions in application development using TCA
+
+## Current Work Items
+See CLAUDE_WIP.md for v1.0 roadmap and work in progress tasks
 
 ## Development Guidelines
 - Swift versions: 6.0, 5.10, 5.9


### PR DESCRIPTION
## Summary
- Add session start analysis requirement to CLAUDE.md
- Add reference to CLAUDE_WIP.md for current work items

## Changes
- Add requirement to analyze source files at the start of each development session
- Add reference to CLAUDE_WIP.md for v1.0 roadmap tracking
- These changes ensure better consistency across development sessions

This PR separates the CLAUDE.md changes that were accidentally included in PR #127.