### PR TITLE
feat\!: change parameter name from 'id' to 'boundaryId' in all APIs

### DIFF
--- a/Benchmarks/Benchmarks/Lockman/Benchmarks.swift
+++ b/Benchmarks/Benchmarks/Lockman/Benchmarks.swift
@@ -154,7 +154,7 @@ private struct SingleExecutionFeature {
             await send(.increment)
           },
           action: action,
-          cancelID: CancelID.userAction
+          boundaryId: CancelID.userAction
         )
 
       case .increment:
@@ -201,7 +201,7 @@ private struct PriorityBasedFeature {
             await send(.increment)
           },
           action: action,
-          cancelID: CancelID.userAction
+          boundaryId: CancelID.userAction
         )
 
       case .increment:
@@ -257,7 +257,7 @@ private struct CompositeStrategyFeature {
             await send(.increment)
           },
           action: action,
-          cancelID: CancelID.userAction
+          boundaryId: CancelID.userAction
         )
 
       case .increment:
@@ -301,7 +301,7 @@ private struct DynamicConditionFeature {
             await send(.increment)
           },
           action: action,
-          cancelID: CancelID.userAction
+          boundaryId: CancelID.userAction
         )
 
       case .increment:
@@ -360,7 +360,7 @@ private struct SingleExecutionBurstFeature {
             await send(.process(id: id, startTime: startTime))
           },
           action: action,
-          cancelID: CancelID.burst
+          boundaryId: CancelID.burst
         )
 
       case .process(let id, let startTime):
@@ -432,7 +432,7 @@ private struct PriorityBasedBurstFeature {
             await send(.process(id: id, startTime: startTime))
           },
           action: action,
-          cancelID: CancelID.burst
+          boundaryId: CancelID.burst
         )
 
       case .process(let id, let startTime):

--- a/Examples/Strategies/Strategies/01-SingleExecutionStrategy.swift
+++ b/Examples/Strategies/Strategies/01-SingleExecutionStrategy.swift
@@ -79,7 +79,7 @@ struct SingleExecutionStrategyFeature {
           await send(.internal(.handleLockFailure(error)))
         },
         action: action,
-        cancelID: CancelID.process
+        boundaryId: CancelID.process
       )
     }
   }

--- a/Examples/Strategies/Strategies/02-PriorityBasedStrategy.swift
+++ b/Examples/Strategies/Strategies/02-PriorityBasedStrategy.swift
@@ -159,7 +159,7 @@ struct PriorityBasedStrategyFeature {
         await send(.internal(.updateResult(button: buttonType, result: failureMessage)))
       },
       action: action,
-      cancelID: CancelID.priorityOperation
+      boundaryId: CancelID.priorityOperation
     )
   }
 

--- a/Examples/Strategies/Strategies/03-ConcurrencyLimitedStrategy.swift
+++ b/Examples/Strategies/Strategies/03-ConcurrencyLimitedStrategy.swift
@@ -138,7 +138,7 @@ struct ConcurrencyLimitedStrategyFeature {
           await send(.internal(.handleLockFailure(id: id, error: error)))
         },
         action: Action.ViewAction.downloadButtonTapped(id),
-        cancelID: CancelID.downloads
+        boundaryId: CancelID.downloads
       )
     }
   }

--- a/Examples/Strategies/Strategies/04-GroupCoordinationStrategy.swift
+++ b/Examples/Strategies/Strategies/04-GroupCoordinationStrategy.swift
@@ -124,7 +124,7 @@ struct GroupCoordinationStrategyFeature {
           await send(.internal(.handleLockFailure(operation: "Start Sync", error: error)))
         },
         action: action,
-        cancelID: CancelID.sync
+        boundaryId: CancelID.sync
       )
 
     case .uploadDataTapped:
@@ -148,7 +148,7 @@ struct GroupCoordinationStrategyFeature {
           await send(.internal(.handleLockFailure(operation: "Upload", error: error)))
         },
         action: action,
-        cancelID: CancelID.upload
+        boundaryId: CancelID.upload
       )
 
     case .downloadDataTapped:
@@ -173,7 +173,7 @@ struct GroupCoordinationStrategyFeature {
           await send(.internal(.handleLockFailure(operation: "Download", error: error)))
         },
         action: action,
-        cancelID: CancelID.download
+        boundaryId: CancelID.download
       )
 
     case .processDataTapped:
@@ -197,7 +197,7 @@ struct GroupCoordinationStrategyFeature {
           await send(.internal(.handleLockFailure(operation: "Process", error: error)))
         },
         action: action,
-        cancelID: CancelID.process
+        boundaryId: CancelID.process
       )
 
     case .cancelSyncTapped:

--- a/Examples/Strategies/Strategies/05-DynamicConditionStrategy.swift
+++ b/Examples/Strategies/Strategies/05-DynamicConditionStrategy.swift
@@ -149,7 +149,7 @@ struct DynamicConditionStrategyFeature {
               )))
         },
         action: action,
-        cancelID: CancelID.sync
+        boundaryId: CancelID.sync
       )
 
     case .toggleLoginTapped:
@@ -191,7 +191,7 @@ struct DynamicConditionStrategyFeature {
               )))
         },
         action: action,
-        cancelID: CancelID.maintenance
+        boundaryId: CancelID.maintenance
       )
 
     case .setHour(let hour):
@@ -233,7 +233,7 @@ struct DynamicConditionStrategyFeature {
               )))
         },
         action: action,
-        cancelID: CancelID.report
+        boundaryId: CancelID.report
       )
 
     case .selectDay(let day):

--- a/Sources/Lockman/Composable/LockmanComposableMacros.swift
+++ b/Sources/Lockman/Composable/LockmanComposableMacros.swift
@@ -44,7 +44,7 @@
 ///             // async work
 ///           },
 ///           action: .login,
-///           cancelID: "login-operation"
+///           boundaryId: "login-operation"
 ///         )
 ///       // ...
 ///       }
@@ -93,7 +93,7 @@ public macro LockmanSingleExecution() =
 ///             // async work
 ///           },
 ///           action: .highPriorityTask,
-///           cancelID: "priority-task"
+///           boundaryId: "priority-task"
 ///         )
 ///       // ...
 ///       }
@@ -153,7 +153,7 @@ public macro LockmanPriorityBased() =
 ///             // navigation logic
 ///           },
 ///           action: .navigate(to: destination),
-///           cancelID: "navigation"
+///           boundaryId: "navigation"
 ///         )
 ///       // ...
 ///       }
@@ -201,7 +201,7 @@ public macro LockmanGroupCoordination() =
 ///             // critical work requiring both single execution and high priority
 ///           },
 ///           action: .criticalOperation,
-///           cancelID: "critical-op"
+///           boundaryId: "critical-op"
 ///         )
 ///       }
 ///     }
@@ -428,7 +428,7 @@ public macro LockmanDynamicCondition() =
 ///             await send(.profileFetched(profile))
 ///           },
 ///           action: .fetchUserProfile(userId),
-///           cancelID: "fetch-profile-\(userId)"
+///           boundaryId: "fetch-profile-\(userId)"
 ///         )
 ///       // ...
 ///       }

--- a/Sources/Lockman/Core/LockmanManager.swift
+++ b/Sources/Lockman/Core/LockmanManager.swift
@@ -137,7 +137,7 @@ public enum LockmanManager {
     /// ```
     public static func boundary<B: LockmanBoundaryId>(_ id: B) {
       LockmanManager.withBoundaryLock(for: id) {
-        container.cleanUp(id: id)
+        container.cleanUp(boundaryId: id)
       }
     }
   }
@@ -164,8 +164,8 @@ extension LockmanManager {
     ManagedCriticalState([:])
 
   /// Retrieves or creates an NSLock for the specified boundary ID.
-  private static func getLock<B: LockmanBoundaryId>(for id: B) -> NSLock {
-    let anyId = AnyLockmanBoundaryId(id)
+  private static func getLock<B: LockmanBoundaryId>(for boundaryId: B) -> NSLock {
+    let anyId = AnyLockmanBoundaryId(boundaryId)
     return boundaryLocks.withCriticalRegion { locks in
       if let existingLock = locks[anyId] {
         return existingLock
@@ -179,10 +179,10 @@ extension LockmanManager {
 
   /// Executes the given operation while holding the boundary-specific lock.
   public static func withBoundaryLock<B: LockmanBoundaryId, T>(
-    for id: B,
+    for boundaryId: B,
     operation: () throws -> T
   ) rethrows -> T {
-    let nsLock = getLock(for: id)
+    let nsLock = getLock(for: boundaryId)
     nsLock.lock()
     defer { nsLock.unlock() }
     return try operation()

--- a/Sources/Lockman/Core/LockmanUnlock.swift
+++ b/Sources/Lockman/Core/LockmanUnlock.swift
@@ -86,7 +86,7 @@ public struct LockmanUnlock<B: LockmanBoundaryId, I: LockmanInfo>: Sendable {
   /// Performs the actual unlock operation immediately.
   private func performUnlockImmediately() {
     LockmanManager.withBoundaryLock(for: id) {
-      strategy.unlock(id: id, info: info)
+      strategy.unlock(boundaryId: id, info: info)
     }
   }
 }

--- a/Sources/Lockman/Core/Protocols/LockmanStrategy.swift
+++ b/Sources/Lockman/Core/Protocols/LockmanStrategy.swift
@@ -123,12 +123,12 @@ public protocol LockmanStrategy<I>: Sendable {
   /// scenarios appropriately.
   ///
   /// - Parameters:
-  ///   - id: A unique boundary identifier conforming to `LockmanBoundaryId`
+  ///   - boundaryId: A unique boundary identifier conforming to `LockmanBoundaryId`
   ///   - info: Lock information of type `I` containing action details
   /// - Returns: A `LockmanResult` indicating whether the lock can be acquired,
   ///   any required actions (such as canceling existing operations), and
   ///   detailed error information if the lock cannot be acquired
-  func canLock<B: LockmanBoundaryId>(id: B, info: I) -> LockmanResult
+  func canLock<B: LockmanBoundaryId>(boundaryId: B, info: I) -> LockmanResult
 
   /// Attempts to acquire a lock for the given boundary and information.
   ///
@@ -146,9 +146,9 @@ public protocol LockmanStrategy<I>: Sendable {
   /// access to internal state appropriately.
   ///
   /// - Parameters:
-  ///   - id: A unique boundary identifier conforming to `LockmanBoundaryId`
+  ///   - boundaryId: A unique boundary identifier conforming to `LockmanBoundaryId`
   ///   - info: Lock information of type `I` to be registered as active
-  func lock<B: LockmanBoundaryId>(id: B, info: I)
+  func lock<B: LockmanBoundaryId>(boundaryId: B, info: I)
 
   /// Releases a previously acquired lock.
   ///
@@ -167,9 +167,9 @@ public protocol LockmanStrategy<I>: Sendable {
   /// may require exact instance matching.
   ///
   /// - Parameters:
-  ///   - id: The boundary identifier for which the lock should be released
+  ///   - boundaryId: The boundary identifier for which the lock should be released
   ///   - info: The same lock information of type `I` that was used when acquiring the lock
-  func unlock<B: LockmanBoundaryId>(id: B, info: I)
+  func unlock<B: LockmanBoundaryId>(boundaryId: B, info: I)
 
   /// Removes all lock information across all boundaries.
   ///
@@ -203,8 +203,8 @@ public protocol LockmanStrategy<I>: Sendable {
   /// - Should not fail if no locks exist for the boundary
   /// - Should preserve locks for other boundaries
   ///
-  /// - Parameter id: The identifier whose lock information should be removed
-  func cleanUp<B: LockmanBoundaryId>(id: B)
+  /// - Parameter boundaryId: The identifier whose lock information should be removed
+  func cleanUp<B: LockmanBoundaryId>(boundaryId: B)
 
   /// Returns current locks information for debugging purposes.
   ///

--- a/Sources/Lockman/Core/Strategies/CompositeStrategy/LockmanCompositeStrategy.swift
+++ b/Sources/Lockman/Core/Strategies/CompositeStrategy/LockmanCompositeStrategy.swift
@@ -61,30 +61,30 @@ where S1.I == I1, S2.I == I2 {
 
   /// Checks if locks can be acquired from all component strategies.
   public func canLock<B: LockmanBoundaryId>(
-    id: B,
+    boundaryId: B,
     info: LockmanCompositeInfo2<I1, I2>
   ) -> LockmanResult {
     // Early return pattern for performance optimization
-    let result1 = strategy1.canLock(id: id, info: info.lockmanInfoForStrategy1)
+    let result1 = strategy1.canLock(boundaryId: boundaryId, info: info.lockmanInfoForStrategy1)
     if case .failure(let error) = result1 {
       let result = LockmanResult.failure(error)
       LockmanLogger.shared.logCanLock(
         result: result,
         strategy: "Composite",
-        boundaryId: String(describing: id),
+        boundaryId: String(describing: boundaryId),
         info: info,
         reason: "Strategy1 failed"
       )
       return result
     }
 
-    let result2 = strategy2.canLock(id: id, info: info.lockmanInfoForStrategy2)
+    let result2 = strategy2.canLock(boundaryId: boundaryId, info: info.lockmanInfoForStrategy2)
     if case .failure(let error) = result2 {
       let result = LockmanResult.failure(error)
       LockmanLogger.shared.logCanLock(
         result: result,
         strategy: "Composite",
-        boundaryId: String(describing: id),
+        boundaryId: String(describing: boundaryId),
         info: info,
         reason: "Strategy2 failed"
       )
@@ -96,7 +96,7 @@ where S1.I == I1, S2.I == I2 {
     LockmanLogger.shared.logCanLock(
       result: result,
       strategy: "Composite",
-      boundaryId: String(describing: id),
+      boundaryId: String(describing: boundaryId),
       info: info,
       reason: nil
     )
@@ -109,23 +109,23 @@ where S1.I == I1, S2.I == I2 {
   /// All strategies will acquire their locks in the order they were specified.
   ///
   /// - Parameters:
-  ///   - id: A unique boundary identifier conforming to `LockmanBoundaryId`
+  ///   - boundaryId: A unique boundary identifier conforming to `LockmanBoundaryId`
   ///   - info: Composite lock information containing details for both strategies
   public func lock<B: LockmanBoundaryId>(
-    id: B,
+    boundaryId: B,
     info: LockmanCompositeInfo2<I1, I2>
   ) {
-    strategy1.lock(id: id, info: info.lockmanInfoForStrategy1)
-    strategy2.lock(id: id, info: info.lockmanInfoForStrategy2)
+    strategy1.lock(boundaryId: boundaryId, info: info.lockmanInfoForStrategy1)
+    strategy2.lock(boundaryId: boundaryId, info: info.lockmanInfoForStrategy2)
   }
 
   public func unlock<B: LockmanBoundaryId>(
-    id: B,
+    boundaryId: B,
     info: LockmanCompositeInfo2<I1, I2>
   ) {
     // Release in reverse order (LIFO)
-    strategy2.unlock(id: id, info: info.lockmanInfoForStrategy2)
-    strategy1.unlock(id: id, info: info.lockmanInfoForStrategy1)
+    strategy2.unlock(boundaryId: boundaryId, info: info.lockmanInfoForStrategy2)
+    strategy1.unlock(boundaryId: boundaryId, info: info.lockmanInfoForStrategy1)
   }
 
   public func cleanUp() {
@@ -133,9 +133,9 @@ where S1.I == I1, S2.I == I2 {
     strategy2.cleanUp()
   }
 
-  public func cleanUp<B: LockmanBoundaryId>(id: B) {
-    strategy1.cleanUp(id: id)
-    strategy2.cleanUp(id: id)
+  public func cleanUp<B: LockmanBoundaryId>(boundaryId: B) {
+    strategy1.cleanUp(boundaryId: boundaryId)
+    strategy2.cleanUp(boundaryId: boundaryId)
   }
 
   /// Returns current locks information for debugging.
@@ -247,43 +247,43 @@ where S1.I == I1, S2.I == I2, S3.I == I3 {
   }
 
   public func canLock<B: LockmanBoundaryId>(
-    id: B,
+    boundaryId: B,
     info: LockmanCompositeInfo3<I1, I2, I3>
   ) -> LockmanResult {
     // Early return pattern for performance optimization
-    let result1 = strategy1.canLock(id: id, info: info.lockmanInfoForStrategy1)
+    let result1 = strategy1.canLock(boundaryId: boundaryId, info: info.lockmanInfoForStrategy1)
     if case .failure(let error) = result1 {
       let result = LockmanResult.failure(error)
       LockmanLogger.shared.logCanLock(
         result: result,
         strategy: "Composite",
-        boundaryId: String(describing: id),
+        boundaryId: String(describing: boundaryId),
         info: info,
         reason: "Strategy1 failed"
       )
       return result
     }
 
-    let result2 = strategy2.canLock(id: id, info: info.lockmanInfoForStrategy2)
+    let result2 = strategy2.canLock(boundaryId: boundaryId, info: info.lockmanInfoForStrategy2)
     if case .failure(let error) = result2 {
       let result = LockmanResult.failure(error)
       LockmanLogger.shared.logCanLock(
         result: result,
         strategy: "Composite",
-        boundaryId: String(describing: id),
+        boundaryId: String(describing: boundaryId),
         info: info,
         reason: "Strategy2 failed"
       )
       return result
     }
 
-    let result3 = strategy3.canLock(id: id, info: info.lockmanInfoForStrategy3)
+    let result3 = strategy3.canLock(boundaryId: boundaryId, info: info.lockmanInfoForStrategy3)
     if case .failure(let error) = result3 {
       let result = LockmanResult.failure(error)
       LockmanLogger.shared.logCanLock(
         result: result,
         strategy: "Composite",
-        boundaryId: String(describing: id),
+        boundaryId: String(describing: boundaryId),
         info: info,
         reason: "Strategy3 failed"
       )
@@ -295,7 +295,7 @@ where S1.I == I1, S2.I == I2, S3.I == I3 {
     LockmanLogger.shared.logCanLock(
       result: result,
       strategy: "Composite",
-      boundaryId: String(describing: id),
+      boundaryId: String(describing: boundaryId),
       info: info,
       reason: nil
     )
@@ -304,23 +304,23 @@ where S1.I == I1, S2.I == I2, S3.I == I3 {
   }
 
   public func lock<B: LockmanBoundaryId>(
-    id: B,
+    boundaryId: B,
     info: LockmanCompositeInfo3<I1, I2, I3>
   ) {
-    strategy1.lock(id: id, info: info.lockmanInfoForStrategy1)
-    strategy2.lock(id: id, info: info.lockmanInfoForStrategy2)
-    strategy3.lock(id: id, info: info.lockmanInfoForStrategy3)
+    strategy1.lock(boundaryId: boundaryId, info: info.lockmanInfoForStrategy1)
+    strategy2.lock(boundaryId: boundaryId, info: info.lockmanInfoForStrategy2)
+    strategy3.lock(boundaryId: boundaryId, info: info.lockmanInfoForStrategy3)
   }
 
   /// Releases locks from all component strategies in reverse order.
   public func unlock<B: LockmanBoundaryId>(
-    id: B,
+    boundaryId: B,
     info: LockmanCompositeInfo3<I1, I2, I3>
   ) {
     // Release in reverse order (LIFO)
-    strategy3.unlock(id: id, info: info.lockmanInfoForStrategy3)
-    strategy2.unlock(id: id, info: info.lockmanInfoForStrategy2)
-    strategy1.unlock(id: id, info: info.lockmanInfoForStrategy1)
+    strategy3.unlock(boundaryId: boundaryId, info: info.lockmanInfoForStrategy3)
+    strategy2.unlock(boundaryId: boundaryId, info: info.lockmanInfoForStrategy2)
+    strategy1.unlock(boundaryId: boundaryId, info: info.lockmanInfoForStrategy1)
   }
 
   public func cleanUp() {
@@ -329,10 +329,10 @@ where S1.I == I1, S2.I == I2, S3.I == I3 {
     strategy3.cleanUp()
   }
 
-  public func cleanUp<B: LockmanBoundaryId>(id: B) {
-    strategy1.cleanUp(id: id)
-    strategy2.cleanUp(id: id)
-    strategy3.cleanUp(id: id)
+  public func cleanUp<B: LockmanBoundaryId>(boundaryId: B) {
+    strategy1.cleanUp(boundaryId: boundaryId)
+    strategy2.cleanUp(boundaryId: boundaryId)
+    strategy3.cleanUp(boundaryId: boundaryId)
   }
 
   /// Returns current locks information for debugging.
@@ -432,56 +432,56 @@ where S1.I == I1, S2.I == I2, S3.I == I3, S4.I == I4 {
   }
 
   public func canLock<B: LockmanBoundaryId>(
-    id: B,
+    boundaryId: B,
     info: LockmanCompositeInfo4<I1, I2, I3, I4>
   ) -> LockmanResult {
     // Early return pattern for performance optimization
-    let result1 = strategy1.canLock(id: id, info: info.lockmanInfoForStrategy1)
+    let result1 = strategy1.canLock(boundaryId: boundaryId, info: info.lockmanInfoForStrategy1)
     if case .failure(let error) = result1 {
       let result = LockmanResult.failure(error)
       LockmanLogger.shared.logCanLock(
         result: result,
         strategy: "Composite",
-        boundaryId: String(describing: id),
+        boundaryId: String(describing: boundaryId),
         info: info,
         reason: "Strategy1 failed"
       )
       return result
     }
 
-    let result2 = strategy2.canLock(id: id, info: info.lockmanInfoForStrategy2)
+    let result2 = strategy2.canLock(boundaryId: boundaryId, info: info.lockmanInfoForStrategy2)
     if case .failure(let error) = result2 {
       let result = LockmanResult.failure(error)
       LockmanLogger.shared.logCanLock(
         result: result,
         strategy: "Composite",
-        boundaryId: String(describing: id),
+        boundaryId: String(describing: boundaryId),
         info: info,
         reason: "Strategy2 failed"
       )
       return result
     }
 
-    let result3 = strategy3.canLock(id: id, info: info.lockmanInfoForStrategy3)
+    let result3 = strategy3.canLock(boundaryId: boundaryId, info: info.lockmanInfoForStrategy3)
     if case .failure(let error) = result3 {
       let result = LockmanResult.failure(error)
       LockmanLogger.shared.logCanLock(
         result: result,
         strategy: "Composite",
-        boundaryId: String(describing: id),
+        boundaryId: String(describing: boundaryId),
         info: info,
         reason: "Strategy3 failed"
       )
       return result
     }
 
-    let result4 = strategy4.canLock(id: id, info: info.lockmanInfoForStrategy4)
+    let result4 = strategy4.canLock(boundaryId: boundaryId, info: info.lockmanInfoForStrategy4)
     if case .failure(let error) = result4 {
       let result = LockmanResult.failure(error)
       LockmanLogger.shared.logCanLock(
         result: result,
         strategy: "Composite",
-        boundaryId: String(describing: id),
+        boundaryId: String(describing: boundaryId),
         info: info,
         reason: "Strategy4 failed"
       )
@@ -493,7 +493,7 @@ where S1.I == I1, S2.I == I2, S3.I == I3, S4.I == I4 {
     LockmanLogger.shared.logCanLock(
       result: result,
       strategy: "Composite",
-      boundaryId: String(describing: id),
+      boundaryId: String(describing: boundaryId),
       info: info,
       reason: nil
     )
@@ -502,24 +502,24 @@ where S1.I == I1, S2.I == I2, S3.I == I3, S4.I == I4 {
   }
 
   public func lock<B: LockmanBoundaryId>(
-    id: B,
+    boundaryId: B,
     info: LockmanCompositeInfo4<I1, I2, I3, I4>
   ) {
-    strategy1.lock(id: id, info: info.lockmanInfoForStrategy1)
-    strategy2.lock(id: id, info: info.lockmanInfoForStrategy2)
-    strategy3.lock(id: id, info: info.lockmanInfoForStrategy3)
-    strategy4.lock(id: id, info: info.lockmanInfoForStrategy4)
+    strategy1.lock(boundaryId: boundaryId, info: info.lockmanInfoForStrategy1)
+    strategy2.lock(boundaryId: boundaryId, info: info.lockmanInfoForStrategy2)
+    strategy3.lock(boundaryId: boundaryId, info: info.lockmanInfoForStrategy3)
+    strategy4.lock(boundaryId: boundaryId, info: info.lockmanInfoForStrategy4)
   }
 
   public func unlock<B: LockmanBoundaryId>(
-    id: B,
+    boundaryId: B,
     info: LockmanCompositeInfo4<I1, I2, I3, I4>
   ) {
     // Release in reverse order (LIFO)
-    strategy4.unlock(id: id, info: info.lockmanInfoForStrategy4)
-    strategy3.unlock(id: id, info: info.lockmanInfoForStrategy3)
-    strategy2.unlock(id: id, info: info.lockmanInfoForStrategy2)
-    strategy1.unlock(id: id, info: info.lockmanInfoForStrategy1)
+    strategy4.unlock(boundaryId: boundaryId, info: info.lockmanInfoForStrategy4)
+    strategy3.unlock(boundaryId: boundaryId, info: info.lockmanInfoForStrategy3)
+    strategy2.unlock(boundaryId: boundaryId, info: info.lockmanInfoForStrategy2)
+    strategy1.unlock(boundaryId: boundaryId, info: info.lockmanInfoForStrategy1)
   }
 
   public func cleanUp() {
@@ -529,11 +529,11 @@ where S1.I == I1, S2.I == I2, S3.I == I3, S4.I == I4 {
     strategy4.cleanUp()
   }
 
-  public func cleanUp<B: LockmanBoundaryId>(id: B) {
-    strategy1.cleanUp(id: id)
-    strategy2.cleanUp(id: id)
-    strategy3.cleanUp(id: id)
-    strategy4.cleanUp(id: id)
+  public func cleanUp<B: LockmanBoundaryId>(boundaryId: B) {
+    strategy1.cleanUp(boundaryId: boundaryId)
+    strategy2.cleanUp(boundaryId: boundaryId)
+    strategy3.cleanUp(boundaryId: boundaryId)
+    strategy4.cleanUp(boundaryId: boundaryId)
   }
 
   /// Returns current locks information for debugging.
@@ -648,69 +648,69 @@ where S1.I == I1, S2.I == I2, S3.I == I3, S4.I == I4, S5.I == I5 {
   }
 
   public func canLock<B: LockmanBoundaryId>(
-    id: B,
+    boundaryId: B,
     info: LockmanCompositeInfo5<I1, I2, I3, I4, I5>
   ) -> LockmanResult {
     // Early return pattern for performance optimization
-    let result1 = strategy1.canLock(id: id, info: info.lockmanInfoForStrategy1)
+    let result1 = strategy1.canLock(boundaryId: boundaryId, info: info.lockmanInfoForStrategy1)
     if case .failure(let error) = result1 {
       let result = LockmanResult.failure(error)
       LockmanLogger.shared.logCanLock(
         result: result,
         strategy: "Composite",
-        boundaryId: String(describing: id),
+        boundaryId: String(describing: boundaryId),
         info: info,
         reason: "Strategy1 failed"
       )
       return result
     }
 
-    let result2 = strategy2.canLock(id: id, info: info.lockmanInfoForStrategy2)
+    let result2 = strategy2.canLock(boundaryId: boundaryId, info: info.lockmanInfoForStrategy2)
     if case .failure(let error) = result2 {
       let result = LockmanResult.failure(error)
       LockmanLogger.shared.logCanLock(
         result: result,
         strategy: "Composite",
-        boundaryId: String(describing: id),
+        boundaryId: String(describing: boundaryId),
         info: info,
         reason: "Strategy2 failed"
       )
       return result
     }
 
-    let result3 = strategy3.canLock(id: id, info: info.lockmanInfoForStrategy3)
+    let result3 = strategy3.canLock(boundaryId: boundaryId, info: info.lockmanInfoForStrategy3)
     if case .failure(let error) = result3 {
       let result = LockmanResult.failure(error)
       LockmanLogger.shared.logCanLock(
         result: result,
         strategy: "Composite",
-        boundaryId: String(describing: id),
+        boundaryId: String(describing: boundaryId),
         info: info,
         reason: "Strategy3 failed"
       )
       return result
     }
 
-    let result4 = strategy4.canLock(id: id, info: info.lockmanInfoForStrategy4)
+    let result4 = strategy4.canLock(boundaryId: boundaryId, info: info.lockmanInfoForStrategy4)
     if case .failure(let error) = result4 {
       let result = LockmanResult.failure(error)
       LockmanLogger.shared.logCanLock(
         result: result,
         strategy: "Composite",
-        boundaryId: String(describing: id),
+        boundaryId: String(describing: boundaryId),
         info: info,
         reason: "Strategy4 failed"
       )
       return result
     }
 
-    let result5 = strategy5.canLock(id: id, info: info.lockmanInfoForStrategy5)
+    let result5 = strategy5.canLock(boundaryId: boundaryId, info: info.lockmanInfoForStrategy5)
     if case .failure(let error) = result5 {
       let result = LockmanResult.failure(error)
       LockmanLogger.shared.logCanLock(
         result: result,
         strategy: "Composite",
-        boundaryId: String(describing: id),
+        boundaryId: String(describing: boundaryId),
         info: info,
         reason: "Strategy5 failed"
       )
@@ -722,7 +722,7 @@ where S1.I == I1, S2.I == I2, S3.I == I3, S4.I == I4, S5.I == I5 {
     LockmanLogger.shared.logCanLock(
       result: result,
       strategy: "Composite",
-      boundaryId: String(describing: id),
+      boundaryId: String(describing: boundaryId),
       info: info,
       reason: nil
     )
@@ -731,26 +731,26 @@ where S1.I == I1, S2.I == I2, S3.I == I3, S4.I == I4, S5.I == I5 {
   }
 
   public func lock<B: LockmanBoundaryId>(
-    id: B,
+    boundaryId: B,
     info: LockmanCompositeInfo5<I1, I2, I3, I4, I5>
   ) {
-    strategy1.lock(id: id, info: info.lockmanInfoForStrategy1)
-    strategy2.lock(id: id, info: info.lockmanInfoForStrategy2)
-    strategy3.lock(id: id, info: info.lockmanInfoForStrategy3)
-    strategy4.lock(id: id, info: info.lockmanInfoForStrategy4)
-    strategy5.lock(id: id, info: info.lockmanInfoForStrategy5)
+    strategy1.lock(boundaryId: boundaryId, info: info.lockmanInfoForStrategy1)
+    strategy2.lock(boundaryId: boundaryId, info: info.lockmanInfoForStrategy2)
+    strategy3.lock(boundaryId: boundaryId, info: info.lockmanInfoForStrategy3)
+    strategy4.lock(boundaryId: boundaryId, info: info.lockmanInfoForStrategy4)
+    strategy5.lock(boundaryId: boundaryId, info: info.lockmanInfoForStrategy5)
   }
 
   public func unlock<B: LockmanBoundaryId>(
-    id: B,
+    boundaryId: B,
     info: LockmanCompositeInfo5<I1, I2, I3, I4, I5>
   ) {
     // Release in reverse order (LIFO)
-    strategy5.unlock(id: id, info: info.lockmanInfoForStrategy5)
-    strategy4.unlock(id: id, info: info.lockmanInfoForStrategy4)
-    strategy3.unlock(id: id, info: info.lockmanInfoForStrategy3)
-    strategy2.unlock(id: id, info: info.lockmanInfoForStrategy2)
-    strategy1.unlock(id: id, info: info.lockmanInfoForStrategy1)
+    strategy5.unlock(boundaryId: boundaryId, info: info.lockmanInfoForStrategy5)
+    strategy4.unlock(boundaryId: boundaryId, info: info.lockmanInfoForStrategy4)
+    strategy3.unlock(boundaryId: boundaryId, info: info.lockmanInfoForStrategy3)
+    strategy2.unlock(boundaryId: boundaryId, info: info.lockmanInfoForStrategy2)
+    strategy1.unlock(boundaryId: boundaryId, info: info.lockmanInfoForStrategy1)
   }
 
   public func cleanUp() {
@@ -761,12 +761,12 @@ where S1.I == I1, S2.I == I2, S3.I == I3, S4.I == I4, S5.I == I5 {
     strategy5.cleanUp()
   }
 
-  public func cleanUp<B: LockmanBoundaryId>(id: B) {
-    strategy1.cleanUp(id: id)
-    strategy2.cleanUp(id: id)
-    strategy3.cleanUp(id: id)
-    strategy4.cleanUp(id: id)
-    strategy5.cleanUp(id: id)
+  public func cleanUp<B: LockmanBoundaryId>(boundaryId: B) {
+    strategy1.cleanUp(boundaryId: boundaryId)
+    strategy2.cleanUp(boundaryId: boundaryId)
+    strategy3.cleanUp(boundaryId: boundaryId)
+    strategy4.cleanUp(boundaryId: boundaryId)
+    strategy5.cleanUp(boundaryId: boundaryId)
   }
 
   /// Returns current locks information for debugging.

--- a/Sources/Lockman/Core/Strategies/ConcurrencyLimitedStrategy/LockmanConcurrencyLimitedStrategy.swift
+++ b/Sources/Lockman/Core/Strategies/ConcurrencyLimitedStrategy/LockmanConcurrencyLimitedStrategy.swift
@@ -29,11 +29,11 @@ public final class LockmanConcurrencyLimitedStrategy: LockmanStrategy, @unchecke
 
   /// Checks if a lock can be acquired based on concurrency limits.
   public func canLock<B: LockmanBoundaryId>(
-    id: B,
+    boundaryId: B,
     info: LockmanConcurrencyLimitedInfo
   ) -> LockmanResult {
     // Use the key-based query for efficient lookup
-    let currentCount = state.count(id: id, key: info.concurrencyId)
+    let currentCount = state.count(id: boundaryId, key: info.concurrencyId)
 
     let result: LockmanResult
     var failureReason: String?
@@ -41,7 +41,7 @@ public final class LockmanConcurrencyLimitedStrategy: LockmanStrategy, @unchecke
     if info.limit.isExceeded(currentCount: currentCount) {
       if case .limited(let limit) = info.limit {
         // Get existing infos in the same concurrency group
-        let existingInfos = state.currents(id: id, key: info.concurrencyId)
+        let existingInfos = state.currents(id: boundaryId, key: info.concurrencyId)
 
         result = .failure(
           LockmanConcurrencyLimitedError.concurrencyLimitReached(
@@ -63,7 +63,7 @@ public final class LockmanConcurrencyLimitedStrategy: LockmanStrategy, @unchecke
     LockmanLogger.shared.logCanLock(
       result: result,
       strategy: "ConcurrencyLimited",
-      boundaryId: String(describing: id),
+      boundaryId: String(describing: boundaryId),
       info: info,
       reason: failureReason
     )
@@ -73,28 +73,28 @@ public final class LockmanConcurrencyLimitedStrategy: LockmanStrategy, @unchecke
 
   /// Adds the lock to the state.
   public func lock<B: LockmanBoundaryId>(
-    id: B,
+    boundaryId: B,
     info: LockmanConcurrencyLimitedInfo
   ) {
-    state.add(id: id, info: info)
+    state.add(id: boundaryId, info: info)
   }
 
   /// Removes the lock from the state.
   public func unlock<B: LockmanBoundaryId>(
-    id: B,
+    boundaryId: B,
     info: LockmanConcurrencyLimitedInfo
   ) {
-    state.remove(id: id, info: info)
+    state.remove(id: boundaryId, info: info)
   }
 
   /// Removes all locks for a specific boundary.
   public func cleanUp<B: LockmanBoundaryId>(
-    id: B
+    boundaryId: B
   ) {
     // Get all locks for this boundary and remove them one by one
-    let currentLocks = state.currents(id: id)
+    let currentLocks = state.currents(id: boundaryId)
     for info in currentLocks {
-      state.remove(id: id, info: info)
+      state.remove(id: boundaryId, info: info)
     }
   }
 

--- a/Sources/Lockman/Core/Strategies/Core/LockmanStrategyContainer.swift
+++ b/Sources/Lockman/Core/Strategies/Core/LockmanStrategyContainer.swift
@@ -66,7 +66,7 @@ public final class LockmanStrategyContainer: @unchecked Sendable {
       self.typeName = String(describing: S.self)
       self.registeredAt = Date()
       self.cleanUp = { anyStrategy.cleanUp() }
-      self.cleanUpById = { id in anyStrategy.cleanUp(id: id) }
+      self.cleanUpById = { id in anyStrategy.cleanUp(boundaryId: id) }
     }
   }
 
@@ -404,10 +404,10 @@ public final class LockmanStrategyContainer: @unchecked Sendable {
   ///
   /// ## Complexity
   /// O(n) where n is the number of registered strategies
-  public func cleanUp<B: LockmanBoundaryId>(id: B) {
+  public func cleanUp<B: LockmanBoundaryId>(boundaryId: B) {
     storage.withCriticalRegion { storage in
       for (_, entry) in storage {
-        entry.cleanUpById(id)
+        entry.cleanUpById(boundaryId)
       }
     }
   }

--- a/Sources/Lockman/Core/Strategies/DynamicConditionStrategy/LockmanDynamicConditionStrategy.swift
+++ b/Sources/Lockman/Core/Strategies/DynamicConditionStrategy/LockmanDynamicConditionStrategy.swift
@@ -65,11 +65,11 @@ public final class LockmanDynamicConditionStrategy: LockmanStrategy, @unchecked 
   /// business logic defined at runtime.
   ///
   /// - Parameters:
-  ///   - id: The boundary identifier
+  ///   - boundaryId: The boundary identifier
   ///   - info: The lock information containing the dynamic condition
   /// - Returns: The result from evaluating the dynamic condition
   public func canLock<B: LockmanBoundaryId>(
-    id: B,
+    boundaryId: B,
     info: LockmanDynamicConditionInfo
   ) -> LockmanResult {
     // Evaluate the condition and get the result directly
@@ -84,7 +84,7 @@ public final class LockmanDynamicConditionStrategy: LockmanStrategy, @unchecked 
     LockmanLogger.shared.logCanLock(
       result: result,
       strategy: "DynamicCondition",
-      boundaryId: String(describing: id),
+      boundaryId: String(describing: boundaryId),
       info: info,
       reason: failureReason
     )
@@ -95,13 +95,13 @@ public final class LockmanDynamicConditionStrategy: LockmanStrategy, @unchecked 
   /// Acquires a lock for the specified boundary and action.
   ///
   /// - Parameters:
-  ///   - id: The boundary identifier
+  ///   - boundaryId: The boundary identifier
   ///   - info: The lock information to register
   public func lock<B: LockmanBoundaryId>(
-    id: B,
+    boundaryId: B,
     info: LockmanDynamicConditionInfo
   ) {
-    state.add(id: id, info: info)
+    state.add(id: boundaryId, info: info)
   }
 
   /// Releases all locks with the same actionId.
@@ -111,14 +111,14 @@ public final class LockmanDynamicConditionStrategy: LockmanStrategy, @unchecked 
   /// actionId exist (e.g., from ReduceWithLock's multi-step locking).
   ///
   /// - Parameters:
-  ///   - id: The boundary identifier
+  ///   - boundaryId: The boundary identifier
   ///   - info: The lock information containing the actionId to remove
   public func unlock<B: LockmanBoundaryId>(
-    id: B,
+    boundaryId: B,
     info: LockmanDynamicConditionInfo
   ) {
     // Remove all locks with the same actionId
-    state.removeAll(id: id, key: info.actionId)
+    state.removeAll(id: boundaryId, key: info.actionId)
   }
 
   /// Removes all active locks across all boundaries.
@@ -128,9 +128,9 @@ public final class LockmanDynamicConditionStrategy: LockmanStrategy, @unchecked 
 
   /// Removes all active locks for the specified boundary.
   ///
-  /// - Parameter id: The boundary identifier whose locks should be removed
-  public func cleanUp<B: LockmanBoundaryId>(id: B) {
-    state.removeAll(id: id)
+  /// - Parameter boundaryId: The boundary identifier whose locks should be removed
+  public func cleanUp<B: LockmanBoundaryId>(boundaryId: B) {
+    state.removeAll(id: boundaryId)
   }
 
   /// Returns current locks information for debugging.

--- a/Sources/Lockman/Core/Strategies/GroupCoordinationStrategy/LockmanGroupCoordinationStrategy.swift
+++ b/Sources/Lockman/Core/Strategies/GroupCoordinationStrategy/LockmanGroupCoordinationStrategy.swift
@@ -115,14 +115,14 @@ public final class LockmanGroupCoordinationStrategy: LockmanStrategy, @unchecked
   // MARK: - LockmanStrategy
 
   public func canLock<B: LockmanBoundaryId>(
-    id: B,
+    boundaryId: B,
     info: LockmanGroupCoordinatedInfo
   ) -> LockmanResult {
     let result: LockmanResult
     var failureReason: String?
 
     result = storage.withCriticalRegion { storage in
-      let anyBoundaryId = AnyLockmanBoundaryId(id)
+      let anyBoundaryId = AnyLockmanBoundaryId(boundaryId)
       let boundaryState = storage[anyBoundaryId]
 
       // Check all groups (AND condition - must satisfy conditions in all groups)
@@ -201,7 +201,7 @@ public final class LockmanGroupCoordinationStrategy: LockmanStrategy, @unchecked
     LockmanLogger.shared.logCanLock(
       result: result,
       strategy: "GroupCoordination",
-      boundaryId: String(describing: id),
+      boundaryId: String(describing: boundaryId),
       info: info,
       reason: failureReason
     )
@@ -210,11 +210,11 @@ public final class LockmanGroupCoordinationStrategy: LockmanStrategy, @unchecked
   }
 
   public func lock<B: LockmanBoundaryId>(
-    id: B,
+    boundaryId: B,
     info: LockmanGroupCoordinatedInfo
   ) {
     storage.withCriticalRegion { storage in
-      let anyBoundaryId = AnyLockmanBoundaryId(id)
+      let anyBoundaryId = AnyLockmanBoundaryId(boundaryId)
 
       // Ensure boundary state exists
       if storage[anyBoundaryId] == nil {
@@ -236,11 +236,11 @@ public final class LockmanGroupCoordinationStrategy: LockmanStrategy, @unchecked
   }
 
   public func unlock<B: LockmanBoundaryId>(
-    id: B,
+    boundaryId: B,
     info: LockmanGroupCoordinatedInfo
   ) {
     storage.withCriticalRegion { storage in
-      let anyBoundaryId = AnyLockmanBoundaryId(id)
+      let anyBoundaryId = AnyLockmanBoundaryId(boundaryId)
 
       // Remove member from all groups
       for groupId in info.groupIds {
@@ -266,9 +266,9 @@ public final class LockmanGroupCoordinationStrategy: LockmanStrategy, @unchecked
     }
   }
 
-  public func cleanUp<B: LockmanBoundaryId>(id: B) {
+  public func cleanUp<B: LockmanBoundaryId>(boundaryId: B) {
     storage.withCriticalRegion { storage in
-      let anyBoundaryId = AnyLockmanBoundaryId(id)
+      let anyBoundaryId = AnyLockmanBoundaryId(boundaryId)
       storage.removeValue(forKey: anyBoundaryId)
     }
   }

--- a/Sources/Lockman/Core/TypeErasure/AnyLockmanStrategy.swift
+++ b/Sources/Lockman/Core/TypeErasure/AnyLockmanStrategy.swift
@@ -96,24 +96,24 @@ public struct AnyLockmanStrategy<I: LockmanInfo>: LockmanStrategy, Sendable {
     // Capture each method as a closure, preserving the concrete strategy's behavior
     // while erasing its type information
 
-    _canLock = { [strategy] id, info in
-      strategy.canLock(id: id, info: info)
+    _canLock = { [strategy] boundaryId, info in
+      strategy.canLock(boundaryId: boundaryId, info: info)
     }
 
-    _lock = { [strategy] id, info in
-      strategy.lock(id: id, info: info)
+    _lock = { [strategy] boundaryId, info in
+      strategy.lock(boundaryId: boundaryId, info: info)
     }
 
-    _unlock = { [strategy] id, info in
-      strategy.unlock(id: id, info: info)
+    _unlock = { [strategy] boundaryId, info in
+      strategy.unlock(boundaryId: boundaryId, info: info)
     }
 
     _cleanUp = { [strategy] in
       strategy.cleanUp()
     }
 
-    _cleanUpById = { [strategy] id in
-      strategy.cleanUp(id: id)
+    _cleanUpById = { [strategy] boundaryId in
+      strategy.cleanUp(boundaryId: boundaryId)
     }
 
     _getCurrentLocks = { [strategy] in
@@ -159,11 +159,11 @@ public struct AnyLockmanStrategy<I: LockmanInfo>: LockmanStrategy, Sendable {
   /// The wrapper does not add its own error handling or modification.
   ///
   /// - Parameters:
-  ///   - id: A unique boundary identifier conforming to `LockmanBoundaryId`
+  ///   - boundaryId: A unique boundary identifier conforming to `LockmanBoundaryId`
   ///   - info: Lock information of type `I`
   /// - Returns: A `LockmanResult` indicating whether the lock can be acquired
-  public func canLock<B: LockmanBoundaryId>(id: B, info: I) -> LockmanResult {
-    _canLock(id, info)
+  public func canLock<B: LockmanBoundaryId>(boundaryId: B, info: I) -> LockmanResult {
+    _canLock(boundaryId, info)
   }
 
   /// Attempts to acquire a lock for the given boundary and information.
@@ -181,10 +181,10 @@ public struct AnyLockmanStrategy<I: LockmanInfo>: LockmanStrategy, Sendable {
   /// the acquired lock. This wrapper does not add any additional state management.
   ///
   /// - Parameters:
-  ///   - id: A unique boundary identifier conforming to `LockmanBoundaryId`
+  ///   - boundaryId: A unique boundary identifier conforming to `LockmanBoundaryId`
   ///   - info: Lock information of type `I` to be registered as active
-  public func lock<B: LockmanBoundaryId>(id: B, info: I) {
-    _lock(id, info)
+  public func lock<B: LockmanBoundaryId>(boundaryId: B, info: I) {
+    _lock(boundaryId, info)
   }
 
   /// Releases a previously acquired lock.
@@ -207,10 +207,10 @@ public struct AnyLockmanStrategy<I: LockmanInfo>: LockmanStrategy, Sendable {
   /// The behavior depends on the concrete strategy's implementation.
   ///
   /// - Parameters:
-  ///   - id: The boundary identifier for which the lock should be released
+  ///   - boundaryId: The boundary identifier for which the lock should be released
   ///   - info: The same lock information of type `I` that was used when acquiring the lock
-  public func unlock<B: LockmanBoundaryId>(id: B, info: I) {
-    _unlock(id, info)
+  public func unlock<B: LockmanBoundaryId>(boundaryId: B, info: I) {
+    _unlock(boundaryId, info)
   }
 
   /// Removes all lock information across all boundaries.
@@ -260,9 +260,9 @@ public struct AnyLockmanStrategy<I: LockmanInfo>: LockmanStrategy, Sendable {
   /// - Scoped cleanup for temporary contexts or workflows
   /// - Partial system resets during development and testing
   ///
-  /// - Parameter id: The identifier whose lock information should be removed
-  public func cleanUp<B: LockmanBoundaryId>(id: B) {
-    _cleanUpById(id)
+  /// - Parameter boundaryId: The identifier whose lock information should be removed
+  public func cleanUp<B: LockmanBoundaryId>(boundaryId: B) {
+    _cleanUpById(boundaryId)
   }
 
   /// Returns current locks information for debugging.

--- a/Sources/Lockman/Documentation.docc/BoundaryOverview.md
+++ b/Sources/Lockman/Documentation.docc/BoundaryOverview.md
@@ -16,7 +16,7 @@ return .withLock(
         // Processing when already running within the same boundary
     },
     action: action,
-    cancelID: CancelID.userAction  // This CancelID functions as a Boundary
+    boundaryId: CancelID.userAction  // This CancelID functions as a Boundary
 )
 ```
 
@@ -35,11 +35,11 @@ Exclusive control between different Boundaries is not possible:
 // ❌ Not possible: Control save and load simultaneously
 case .saveButtonTapped:
     // Control only within CancelID.save boundary
-    return .withLock(..., cancelID: CancelID.save)
+    return .withLock(..., boundaryId: CancelID.save)
     
 case .loadButtonTapped:
     // Control only within CancelID.load boundary (independent from save)
-    return .withLock(..., cancelID: CancelID.load)
+    return .withLock(..., boundaryId: CancelID.load)
 ```
 
 Since these are treated as separate boundaries, load can be executed even while save is running.
@@ -54,7 +54,7 @@ return .withLock(
     operation: { send in /* ... */ },
     lockFailure: { error, send in /* ... */ },
     action: action,
-    cancelID: [CancelID.save, CancelID.validate]  // Multiple specification not allowed
+    boundaryId: [CancelID.save, CancelID.validate]  // Multiple specification not allowed
 )
 ```
 
@@ -67,7 +67,7 @@ enum CancelID {
 }
 
 case .saveButtonTapped, .loadButtonTapped, .validateButtonTapped:
-    return .withLock(..., cancelID: CancelID.fileOperation)
+    return .withLock(..., boundaryId: CancelID.fileOperation)
 ```
 
 ## Summary

--- a/Sources/Lockman/Documentation.docc/Configuration.md
+++ b/Sources/Lockman/Documentation.docc/Configuration.md
@@ -83,7 +83,7 @@ func applicationDidFinishLaunching() {
         // Processing that requires immediate release
     },
     action: action,
-    cancelID: cancelID
+    boundaryId: cancelID
 )
 ```
 

--- a/Sources/Lockman/Documentation.docc/DynamicConditionStrategy.md
+++ b/Sources/Lockman/Documentation.docc/DynamicConditionStrategy.md
@@ -44,7 +44,7 @@ ReduceWithLock { state, action in
                 send(.paymentCompleted)
             },
             lockAction: PaymentAction.makePayment,
-            cancelID: CancelID.payment,
+            boundaryId: CancelID.payment,
             lockCondition: { state, action in
                 // Action-level condition
                 guard state.balance >= amount else {
@@ -129,7 +129,7 @@ ReduceWithLock { state, action in
                 send(.operationCompleted)
             },
             lockAction: CriticalAction.execute, // 3. Traditional strategy (SingleExecution, etc.)
-            cancelID: CancelID.critical,
+            boundaryId: CancelID.critical,
             lockCondition: { state, _ in
                 // 1. Action-level condition
                 guard state.systemStatus == .ready else {

--- a/Sources/Lockman/Documentation.docc/ErrorHandling.md
+++ b/Sources/Lockman/Documentation.docc/ErrorHandling.md
@@ -24,7 +24,7 @@ Basic lockFailure handler structure used in all strategies:
         }
     },
     action: action,
-    cancelID: cancelID
+    boundaryId: cancelID
 )
 ```
 

--- a/Sources/Lockman/Documentation.docc/GettingStarted.md
+++ b/Sources/Lockman/Documentation.docc/GettingStarted.md
@@ -122,7 +122,7 @@ var body: some Reducer<State, Action> {
                     state.message = "Processing is already in progress"
                 },
                 action: action,
-                cancelID: CancelID.userAction
+                boundaryId: CancelID.userAction
             )
             
         case .processStart:

--- a/Sources/Lockman/Documentation.docc/Lock.md
+++ b/Sources/Lockman/Documentation.docc/Lock.md
@@ -32,7 +32,7 @@ The most basic and recommended usage. Automatically manages lock acquisition and
   catch handler: { error, send in /* Error handling */ }, // Optional
   lockFailure: { error, send in /* Lock acquisition failure handling */ }, // Optional
   action: action,
-  cancelID: cancelID
+  boundaryId: cancelID
 )
 ```
 
@@ -65,7 +65,7 @@ Used when you want to manually control the lock release timing. Parameters are t
     unlock() // Release on error too
   },
   action: action,
-  cancelID: cancelID
+  boundaryId: cancelID
 )
 ```
 
@@ -88,7 +88,7 @@ Maintains the same lock while executing multiple Effects sequentially.
   ],
   lockFailure: { error, send in /* Lock acquisition failure handling */ }, // Optional
   action: action,
-  cancelID: cancelID
+  boundaryId: cancelID
 )
 ```
 
@@ -107,7 +107,7 @@ When determining the unlock timing, Lockman follows this priority order:
      unlockOption: .transition, // This takes precedence
      operation: { send in /* ... */ },
      action: action,
-     cancelID: cancelID
+     boundaryId: cancelID
    )
    ```
 

--- a/Sources/Lockman/Documentation.docc/SingleExecutionStrategy.md
+++ b/Sources/Lockman/Documentation.docc/SingleExecutionStrategy.md
@@ -94,7 +94,7 @@ case .saveButtonTapped:
             send(.saveBusy("Save process is currently running"))
         },
         action: .save,
-        cancelID: CancelID.userAction
+        boundaryId: CancelID.userAction
     )
 ```
 

--- a/Sources/Lockman/Documentation.docc/Unlock.md
+++ b/Sources/Lockman/Documentation.docc/Unlock.md
@@ -63,7 +63,7 @@ Unlock execution timing can be controlled with LockmanUnlockOption:
     send(.failed(error))
   },
   action: action,
-  cancelID: cancelID
+  boundaryId: cancelID
 )
 ```
 
@@ -90,7 +90,7 @@ Basic usage example:
     send(.failed(error))
   },
   action: action,
-  cancelID: cancelID
+  boundaryId: cancelID
 )
 ```
 
@@ -103,7 +103,7 @@ Example of release in another screen's delegate:
     send(.delegate(unlock: unlock))
   },
   action: action,
-  cancelID: cancelID
+  boundaryId: cancelID
 )
 
 // Receive and release on the delegate side

--- a/Tests/LockmanTests/Composable/EffectLockmanErrorTests.swift
+++ b/Tests/LockmanTests/Composable/EffectLockmanErrorTests.swift
@@ -51,15 +51,16 @@ final class EffectLockmanErrorTests: XCTestCase {
       LockmanStrategyId("MockUnregisteredStrategy")
     }
 
-    func canLock<B: LockmanBoundaryId>(id _: B, info _: LockmanSingleExecutionInfo) -> LockmanResult
+    func canLock<B: LockmanBoundaryId>(boundaryId _: B, info _: LockmanSingleExecutionInfo)
+      -> LockmanResult
     {
       .success
     }
 
-    func lock<B: LockmanBoundaryId>(id _: B, info _: LockmanSingleExecutionInfo) {}
-    func unlock<B: LockmanBoundaryId>(id _: B, info _: LockmanSingleExecutionInfo) {}
+    func lock<B: LockmanBoundaryId>(boundaryId _: B, info _: LockmanSingleExecutionInfo) {}
+    func unlock<B: LockmanBoundaryId>(boundaryId _: B, info _: LockmanSingleExecutionInfo) {}
     func cleanUp() {}
-    func cleanUp<B: LockmanBoundaryId>(id _: B) {}
+    func cleanUp<B: LockmanBoundaryId>(boundaryId _: B) {}
     func getCurrentLocks() -> [AnyLockmanBoundaryId: [any LockmanInfo]] { [:] }
   }
 
@@ -84,7 +85,7 @@ final class EffectLockmanErrorTests: XCTestCase {
             operationExecuted.setValue(true)
           },
           action: action,
-          cancelID: cancelID
+          boundaryId: cancelID
         )
 
         // Effect should be created (error handling is internal)
@@ -113,7 +114,7 @@ final class EffectLockmanErrorTests: XCTestCase {
           // This operation would execute in a real environment
         },
         action: action,
-        cancelID: cancelID
+        boundaryId: cancelID
       )
 
       // Effect should be created successfully
@@ -138,7 +139,7 @@ final class EffectLockmanErrorTests: XCTestCase {
             XCTFail("Operation should not execute with unregistered strategy")
           },
           action: action,
-          cancelID: cancelID
+          boundaryId: cancelID
         )
 
         XCTAssertNotNil(effect)
@@ -166,7 +167,7 @@ final class EffectLockmanErrorTests: XCTestCase {
         let effect = Effect<Never>.concatenateWithLock(
           operations: operations,
           action: action,
-          cancelID: cancelID
+          boundaryId: cancelID
         )
 
         // Effect should handle the error gracefully
@@ -251,7 +252,7 @@ final class EffectLockmanErrorTests: XCTestCase {
             // Error handling would occur here in real usage
           },
           action: action,
-          cancelID: cancelID
+          boundaryId: cancelID
         )
 
         XCTAssertNotNil(effect)
@@ -275,7 +276,7 @@ final class EffectLockmanErrorTests: XCTestCase {
               XCTFail("No operations should execute")
             },
             action: action,
-            cancelID: "multi-error-test"
+            boundaryId: "multi-error-test"
           )
 
           XCTAssertNotNil(effect)
@@ -300,7 +301,7 @@ final class EffectLockmanErrorTests: XCTestCase {
             XCTFail("Should fail without registration")
           },
           action: action,
-          cancelID: cancelID
+          boundaryId: cancelID
         )
 
         XCTAssertNotNil(effect1)
@@ -320,7 +321,7 @@ final class EffectLockmanErrorTests: XCTestCase {
           // This would execute successfully in real environment
         },
         action: action,
-        cancelID: cancelID
+        boundaryId: cancelID
       )
 
       XCTAssertNotNil(effect2)

--- a/Tests/LockmanTests/Composable/EffectLockmanExclusiveTests.swift
+++ b/Tests/LockmanTests/Composable/EffectLockmanExclusiveTests.swift
@@ -172,11 +172,11 @@ final class DeadlockPreventionTests: XCTestCase {
       let info = LockmanSingleExecutionInfo(actionId: "test", mode: .boundary)
 
       // Check if we can acquire lock
-      let canLockResult = strategy.canLock(id: id, info: info)
+      let canLockResult = strategy.canLock(boundaryId: id, info: info)
       XCTAssertEqual(canLockResult, .success)
 
       // Acquire lock through strategy
-      strategy.lock(id: id, info: info)
+      strategy.lock(boundaryId: id, info: info)
 
       // Unlock using LockmanUnlock (executed under NSLock protection)
       let anyStrategy = AnyLockmanStrategy(strategy)
@@ -185,12 +185,12 @@ final class DeadlockPreventionTests: XCTestCase {
       unlock()
 
       // Verify that lock can be acquired again after unlock
-      let secondCanLockResult = strategy.canLock(id: id, info: info)
+      let secondCanLockResult = strategy.canLock(boundaryId: id, info: info)
       XCTAssertEqual(secondCanLockResult, .success)
 
       // Acquire and cleanup
-      strategy.lock(id: id, info: info)
-      strategy.unlock(id: id, info: info)
+      strategy.lock(boundaryId: id, info: info)
+      strategy.unlock(boundaryId: id, info: info)
     }
   }
 
@@ -417,7 +417,7 @@ private struct TestFeature {
             await send(.completed)
           },
           action: action,
-          cancelID: CancelID.test
+          boundaryId: CancelID.test
         )
       case .completed:
         return .none

--- a/Tests/LockmanTests/Composable/EffectLockmanPrecedingCancellationTests.swift
+++ b/Tests/LockmanTests/Composable/EffectLockmanPrecedingCancellationTests.swift
@@ -154,7 +154,7 @@ final class EffectWithLockPrecedingCancellationTests: XCTestCase {
               }
             },
             action: PriorityBasedAction.lowPriority,
-            cancelID: CancelID.task
+            boundaryId: CancelID.task
           )
 
         case .startHighPriority:
@@ -172,7 +172,7 @@ final class EffectWithLockPrecedingCancellationTests: XCTestCase {
               }
             },
             action: PriorityBasedAction.highExclusive,
-            cancelID: CancelID.task
+            boundaryId: CancelID.task
           )
 
         case .taskCompleted(let priority):

--- a/Tests/LockmanTests/Composable/EffectLockmanTests.swift
+++ b/Tests/LockmanTests/Composable/EffectLockmanTests.swift
@@ -50,9 +50,9 @@ final class EffectWithLockSingleExecutionStrategyTests: XCTestCase {
       )
 
       // Use correct API for locking
-      let result = strategy.canLock(id: id, info: info)
+      let result = strategy.canLock(boundaryId: id, info: info)
       XCTAssertEqual(result, .success)
-      strategy.lock(id: id, info: info)
+      strategy.lock(boundaryId: id, info: info)
 
       // When: Attempting to execute the same action
       await store.send(.tapIncrement)
@@ -62,7 +62,7 @@ final class EffectWithLockSingleExecutionStrategyTests: XCTestCase {
       // State remains unchanged (count is still 0)
 
       // Clean up: Release the lock for next tests
-      strategy.unlock(id: id, info: info)
+      strategy.unlock(boundaryId: id, info: info)
     }
   }
 
@@ -85,9 +85,9 @@ final class EffectWithLockSingleExecutionStrategyTests: XCTestCase {
       )
 
       // Given: Pre-existing lock
-      let lockResult = strategy.canLock(id: id, info: info)
+      let lockResult = strategy.canLock(boundaryId: id, info: info)
       XCTAssertEqual(lockResult, .success)
-      strategy.lock(id: id, info: info)
+      strategy.lock(boundaryId: id, info: info)
 
       // When: First attempt is blocked
       await store.send(.tapIncrement)
@@ -95,7 +95,7 @@ final class EffectWithLockSingleExecutionStrategyTests: XCTestCase {
       // State remains unchanged at this point
 
       // And: Lock is released
-      strategy.unlock(id: id, info: info)
+      strategy.unlock(boundaryId: id, info: info)
 
       // When: Second attempt after unlock
       await store.send(.tapIncrement)
@@ -126,9 +126,9 @@ final class EffectWithLockSingleExecutionStrategyTests: XCTestCase {
         actionId: TestSingleExecutionFeature.Action.tapIncrement.actionName,
         mode: .boundary
       )
-      let lockResult = strategy.canLock(id: id, info: incrementInfo)
+      let lockResult = strategy.canLock(boundaryId: id, info: incrementInfo)
       XCTAssertEqual(lockResult, .success)
-      strategy.lock(id: id, info: incrementInfo)
+      strategy.lock(boundaryId: id, info: incrementInfo)
 
       // When: tapIncrement is blocked
       await store.send(.tapIncrement)
@@ -136,7 +136,7 @@ final class EffectWithLockSingleExecutionStrategyTests: XCTestCase {
       // State remains unchanged (count is still 0)
 
       // Clean up: Release the lock
-      strategy.unlock(id: id, info: incrementInfo)
+      strategy.unlock(boundaryId: id, info: incrementInfo)
 
       // But: tapDecrement should work (different action name)
       await store.send(.tapDecrement)
@@ -164,9 +164,9 @@ final class EffectWithLockSingleExecutionStrategyTests: XCTestCase {
       // Given: Pre-existing lock
       let id = TestSingleExecutionFeature.CancelID.userAction
       let info = LockmanSingleExecutionInfo(actionId: "tapIncrement", mode: .boundary)
-      let lockResult = strategy.canLock(id: id, info: info)
+      let lockResult = strategy.canLock(boundaryId: id, info: info)
       XCTAssertEqual(lockResult, .success)
-      strategy.lock(id: id, info: info)
+      strategy.lock(boundaryId: id, info: info)
 
       // When: Attempting action that will fail to acquire lock
       await store.send(.tapIncrement)
@@ -176,7 +176,7 @@ final class EffectWithLockSingleExecutionStrategyTests: XCTestCase {
       // State remains unchanged (count is still 0)
 
       // Clean up: Release the lock
-      strategy.unlock(id: id, info: info)
+      strategy.unlock(boundaryId: id, info: info)
     }
   }
 
@@ -343,9 +343,9 @@ final class EffectConcatenateWithLockTests: XCTestCase {
         actionId: TestConcatenateWithLockFeature.Action.executeConcatenateWithLock.actionName,
         mode: .boundary
       )
-      let result = strategy.canLock(id: id, info: info)
+      let result = strategy.canLock(boundaryId: id, info: info)
       XCTAssertEqual(result, .success)
-      strategy.lock(id: id, info: info)
+      strategy.lock(boundaryId: id, info: info)
 
       // When: Attempting to execute the same action
       await store.send(.executeConcatenateWithLock)
@@ -355,7 +355,7 @@ final class EffectConcatenateWithLockTests: XCTestCase {
       // State remains unchanged (count is still 0)
 
       // Clean up: Release the lock for next tests
-      strategy.unlock(id: id, info: info)
+      strategy.unlock(boundaryId: id, info: info)
 
       // Verify that after unlock, action can execute normally
       await store.send(.executeConcatenateWithLock)
@@ -494,7 +494,7 @@ private struct TestConcatenateWithLockFeature {
             .send(.increment),
           ],
           action: action,
-          cancelID: CancelID.userAction
+          boundaryId: CancelID.userAction
         )
 
       case .executeConcatenateWithLockWithFailure:
@@ -504,7 +504,7 @@ private struct TestConcatenateWithLockFeature {
             .send(.operationFailed)
           ],
           action: action,
-          cancelID: CancelID.userAction
+          boundaryId: CancelID.userAction
         )
 
       case .executeConcatenateWithLockWithCancel:
@@ -514,7 +514,7 @@ private struct TestConcatenateWithLockFeature {
             .send(.operationCanceled)
           ],
           action: action,
-          cancelID: CancelID.userAction
+          boundaryId: CancelID.userAction
         )
 
       case .executeConcatenateWithLockEmpty:
@@ -522,7 +522,7 @@ private struct TestConcatenateWithLockFeature {
           unlockOption: .immediate,
           operations: [],
           action: action,
-          cancelID: CancelID.userAction
+          boundaryId: CancelID.userAction
         )
 
       case .increment:
@@ -591,7 +591,7 @@ private struct TestSingleExecutionFeature {
             await send(.increment)
           },
           action: action,
-          cancelID: CancelID.userAction
+          boundaryId: CancelID.userAction
         )
 
       case .tapDecrement:
@@ -601,7 +601,7 @@ private struct TestSingleExecutionFeature {
             await send(.decrement)
           },
           action: action,
-          cancelID: CancelID.userAction
+          boundaryId: CancelID.userAction
         )
 
       case .increment:
@@ -661,7 +661,7 @@ private struct TestMultiIdFeature {
             await send(.increment)
           },
           action: action,
-          cancelID: CancelID.id1
+          boundaryId: CancelID.id1
         )
 
       case .actionWithId2:
@@ -672,7 +672,7 @@ private struct TestMultiIdFeature {
             unlock()
           },
           action: action,
-          cancelID: CancelID.id2
+          boundaryId: CancelID.id2
         )
 
       case .increment:

--- a/Tests/LockmanTests/Composable/EffectWithLockLockFailureTests.swift
+++ b/Tests/LockmanTests/Composable/EffectWithLockLockFailureTests.swift
@@ -47,7 +47,7 @@ final class EffectWithLockLockFailureTests: XCTestCase {
           let strategy = LockmanSingleExecutionStrategy.shared
 
           // Manually lock it first to cause failure on second attempt
-          strategy.lock(id: TestBoundaryId.testBoundary, info: lockInfo)
+          strategy.lock(boundaryId: TestBoundaryId.testBoundary, info: lockInfo)
 
           return .withLock(
             operation: { send, unlock in
@@ -65,7 +65,7 @@ final class EffectWithLockLockFailureTests: XCTestCase {
               await send(.lockFailureOccurred(error.localizedDescription))
             },
             action: lockAction,
-            cancelID: TestBoundaryId.testBoundary
+            boundaryId: TestBoundaryId.testBoundary
           )
 
         case .testManualUnlockWithOperationError:
@@ -88,7 +88,7 @@ final class EffectWithLockLockFailureTests: XCTestCase {
               await send(.lockFailureOccurred("Should not be called"))
             },
             action: TestAction(),
-            cancelID: TestBoundaryId.testBoundary2
+            boundaryId: TestBoundaryId.testBoundary2
           )
 
         case .lockFailureOccurred(let errorMessage):
@@ -208,7 +208,7 @@ final class EffectWithLockLockFailureTests: XCTestCase {
             // No catch handler
             // No lockFailure handler
             action: EffectWithLockLockFailureTests.TestAction(),
-            cancelID: EffectWithLockLockFailureTests.TestBoundaryId.testBoundary
+            boundaryId: EffectWithLockLockFailureTests.TestBoundaryId.testBoundary
           )
 
         case .completed:

--- a/Tests/LockmanTests/Composable/ReduceWithLockIntegrationTests.swift
+++ b/Tests/LockmanTests/Composable/ReduceWithLockIntegrationTests.swift
@@ -128,7 +128,7 @@ final class ReduceWithLockIntegrationTests: XCTestCase {
             await send(.setLockAcquired(true))
           },
           lockAction: TestLockAction(),
-          cancelID: cancelID,
+          boundaryId: cancelID,
           lockCondition: { _, _ in
             // Action-level condition
             return .success
@@ -194,8 +194,8 @@ final class ReduceWithLockIntegrationTests: XCTestCase {
     )
 
     // Acquire both locks
-    dynamicStrategy.lock(id: boundary, info: info1)
-    dynamicStrategy.lock(id: boundary, info: info2)
+    dynamicStrategy.lock(boundaryId: boundary, info: info1)
+    dynamicStrategy.lock(boundaryId: boundary, info: info2)
 
     // Verify both locks exist (different uniqueIds)
     let locks = dynamicStrategy.getCurrentLocks()[AnyLockmanBoundaryId(boundary)] ?? []
@@ -203,7 +203,7 @@ final class ReduceWithLockIntegrationTests: XCTestCase {
     XCTAssertEqual(locksWithActionId.count, 2, "Should have 2 locks with same actionId")
 
     // Unlock removes ALL locks with same actionId
-    dynamicStrategy.unlock(id: boundary, info: info1)
+    dynamicStrategy.unlock(boundaryId: boundary, info: info1)
 
     // Verify all locks with the actionId are removed
     let remainingLocks = dynamicStrategy.getCurrentLocks()[AnyLockmanBoundaryId(boundary)] ?? []
@@ -248,7 +248,7 @@ final class ReduceWithLockIntegrationTests: XCTestCase {
               tracker.errorHandlerCalled = true
             },
             lockAction: TestLockAction(),
-            cancelID: TestLockAction().lockmanInfo.actionId,
+            boundaryId: TestLockAction().lockmanInfo.actionId,
             lockCondition: { _, _ in
               // Failing condition
               return .failure(
@@ -325,7 +325,7 @@ final class ReduceWithLockIntegrationTests: XCTestCase {
               await send(.setLockAcquired(true))
             },
             lockAction: TestLockAction(),
-            cancelID: TestLockAction().lockmanInfo.actionId
+            boundaryId: TestLockAction().lockmanInfo.actionId
           )
         case .setLockAcquired(let value):
           state.lockAcquired = value
@@ -385,7 +385,7 @@ final class ReduceWithLockIntegrationTests: XCTestCase {
               unlock()
             },
             lockAction: TestLockAction(),
-            cancelID: TestLockAction().lockmanInfo.actionId
+            boundaryId: TestLockAction().lockmanInfo.actionId
           )
         default:
           return .none
@@ -442,7 +442,7 @@ final class ReduceWithLockIntegrationTests: XCTestCase {
               await send(.setLockAcquired(true))
             },
             lockAction: TestLockAction(),
-            cancelID: TestLockAction().lockmanInfo.actionId,
+            boundaryId: TestLockAction().lockmanInfo.actionId,
             lockCondition: { _, _ in
               // Action-level condition
               return .success
@@ -490,7 +490,7 @@ final class ReduceWithLockIntegrationTests: XCTestCase {
 
     // Create another lock to simulate step 3 failing
     singleExecutionStrategy.lock(
-      id: cancelID,
+      boundaryId: cancelID,
       info: LockmanSingleExecutionInfo(actionId: cancelID, mode: .boundary)
     )
 
@@ -514,7 +514,7 @@ final class ReduceWithLockIntegrationTests: XCTestCase {
               XCTFail("Operation should not execute when step 3 fails")
             },
             lockAction: TestLockAction(),
-            cancelID: TestLockAction().lockmanInfo.actionId,
+            boundaryId: TestLockAction().lockmanInfo.actionId,
             lockCondition: { _, _ in
               tracker.step2Evaluated = true
               return .success  // Step 2 also passes
@@ -549,7 +549,7 @@ final class ReduceWithLockIntegrationTests: XCTestCase {
 
     // Clean up the test lock
     singleExecutionStrategy.unlock(
-      id: cancelID,
+      boundaryId: cancelID,
       info: LockmanSingleExecutionInfo(actionId: cancelID, mode: .boundary)
     )
   }

--- a/Tests/LockmanTests/Core/Debug/LockmanDebugFormattersTests.swift
+++ b/Tests/LockmanTests/Core/Debug/LockmanDebugFormattersTests.swift
@@ -28,11 +28,12 @@ final class LockmanDebugFormattersTests: XCTestCase {
     let longBoundaryId = "VeryLongBoundaryIdForTestingColumnWidth"
 
     // Lock with both strategies
-    _ = LockmanDynamicConditionStrategy.shared.canLock(id: shortBoundaryId, info: dynamicInfo)
-    LockmanDynamicConditionStrategy.shared.lock(id: shortBoundaryId, info: dynamicInfo)
+    _ = LockmanDynamicConditionStrategy.shared.canLock(
+      boundaryId: shortBoundaryId, info: dynamicInfo)
+    LockmanDynamicConditionStrategy.shared.lock(boundaryId: shortBoundaryId, info: dynamicInfo)
 
-    _ = LockmanSingleExecutionStrategy.shared.canLock(id: longBoundaryId, info: singleInfo)
-    LockmanSingleExecutionStrategy.shared.lock(id: longBoundaryId, info: singleInfo)
+    _ = LockmanSingleExecutionStrategy.shared.canLock(boundaryId: longBoundaryId, info: singleInfo)
+    LockmanSingleExecutionStrategy.shared.lock(boundaryId: longBoundaryId, info: singleInfo)
 
     // Capture output
     let originalStdout = dup(STDOUT_FILENO)

--- a/Tests/LockmanTests/Core/DebugTests.swift
+++ b/Tests/LockmanTests/Core/DebugTests.swift
@@ -41,14 +41,14 @@ final class DebugTests: XCTestCase {
     let info1 = LockmanSingleExecutionInfo(actionId: "testAction1", mode: .boundary)
 
     // Acquire locks
-    XCTAssertEqual(strategy.canLock(id: boundaryId, info: info1), .success)
-    strategy.lock(id: boundaryId, info: info1)
+    XCTAssertEqual(strategy.canLock(boundaryId: boundaryId, info: info1), .success)
+    strategy.lock(boundaryId: boundaryId, info: info1)
 
     // This should print a table with the active lock
     LockmanManager.debug.printCurrentLocks()
 
     // Clean up
-    strategy.unlock(id: boundaryId, info: info1)
+    strategy.unlock(boundaryId: boundaryId, info: info1)
   }
 
   func testDebugDescriptionForAllInfoTypes() {

--- a/Tests/LockmanTests/Core/LockmanConfigurationTests.swift
+++ b/Tests/LockmanTests/Core/LockmanConfigurationTests.swift
@@ -179,11 +179,11 @@ final class LockmanConfigurationIntegrationTests: XCTestCase {
     let info = LockmanSingleExecutionInfo(actionId: "test-immediate", mode: .boundary)
 
     // Lock
-    strategy.lock(id: boundaryId, info: info)
+    strategy.lock(boundaryId: boundaryId, info: info)
 
     // Verify it's locked - another instance with same actionId should fail
     let anotherInfo = LockmanSingleExecutionInfo(actionId: "test-immediate", mode: .boundary)
-    XCTAssertLockFailure(strategy.canLock(id: boundaryId, info: anotherInfo))
+    XCTAssertLockFailure(strategy.canLock(boundaryId: boundaryId, info: anotherInfo))
 
     // Create unlock token with immediate option
     let unlockToken = LockmanUnlock(
@@ -199,7 +199,7 @@ final class LockmanConfigurationIntegrationTests: XCTestCase {
     // For immediate unlock, no wait is needed
     // Should be able to lock again with a new info instance (same actionId)
     let newInfo = LockmanSingleExecutionInfo(actionId: "test-immediate", mode: .boundary)
-    XCTAssertEqual(strategy.canLock(id: boundaryId, info: newInfo), .success)
+    XCTAssertEqual(strategy.canLock(boundaryId: boundaryId, info: newInfo), .success)
 
     // Clean up
     strategy.cleanUp()
@@ -227,22 +227,23 @@ final class LockmanConfigurationIntegrationTests: XCTestCase {
     )
 
     // Lock
-    strategy.lock(id: boundaryId, info: info)
-    XCTAssertLockFailure(strategy.canLock(id: boundaryId, info: info))
+    strategy.lock(boundaryId: boundaryId, info: info)
+    XCTAssertLockFailure(strategy.canLock(boundaryId: boundaryId, info: info))
 
     // Call unlock (should be delayed)
     unlockToken()
 
     // Verify still locked immediately after
     XCTAssertLockFailure(
-      strategy.canLock(id: boundaryId, info: info), "Lock should not be released immediately")
+      strategy.canLock(boundaryId: boundaryId, info: info),
+      "Lock should not be released immediately")
 
     // Wait a small amount to ensure we're testing the delay
     try await Task.sleep(nanoseconds: 100_000_000)  // 100ms
 
     // For transition delay, we should still be locked at this point on all platforms
     XCTAssertLockFailure(
-      strategy.canLock(id: boundaryId, info: info),
+      strategy.canLock(boundaryId: boundaryId, info: info),
       "Lock should still be held during transition delay")
 
     // Wait for the maximum possible transition delay across all platforms
@@ -250,7 +251,7 @@ final class LockmanConfigurationIntegrationTests: XCTestCase {
 
     // Now it should definitely be unlocked
     XCTAssertEqual(
-      strategy.canLock(id: boundaryId, info: info), .success,
+      strategy.canLock(boundaryId: boundaryId, info: info), .success,
       "Lock should be released after transition delay")
   }
 }

--- a/Tests/LockmanTests/Core/LockmanEdgeCaseTests.swift
+++ b/Tests/LockmanTests/Core/LockmanEdgeCaseTests.swift
@@ -13,14 +13,14 @@ final class LockmanEdgeCaseTests: XCTestCase {
     let emptyBoundaryId = ""
 
     // Should handle empty boundary ID without crashing
-    XCTAssertEqual(strategy.canLock(id: emptyBoundaryId, info: info), .success)
-    strategy.lock(id: emptyBoundaryId, info: info)
-    XCTAssertLockFailure(strategy.canLock(id: emptyBoundaryId, info: info))
-    strategy.unlock(id: emptyBoundaryId, info: info)
-    XCTAssertEqual(strategy.canLock(id: emptyBoundaryId, info: info), .success)
+    XCTAssertEqual(strategy.canLock(boundaryId: emptyBoundaryId, info: info), .success)
+    strategy.lock(boundaryId: emptyBoundaryId, info: info)
+    XCTAssertLockFailure(strategy.canLock(boundaryId: emptyBoundaryId, info: info))
+    strategy.unlock(boundaryId: emptyBoundaryId, info: info)
+    XCTAssertEqual(strategy.canLock(boundaryId: emptyBoundaryId, info: info), .success)
 
     // Cleanup should work
-    strategy.cleanUp(id: emptyBoundaryId)
+    strategy.cleanUp(boundaryId: emptyBoundaryId)
   }
 
   func testVeryLongBoundaryIDHandling() async throws {
@@ -28,12 +28,12 @@ final class LockmanEdgeCaseTests: XCTestCase {
     let info = LockmanPriorityBasedInfo(actionId: "test-action", priority: .high(.exclusive))
     let longBoundaryId = String(repeating: "VeryLongBoundaryId", count: 100)  // 1800 characters
 
-    XCTAssertEqual(strategy.canLock(id: longBoundaryId, info: info), .success)
-    strategy.lock(id: longBoundaryId, info: info)
-    XCTAssertLockFailure(strategy.canLock(id: longBoundaryId, info: info))
-    strategy.unlock(id: longBoundaryId, info: info)
+    XCTAssertEqual(strategy.canLock(boundaryId: longBoundaryId, info: info), .success)
+    strategy.lock(boundaryId: longBoundaryId, info: info)
+    XCTAssertLockFailure(strategy.canLock(boundaryId: longBoundaryId, info: info))
+    strategy.unlock(boundaryId: longBoundaryId, info: info)
 
-    strategy.cleanUp(id: longBoundaryId)
+    strategy.cleanUp(boundaryId: longBoundaryId)
   }
 
   func testUnicodeBoundaryIDHandling() async throws {
@@ -41,12 +41,12 @@ final class LockmanEdgeCaseTests: XCTestCase {
     let info = LockmanSingleExecutionInfo(actionId: "test-action", mode: .boundary)
     let unicodeBoundaryId = "🔒境界識別子📱测试🚀"
 
-    XCTAssertEqual(strategy.canLock(id: unicodeBoundaryId, info: info), .success)
-    strategy.lock(id: unicodeBoundaryId, info: info)
-    XCTAssertLockFailure(strategy.canLock(id: unicodeBoundaryId, info: info))
-    strategy.unlock(id: unicodeBoundaryId, info: info)
+    XCTAssertEqual(strategy.canLock(boundaryId: unicodeBoundaryId, info: info), .success)
+    strategy.lock(boundaryId: unicodeBoundaryId, info: info)
+    XCTAssertLockFailure(strategy.canLock(boundaryId: unicodeBoundaryId, info: info))
+    strategy.unlock(boundaryId: unicodeBoundaryId, info: info)
 
-    strategy.cleanUp(id: unicodeBoundaryId)
+    strategy.cleanUp(boundaryId: unicodeBoundaryId)
   }
 
   func testSpecialCharacterBoundaryIDHandling() async throws {
@@ -54,9 +54,9 @@ final class LockmanEdgeCaseTests: XCTestCase {
     let info = LockmanPriorityBasedInfo(actionId: "test", priority: .low(.replaceable))
     let specialBoundaryId = "boundary@#$%^&*()_+-=[]{}|;':\",./<>?"
 
-    XCTAssertEqual(strategy.canLock(id: specialBoundaryId, info: info), .success)
-    strategy.lock(id: specialBoundaryId, info: info)
-    strategy.cleanUp(id: specialBoundaryId)
+    XCTAssertEqual(strategy.canLock(boundaryId: specialBoundaryId, info: info), .success)
+    strategy.lock(boundaryId: specialBoundaryId, info: info)
+    strategy.cleanUp(boundaryId: specialBoundaryId)
   }
 
   // MARK: - Action ID Edge Cases
@@ -66,15 +66,15 @@ final class LockmanEdgeCaseTests: XCTestCase {
     let emptyActionInfo = LockmanSingleExecutionInfo(actionId: "", mode: .boundary)
     let boundaryId = "test-boundary"
 
-    XCTAssertEqual(strategy.canLock(id: boundaryId, info: emptyActionInfo), .success)
-    strategy.lock(id: boundaryId, info: emptyActionInfo)
-    XCTAssertLockFailure(strategy.canLock(id: boundaryId, info: emptyActionInfo))
+    XCTAssertEqual(strategy.canLock(boundaryId: boundaryId, info: emptyActionInfo), .success)
+    strategy.lock(boundaryId: boundaryId, info: emptyActionInfo)
+    XCTAssertLockFailure(strategy.canLock(boundaryId: boundaryId, info: emptyActionInfo))
 
     // Different empty action should also conflict
     let anotherEmptyInfo = LockmanSingleExecutionInfo(actionId: "", mode: .boundary)
-    XCTAssertLockFailure(strategy.canLock(id: boundaryId, info: anotherEmptyInfo))
+    XCTAssertLockFailure(strategy.canLock(boundaryId: boundaryId, info: anotherEmptyInfo))
 
-    strategy.unlock(id: boundaryId, info: emptyActionInfo)
+    strategy.unlock(boundaryId: boundaryId, info: emptyActionInfo)
     strategy.cleanUp()
   }
 
@@ -84,13 +84,13 @@ final class LockmanEdgeCaseTests: XCTestCase {
     let info = LockmanPriorityBasedInfo(actionId: longActionId, priority: .high(.exclusive))
     let boundaryId = "test-boundary"
 
-    XCTAssertEqual(strategy.canLock(id: boundaryId, info: info), .success)
-    strategy.lock(id: boundaryId, info: info)
+    XCTAssertEqual(strategy.canLock(boundaryId: boundaryId, info: info), .success)
+    strategy.lock(boundaryId: boundaryId, info: info)
 
     // Same long action ID with lower priority should fail
     let sameActionInfo = LockmanPriorityBasedInfo(
       actionId: longActionId, priority: .low(.exclusive))
-    XCTAssertLockFailure(strategy.canLock(id: boundaryId, info: sameActionInfo))
+    XCTAssertLockFailure(strategy.canLock(boundaryId: boundaryId, info: sameActionInfo))
 
     strategy.cleanUp()
   }
@@ -101,14 +101,14 @@ final class LockmanEdgeCaseTests: XCTestCase {
     let info = LockmanSingleExecutionInfo(actionId: unicodeActionId, mode: .boundary)
     let boundaryId = "test-boundary"
 
-    XCTAssertEqual(strategy.canLock(id: boundaryId, info: info), .success)
-    strategy.lock(id: boundaryId, info: info)
+    XCTAssertEqual(strategy.canLock(boundaryId: boundaryId, info: info), .success)
+    strategy.lock(boundaryId: boundaryId, info: info)
 
     // Same unicode action ID should conflict
     let sameUnicodeInfo = LockmanSingleExecutionInfo(actionId: unicodeActionId, mode: .boundary)
-    XCTAssertLockFailure(strategy.canLock(id: boundaryId, info: sameUnicodeInfo))
+    XCTAssertLockFailure(strategy.canLock(boundaryId: boundaryId, info: sameUnicodeInfo))
 
-    strategy.unlock(id: boundaryId, info: info)
+    strategy.unlock(boundaryId: boundaryId, info: info)
     strategy.cleanUp()
   }
 
@@ -126,15 +126,15 @@ final class LockmanEdgeCaseTests: XCTestCase {
       actionId: "none-action", priority: .high(.exclusive))
 
     // First none priority should succeed
-    XCTAssertEqual(strategy.canLock(id: boundaryId, info: noneInfo1), .success)
-    strategy.lock(id: boundaryId, info: noneInfo1)
+    XCTAssertEqual(strategy.canLock(boundaryId: boundaryId, info: noneInfo1), .success)
+    strategy.lock(boundaryId: boundaryId, info: noneInfo1)
 
     // Second none priority with same action ID should succeed (no conflicts for .none)
-    XCTAssertEqual(strategy.canLock(id: boundaryId, info: noneInfo2), .success)
-    strategy.lock(id: boundaryId, info: noneInfo2)
+    XCTAssertEqual(strategy.canLock(boundaryId: boundaryId, info: noneInfo2), .success)
+    strategy.lock(boundaryId: boundaryId, info: noneInfo2)
 
     // High priority should succeed (may not cancel if none priority doesn't block)
-    let result = strategy.canLock(id: boundaryId, info: highInfo)
+    let result = strategy.canLock(boundaryId: boundaryId, info: highInfo)
     switch result {
     case .success, .successWithPrecedingCancellation:
       // Success - either immediate success or with cancellation
@@ -178,9 +178,9 @@ final class LockmanEdgeCaseTests: XCTestCase {
     for i in 0..<operationCount {
       let info = LockmanSingleExecutionInfo(actionId: "operation-\(i)", mode: .boundary)
 
-      XCTAssertEqual(strategy.canLock(id: boundaryId, info: info), .success)
-      strategy.lock(id: boundaryId, info: info)
-      strategy.unlock(id: boundaryId, info: info)
+      XCTAssertEqual(strategy.canLock(boundaryId: boundaryId, info: info), .success)
+      strategy.lock(boundaryId: boundaryId, info: info)
+      strategy.unlock(boundaryId: boundaryId, info: info)
     }
 
     let endTime = CFAbsoluteTimeGetCurrent()
@@ -201,8 +201,8 @@ final class LockmanEdgeCaseTests: XCTestCase {
       let boundaryId = "boundary-\(i)"
       let info = LockmanPriorityBasedInfo(actionId: "action", priority: .low(.exclusive))
 
-      XCTAssertEqual(strategy.canLock(id: boundaryId, info: info), .success)
-      strategy.lock(id: boundaryId, info: info)
+      XCTAssertEqual(strategy.canLock(boundaryId: boundaryId, info: info), .success)
+      strategy.lock(boundaryId: boundaryId, info: info)
     }
 
     // Verify all are locked independently
@@ -210,7 +210,7 @@ final class LockmanEdgeCaseTests: XCTestCase {
       let boundaryId = "boundary-\(i)"
       let newInfo = LockmanPriorityBasedInfo(actionId: "action", priority: .low(.exclusive))
 
-      XCTAssertLockFailure(strategy.canLock(id: boundaryId, info: newInfo))
+      XCTAssertLockFailure(strategy.canLock(boundaryId: boundaryId, info: newInfo))
     }
 
     strategy.cleanUp()
@@ -237,9 +237,9 @@ final class LockmanEdgeCaseTests: XCTestCase {
     // Use a subset to avoid excessive test time
     for i in 0..<100 {
       let info = infos[i]
-      XCTAssertEqual(strategy.canLock(id: boundaryId, info: info), .success)
-      strategy.lock(id: boundaryId, info: info)
-      strategy.unlock(id: boundaryId, info: info)
+      XCTAssertEqual(strategy.canLock(boundaryId: boundaryId, info: info), .success)
+      strategy.lock(boundaryId: boundaryId, info: info)
+      strategy.unlock(boundaryId: boundaryId, info: info)
     }
 
     strategy.cleanUp()
@@ -253,13 +253,13 @@ final class LockmanEdgeCaseTests: XCTestCase {
       typealias I = LockmanSingleExecutionInfo
       var strategyId: LockmanStrategyId { LockmanStrategyId(type: Self.self) }
       static func makeStrategyId() -> LockmanStrategyId { LockmanStrategyId(type: self) }
-      func canLock<B: LockmanBoundaryId>(id _: B, info _: LockmanSingleExecutionInfo)
+      func canLock<B: LockmanBoundaryId>(boundaryId _: B, info _: LockmanSingleExecutionInfo)
         -> LockmanResult
       { .success }
-      func lock<B: LockmanBoundaryId>(id _: B, info _: LockmanSingleExecutionInfo) {}
-      func unlock<B: LockmanBoundaryId>(id _: B, info _: LockmanSingleExecutionInfo) {}
+      func lock<B: LockmanBoundaryId>(boundaryId _: B, info _: LockmanSingleExecutionInfo) {}
+      func unlock<B: LockmanBoundaryId>(boundaryId _: B, info _: LockmanSingleExecutionInfo) {}
       func cleanUp() {}
-      func cleanUp<B: LockmanBoundaryId>(id _: B) {}
+      func cleanUp<B: LockmanBoundaryId>(boundaryId _: B) {}
       func getCurrentLocks() -> [AnyLockmanBoundaryId: [any LockmanInfo]] { [:] }
     }
 
@@ -267,13 +267,13 @@ final class LockmanEdgeCaseTests: XCTestCase {
       typealias I = LockmanSingleExecutionInfo
       var strategyId: LockmanStrategyId { LockmanStrategyId(type: Self.self) }
       static func makeStrategyId() -> LockmanStrategyId { LockmanStrategyId(type: self) }
-      func canLock<B: LockmanBoundaryId>(id _: B, info _: LockmanSingleExecutionInfo)
+      func canLock<B: LockmanBoundaryId>(boundaryId _: B, info _: LockmanSingleExecutionInfo)
         -> LockmanResult
       { .success }
-      func lock<B: LockmanBoundaryId>(id _: B, info _: LockmanSingleExecutionInfo) {}
-      func unlock<B: LockmanBoundaryId>(id _: B, info _: LockmanSingleExecutionInfo) {}
+      func lock<B: LockmanBoundaryId>(boundaryId _: B, info _: LockmanSingleExecutionInfo) {}
+      func unlock<B: LockmanBoundaryId>(boundaryId _: B, info _: LockmanSingleExecutionInfo) {}
       func cleanUp() {}
-      func cleanUp<B: LockmanBoundaryId>(id _: B) {}
+      func cleanUp<B: LockmanBoundaryId>(boundaryId _: B) {}
       func getCurrentLocks() -> [AnyLockmanBoundaryId: [any LockmanInfo]] { [:] }
     }
 
@@ -281,12 +281,13 @@ final class LockmanEdgeCaseTests: XCTestCase {
       typealias I = LockmanPriorityBasedInfo
       var strategyId: LockmanStrategyId { LockmanStrategyId(type: Self.self) }
       static func makeStrategyId() -> LockmanStrategyId { LockmanStrategyId(type: self) }
-      func canLock<B: LockmanBoundaryId>(id _: B, info _: LockmanPriorityBasedInfo) -> LockmanResult
+      func canLock<B: LockmanBoundaryId>(boundaryId _: B, info _: LockmanPriorityBasedInfo)
+        -> LockmanResult
       { .success }
-      func lock<B: LockmanBoundaryId>(id _: B, info _: LockmanPriorityBasedInfo) {}
-      func unlock<B: LockmanBoundaryId>(id _: B, info _: LockmanPriorityBasedInfo) {}
+      func lock<B: LockmanBoundaryId>(boundaryId _: B, info _: LockmanPriorityBasedInfo) {}
+      func unlock<B: LockmanBoundaryId>(boundaryId _: B, info _: LockmanPriorityBasedInfo) {}
       func cleanUp() {}
-      func cleanUp<B: LockmanBoundaryId>(id _: B) {}
+      func cleanUp<B: LockmanBoundaryId>(boundaryId _: B) {}
       func getCurrentLocks() -> [AnyLockmanBoundaryId: [any LockmanInfo]] { [:] }
     }
 
@@ -323,15 +324,15 @@ final class LockmanEdgeCaseTests: XCTestCase {
 
     // Cleanup should not crash even with no locks
     strategy.cleanUp()
-    strategy.cleanUp(id: "non-existent-boundary")
+    strategy.cleanUp(boundaryId: "non-existent-boundary")
 
     // Should still be usable after cleanup
     let info = LockmanSingleExecutionInfo(actionId: "test", mode: .boundary)
     let boundaryId = "test-boundary"
 
-    XCTAssertEqual(strategy.canLock(id: boundaryId, info: info), .success)
-    strategy.lock(id: boundaryId, info: info)
-    strategy.unlock(id: boundaryId, info: info)
+    XCTAssertEqual(strategy.canLock(boundaryId: boundaryId, info: info), .success)
+    strategy.lock(boundaryId: boundaryId, info: info)
+    strategy.unlock(boundaryId: boundaryId, info: info)
   }
 
   func testMultipleCleanupCalls() async throws {
@@ -340,16 +341,16 @@ final class LockmanEdgeCaseTests: XCTestCase {
     let info = LockmanPriorityBasedInfo(actionId: "test", priority: .high(.exclusive))
 
     // Lock something first
-    strategy.lock(id: boundaryId, info: info)
+    strategy.lock(boundaryId: boundaryId, info: info)
 
     // Multiple cleanup calls should be safe
     strategy.cleanUp()
     strategy.cleanUp()
-    strategy.cleanUp(id: boundaryId)
-    strategy.cleanUp(id: boundaryId)
+    strategy.cleanUp(boundaryId: boundaryId)
+    strategy.cleanUp(boundaryId: boundaryId)
 
     // Should still be usable
-    XCTAssertEqual(strategy.canLock(id: boundaryId, info: info), .success)
+    XCTAssertEqual(strategy.canLock(boundaryId: boundaryId, info: info), .success)
   }
 
   func testCleanupDuringActiveOperations() async throws {
@@ -358,16 +359,16 @@ final class LockmanEdgeCaseTests: XCTestCase {
     let info = LockmanSingleExecutionInfo(actionId: "test-action", mode: .boundary)
 
     // Lock first
-    strategy.lock(id: boundaryId, info: info)
-    XCTAssertLockFailure(strategy.canLock(id: boundaryId, info: info))
+    strategy.lock(boundaryId: boundaryId, info: info)
+    XCTAssertLockFailure(strategy.canLock(boundaryId: boundaryId, info: info))
 
     // Cleanup should clear the lock
     strategy.cleanUp()
-    XCTAssertEqual(strategy.canLock(id: boundaryId, info: info), .success)
+    XCTAssertEqual(strategy.canLock(boundaryId: boundaryId, info: info), .success)
 
     // Should be able to lock again
-    strategy.lock(id: boundaryId, info: info)
-    XCTAssertLockFailure(strategy.canLock(id: boundaryId, info: info))
+    strategy.lock(boundaryId: boundaryId, info: info)
+    XCTAssertLockFailure(strategy.canLock(boundaryId: boundaryId, info: info))
 
     strategy.cleanUp()
   }
@@ -383,17 +384,17 @@ final class LockmanEdgeCaseTests: XCTestCase {
     let priorityInfo = LockmanPriorityBasedInfo(actionId: "action", priority: .high(.exclusive))
 
     // Both strategies should be able to use the same boundary ID independently
-    singleStrategy.lock(id: boundaryId, info: singleInfo)
-    priorityStrategy.lock(id: boundaryId, info: priorityInfo)
+    singleStrategy.lock(boundaryId: boundaryId, info: singleInfo)
+    priorityStrategy.lock(boundaryId: boundaryId, info: priorityInfo)
 
     // Each should respect their own locks
-    XCTAssertLockFailure(singleStrategy.canLock(id: boundaryId, info: singleInfo))
-    XCTAssertLockFailure(priorityStrategy.canLock(id: boundaryId, info: priorityInfo))
+    XCTAssertLockFailure(singleStrategy.canLock(boundaryId: boundaryId, info: singleInfo))
+    XCTAssertLockFailure(priorityStrategy.canLock(boundaryId: boundaryId, info: priorityInfo))
 
     // Cleanup one shouldn't affect the other
-    singleStrategy.cleanUp(id: boundaryId)
-    XCTAssertEqual(singleStrategy.canLock(id: boundaryId, info: singleInfo), .success)
-    XCTAssertLockFailure(priorityStrategy.canLock(id: boundaryId, info: priorityInfo))
+    singleStrategy.cleanUp(boundaryId: boundaryId)
+    XCTAssertEqual(singleStrategy.canLock(boundaryId: boundaryId, info: singleInfo), .success)
+    XCTAssertLockFailure(priorityStrategy.canLock(boundaryId: boundaryId, info: priorityInfo))
 
     priorityStrategy.cleanUp()
   }
@@ -421,9 +422,9 @@ final class LockmanEdgeCaseTests: XCTestCase {
     let boundaryId = "persistence-test"
 
     // Use in multiple operations
-    strategy.lock(id: boundaryId, info: info)
-    strategy.unlock(id: boundaryId, info: info)
-    strategy.lock(id: boundaryId, info: info)
+    strategy.lock(boundaryId: boundaryId, info: info)
+    strategy.unlock(boundaryId: boundaryId, info: info)
+    strategy.lock(boundaryId: boundaryId, info: info)
 
     // Unique ID should remain the same
     XCTAssertEqual(info.uniqueId, originalUniqueId)

--- a/Tests/LockmanTests/Core/LockmanMainTests.swift
+++ b/Tests/LockmanTests/Core/LockmanMainTests.swift
@@ -309,14 +309,14 @@ final class LockmanMainTests: XCTestCase {
         let singleBoundary = TestBoundaryId("single")
         let singleInfo = LockmanSingleExecutionInfo(actionId: "test-action", mode: .boundary)
 
-        let canLockSingle = singleStrategy.canLock(id: singleBoundary, info: singleInfo)
+        let canLockSingle = singleStrategy.canLock(boundaryId: singleBoundary, info: singleInfo)
         XCTAssertEqual(canLockSingle, .success)
 
-        singleStrategy.lock(id: singleBoundary, info: singleInfo)
-        let canLockAgain = singleStrategy.canLock(id: singleBoundary, info: singleInfo)
+        singleStrategy.lock(boundaryId: singleBoundary, info: singleInfo)
+        let canLockAgain = singleStrategy.canLock(boundaryId: singleBoundary, info: singleInfo)
         XCTAssertLockFailure(canLockAgain)
 
-        singleStrategy.unlock(id: singleBoundary, info: singleInfo)
+        singleStrategy.unlock(boundaryId: singleBoundary, info: singleInfo)
 
         // 3. Test priority based strategy
         let priorityBoundary = TestBoundaryId("priority")
@@ -325,8 +325,9 @@ final class LockmanMainTests: XCTestCase {
         let lowPriorityInfo = LockmanPriorityBasedInfo(
           actionId: "low", priority: .low(.replaceable))
 
-        priorityStrategy.lock(id: priorityBoundary, info: lowPriorityInfo)
-        let canLockHigh = priorityStrategy.canLock(id: priorityBoundary, info: highPriorityInfo)
+        priorityStrategy.lock(boundaryId: priorityBoundary, info: lowPriorityInfo)
+        let canLockHigh = priorityStrategy.canLock(
+          boundaryId: priorityBoundary, info: highPriorityInfo)
         if case .successWithPrecedingCancellation = canLockHigh {
           // Success - precedingActionCancelled is expected
         } else {

--- a/Tests/LockmanTests/Core/LockmanStateActionIndexTests.swift
+++ b/Tests/LockmanTests/Core/LockmanStateActionIndexTests.swift
@@ -33,11 +33,11 @@ final class LockmanStateActionIndexTests: XCTestCase {
     var strategyId: LockmanStrategyId { LockmanStrategyId(type: Self.self) }
     static func makeStrategyId() -> LockmanStrategyId { LockmanStrategyId(type: self) }
 
-    func canLock<B: LockmanBoundaryId>(id: B, info: TestInfo) -> LockmanResult { .success }
-    func lock<B: LockmanBoundaryId>(id: B, info: TestInfo) {}
-    func unlock<B: LockmanBoundaryId>(id: B, info: TestInfo) {}
+    func canLock<B: LockmanBoundaryId>(boundaryId: B, info: TestInfo) -> LockmanResult { .success }
+    func lock<B: LockmanBoundaryId>(boundaryId: B, info: TestInfo) {}
+    func unlock<B: LockmanBoundaryId>(boundaryId: B, info: TestInfo) {}
     func cleanUp() {}
-    func cleanUp<B: LockmanBoundaryId>(id: B) {}
+    func cleanUp<B: LockmanBoundaryId>(boundaryId: B) {}
     func getCurrentLocks() -> [AnyLockmanBoundaryId: [any LockmanInfo]] { [:] }
   }
 

--- a/Tests/LockmanTests/Core/LockmanUnlockTests.swift
+++ b/Tests/LockmanTests/Core/LockmanUnlockTests.swift
@@ -62,27 +62,27 @@ private final class MockLockmanStrategy: LockmanStrategy, @unchecked Sendable {
   }
 
   func canLock<B: LockmanBoundaryId>(
-    id _: B,
+    boundaryId _: B,
     info _: TestLockmanInfo
   ) -> LockmanResult {
     .success
   }
 
   func lock<B: LockmanBoundaryId>(
-    id _: B,
+    boundaryId _: B,
     info _: TestLockmanInfo
   ) {}
 
-  func unlock<B: LockmanBoundaryId>(id: B, info: TestLockmanInfo) {
+  func unlock<B: LockmanBoundaryId>(boundaryId: B, info: TestLockmanInfo) {
     unlockQueue.sync {
-      unlockCalls.append((boundaryId: id, info: info))
+      unlockCalls.append((boundaryId: boundaryId, info: info))
       unlockCallCount += 1
     }
   }
 
   func cleanUp() {}
 
-  func cleanUp<B: LockmanBoundaryId>(id _: B) {}
+  func cleanUp<B: LockmanBoundaryId>(boundaryId _: B) {}
 
   func getCurrentLocks() -> [AnyLockmanBoundaryId: [any LockmanInfo]] {
     [:]

--- a/Tests/LockmanTests/Core/Strategies/CompositeStrategy/LockmanCompositeActionTests.swift
+++ b/Tests/LockmanTests/Core/Strategies/CompositeStrategy/LockmanCompositeActionTests.swift
@@ -156,11 +156,11 @@ final class LockmanCompositeActionTests: XCTestCase {
     let boundaryId = "test-boundary"
     let info = action.lockmanInfo
 
-    XCTAssertEqual(compositeStrategy.canLock(id: boundaryId, info: info), .success)
-    compositeStrategy.lock(id: boundaryId, info: info)
-    XCTAssertLockFailure(compositeStrategy.canLock(id: boundaryId, info: info))
-    compositeStrategy.unlock(id: boundaryId, info: info)
-    XCTAssertEqual(compositeStrategy.canLock(id: boundaryId, info: info), .success)
+    XCTAssertEqual(compositeStrategy.canLock(boundaryId: boundaryId, info: info), .success)
+    compositeStrategy.lock(boundaryId: boundaryId, info: info)
+    XCTAssertLockFailure(compositeStrategy.canLock(boundaryId: boundaryId, info: info))
+    compositeStrategy.unlock(boundaryId: boundaryId, info: info)
+    XCTAssertEqual(compositeStrategy.canLock(boundaryId: boundaryId, info: info), .success)
   }
 
   // MARK: - CompositeAction3 Tests
@@ -202,8 +202,8 @@ final class LockmanCompositeActionTests: XCTestCase {
     let boundaryId = "test-boundary"
     let info = action.lockmanInfo
 
-    XCTAssertEqual(compositeStrategy.canLock(id: boundaryId, info: info), .success)
-    compositeStrategy.lock(id: boundaryId, info: info)
+    XCTAssertEqual(compositeStrategy.canLock(boundaryId: boundaryId, info: info), .success)
+    compositeStrategy.lock(boundaryId: boundaryId, info: info)
     compositeStrategy.cleanUp()
   }
 
@@ -245,7 +245,7 @@ final class LockmanCompositeActionTests: XCTestCase {
     let boundaryId = "test-boundary"
     let info = action.lockmanInfo
 
-    XCTAssertEqual(compositeStrategy.canLock(id: boundaryId, info: info), .success)
+    XCTAssertEqual(compositeStrategy.canLock(boundaryId: boundaryId, info: info), .success)
   }
 
   // MARK: - CompositeAction5 Tests
@@ -289,11 +289,11 @@ final class LockmanCompositeActionTests: XCTestCase {
     let boundaryId = "test-boundary"
     let info = action.lockmanInfo
 
-    let result = compositeStrategy.canLock(id: boundaryId, info: info)
+    let result = compositeStrategy.canLock(boundaryId: boundaryId, info: info)
     XCTAssertEqual(result, .success)
 
     // Cleanup
-    compositeStrategy.cleanUp(id: boundaryId)
+    compositeStrategy.cleanUp(boundaryId: boundaryId)
   }
 
   // MARK: - LockmanAction Protocol Tests

--- a/Tests/LockmanTests/Core/Strategies/CompositeStrategy/LockmanCompositeBasicTests.swift
+++ b/Tests/LockmanTests/Core/Strategies/CompositeStrategy/LockmanCompositeBasicTests.swift
@@ -18,11 +18,11 @@ final class LockmanCompositeBasicTests: XCTestCase {
     )
 
     // Test basic lock workflow
-    XCTAssertEqual(composite.canLock(id: boundaryId, info: info), .success)
-    composite.lock(id: boundaryId, info: info)
-    XCTAssertLockFailure(composite.canLock(id: boundaryId, info: info))
-    composite.unlock(id: boundaryId, info: info)
-    XCTAssertEqual(composite.canLock(id: boundaryId, info: info), .success)
+    XCTAssertEqual(composite.canLock(boundaryId: boundaryId, info: info), .success)
+    composite.lock(boundaryId: boundaryId, info: info)
+    XCTAssertLockFailure(composite.canLock(boundaryId: boundaryId, info: info))
+    composite.unlock(boundaryId: boundaryId, info: info)
+    XCTAssertEqual(composite.canLock(boundaryId: boundaryId, info: info), .success)
 
     // Cleanup
     composite.cleanUp()
@@ -48,11 +48,11 @@ final class LockmanCompositeBasicTests: XCTestCase {
     )
 
     // Test basic lock workflow
-    XCTAssertEqual(composite.canLock(id: boundaryId, info: info), .success)
-    composite.lock(id: boundaryId, info: info)
-    XCTAssertLockFailure(composite.canLock(id: boundaryId, info: info))
-    composite.unlock(id: boundaryId, info: info)
-    XCTAssertEqual(composite.canLock(id: boundaryId, info: info), .success)
+    XCTAssertEqual(composite.canLock(boundaryId: boundaryId, info: info), .success)
+    composite.lock(boundaryId: boundaryId, info: info)
+    XCTAssertLockFailure(composite.canLock(boundaryId: boundaryId, info: info))
+    composite.unlock(boundaryId: boundaryId, info: info)
+    XCTAssertEqual(composite.canLock(boundaryId: boundaryId, info: info), .success)
 
     // Cleanup
     composite.cleanUp()
@@ -129,17 +129,17 @@ final class LockmanCompositeBasicTests: XCTestCase {
     )
 
     // Lock and verify it's active
-    composite.lock(id: boundaryId, info: info)
-    XCTAssertLockFailure(composite.canLock(id: boundaryId, info: info))
+    composite.lock(boundaryId: boundaryId, info: info)
+    XCTAssertLockFailure(composite.canLock(boundaryId: boundaryId, info: info))
 
     // Global cleanup
     composite.cleanUp()
-    XCTAssertEqual(composite.canLock(id: boundaryId, info: info), .success)
+    XCTAssertEqual(composite.canLock(boundaryId: boundaryId, info: info), .success)
 
     // Test boundary-specific cleanup
-    composite.lock(id: boundaryId, info: info)
-    composite.cleanUp(id: boundaryId)
-    XCTAssertEqual(composite.canLock(id: boundaryId, info: info), .success)
+    composite.lock(boundaryId: boundaryId, info: info)
+    composite.cleanUp(boundaryId: boundaryId)
+    XCTAssertEqual(composite.canLock(boundaryId: boundaryId, info: info), .success)
   }
 
   func testcoordinationLogicTesting() {
@@ -152,7 +152,7 @@ final class LockmanCompositeBasicTests: XCTestCase {
     // Setup a lower priority lock
     let lowPriorityInfo1 = LockmanPriorityBasedInfo(
       actionId: "low-action", priority: .low(.exclusive))
-    priority.lock(id: boundaryId, info: lowPriorityInfo1)
+    priority.lock(boundaryId: boundaryId, info: lowPriorityInfo1)
 
     // Create composite info that should trigger cancellation
     let info = LockmanCompositeInfo2(
@@ -162,7 +162,7 @@ final class LockmanCompositeBasicTests: XCTestCase {
       lockmanInfoForStrategy2: LockmanSingleExecutionInfo(actionId: "test-action", mode: .boundary)
     )
 
-    let result = composite.canLock(id: boundaryId, info: info)
+    let result = composite.canLock(boundaryId: boundaryId, info: info)
     if case .successWithPrecedingCancellation = result {
       // Success - precedingActionCancelled is expected
     } else {
@@ -170,7 +170,7 @@ final class LockmanCompositeBasicTests: XCTestCase {
     }
 
     // Cleanup
-    priority.cleanUp(id: boundaryId)
-    single.cleanUp(id: boundaryId)
+    priority.cleanUp(boundaryId: boundaryId)
+    single.cleanUp(boundaryId: boundaryId)
   }
 }

--- a/Tests/LockmanTests/Core/Strategies/ConcurrencyLimitedStrategy/LockmanConcurrencyLimitedActionTests.swift
+++ b/Tests/LockmanTests/Core/Strategies/ConcurrencyLimitedStrategy/LockmanConcurrencyLimitedActionTests.swift
@@ -138,11 +138,11 @@ final class LockmanConcurrencyLimitedActionTests: XCTestCase {
     let info = action.lockmanInfo
 
     // First lock should succeed
-    let result = strategy.canLock(id: boundary, info: info)
+    let result = strategy.canLock(boundaryId: boundary, info: info)
     XCTAssertEqual(result, .success)
 
     // Clean up
-    strategy.cleanUp(id: boundary)
+    strategy.cleanUp(boundaryId: boundary)
   }
 
   func testMultipleActionsRespectConcurrencyLimits() {
@@ -153,14 +153,14 @@ final class LockmanConcurrencyLimitedActionTests: XCTestCase {
     let action1 = TestAction.processData
     let action2 = TestAction.processData
 
-    strategy.lock(id: boundary, info: action1.lockmanInfo)
+    strategy.lock(boundaryId: boundary, info: action1.lockmanInfo)
 
     // Second should fail
-    let result = strategy.canLock(id: boundary, info: action2.lockmanInfo)
+    let result = strategy.canLock(boundaryId: boundary, info: action2.lockmanInfo)
     XCTAssertLockFailure(result)
 
     // Clean up
-    strategy.cleanUp(id: boundary)
+    strategy.cleanUp(boundaryId: boundary)
   }
 
   // MARK: - Type Safety Tests
@@ -211,12 +211,12 @@ extension LockmanConcurrencyLimitedActionTests {
     // Lock many unlimited actions
     for i in 0..<100 {
       let action = i % 2 == 0 ? UnlimitedTestAction.refreshUI : UnlimitedTestAction.updateCache
-      let result = strategy.canLock(id: boundary, info: action.lockmanInfo)
+      let result = strategy.canLock(boundaryId: boundary, info: action.lockmanInfo)
       XCTAssertEqual(result, .success)
-      strategy.lock(id: boundary, info: action.lockmanInfo)
+      strategy.lock(boundaryId: boundary, info: action.lockmanInfo)
     }
 
     // Clean up
-    strategy.cleanUp(id: boundary)
+    strategy.cleanUp(boundaryId: boundary)
   }
 }

--- a/Tests/LockmanTests/Core/Strategies/ConcurrencyLimitedStrategy/LockmanConcurrencyLimitedStrategyTests.swift
+++ b/Tests/LockmanTests/Core/Strategies/ConcurrencyLimitedStrategy/LockmanConcurrencyLimitedStrategyTests.swift
@@ -77,10 +77,10 @@ final class LockmanConcurrencyLimitedStrategyTests: XCTestCase {
     let info = LockmanConcurrencyLimitedInfo(
       actionId: "action", group: TestConcurrencyGroup.apiRequests)
 
-    let result = strategy.canLock(id: boundary, info: info)
+    let result = strategy.canLock(boundaryId: boundary, info: info)
     XCTAssertEqual(result, .success)
 
-    strategy.cleanUp(id: boundary)
+    strategy.cleanUp(boundaryId: boundary)
   }
 
   func testMultipleLocksWithinLimitSucceed() {
@@ -96,16 +96,16 @@ final class LockmanConcurrencyLimitedStrategyTests: XCTestCase {
       actionId: "action3", group: TestConcurrencyGroup.apiRequests)
 
     // All three should succeed
-    XCTAssertEqual(strategy.canLock(id: boundary, info: info1), .success)
-    strategy.lock(id: boundary, info: info1)
+    XCTAssertEqual(strategy.canLock(boundaryId: boundary, info: info1), .success)
+    strategy.lock(boundaryId: boundary, info: info1)
 
-    XCTAssertEqual(strategy.canLock(id: boundary, info: info2), .success)
-    strategy.lock(id: boundary, info: info2)
+    XCTAssertEqual(strategy.canLock(boundaryId: boundary, info: info2), .success)
+    strategy.lock(boundaryId: boundary, info: info2)
 
-    XCTAssertEqual(strategy.canLock(id: boundary, info: info3), .success)
-    strategy.lock(id: boundary, info: info3)
+    XCTAssertEqual(strategy.canLock(boundaryId: boundary, info: info3), .success)
+    strategy.lock(boundaryId: boundary, info: info3)
 
-    strategy.cleanUp(id: boundary)
+    strategy.cleanUp(boundaryId: boundary)
   }
 
   func testLockFailsWhenLimitExceeded() {
@@ -121,14 +121,14 @@ final class LockmanConcurrencyLimitedStrategyTests: XCTestCase {
       actionId: "upload3", group: TestConcurrencyGroup.fileOperations)
 
     // First two should succeed
-    XCTAssertEqual(strategy.canLock(id: boundary, info: info1), .success)
-    strategy.lock(id: boundary, info: info1)
+    XCTAssertEqual(strategy.canLock(boundaryId: boundary, info: info1), .success)
+    strategy.lock(boundaryId: boundary, info: info1)
 
-    XCTAssertEqual(strategy.canLock(id: boundary, info: info2), .success)
-    strategy.lock(id: boundary, info: info2)
+    XCTAssertEqual(strategy.canLock(boundaryId: boundary, info: info2), .success)
+    strategy.lock(boundaryId: boundary, info: info2)
 
     // Third should fail
-    let result = strategy.canLock(id: boundary, info: info3)
+    let result = strategy.canLock(boundaryId: boundary, info: info3)
     XCTAssertLockFailure(result)
 
     if case .failure(let error) = result,
@@ -147,7 +147,7 @@ final class LockmanConcurrencyLimitedStrategyTests: XCTestCase {
       XCTFail("Expected LockmanConcurrencyLimitedError")
     }
 
-    strategy.cleanUp(id: boundary)
+    strategy.cleanUp(boundaryId: boundary)
   }
 
   func testUnlimitedGroupAllowsManyLocks() {
@@ -158,11 +158,11 @@ final class LockmanConcurrencyLimitedStrategyTests: XCTestCase {
     for i in 0..<100 {
       let info = LockmanConcurrencyLimitedInfo(
         actionId: "ui\(i)", group: TestConcurrencyGroup.uiUpdates)
-      XCTAssertEqual(strategy.canLock(id: boundary, info: info), .success)
-      strategy.lock(id: boundary, info: info)
+      XCTAssertEqual(strategy.canLock(boundaryId: boundary, info: info), .success)
+      strategy.lock(boundaryId: boundary, info: info)
     }
 
-    strategy.cleanUp(id: boundary)
+    strategy.cleanUp(boundaryId: boundary)
   }
 
   // MARK: - Direct Limit Tests
@@ -175,13 +175,13 @@ final class LockmanConcurrencyLimitedStrategyTests: XCTestCase {
     let info2 = LockmanConcurrencyLimitedInfo(actionId: "special1", .limited(1))
 
     // First should succeed
-    XCTAssertEqual(strategy.canLock(id: boundary, info: info1), .success)
-    strategy.lock(id: boundary, info: info1)
+    XCTAssertEqual(strategy.canLock(boundaryId: boundary, info: info1), .success)
+    strategy.lock(boundaryId: boundary, info: info1)
 
     // Second with same actionId should fail (limit is 1)
-    XCTAssertLockFailure(strategy.canLock(id: boundary, info: info2))
+    XCTAssertLockFailure(strategy.canLock(boundaryId: boundary, info: info2))
 
-    strategy.cleanUp(id: boundary)
+    strategy.cleanUp(boundaryId: boundary)
   }
 
   func testDirectUnlimitedConfiguration() {
@@ -191,11 +191,11 @@ final class LockmanConcurrencyLimitedStrategyTests: XCTestCase {
     // Multiple locks with same actionId and unlimited
     for _ in 0..<50 {
       let info = LockmanConcurrencyLimitedInfo(actionId: "unlimited-action", .unlimited)
-      XCTAssertEqual(strategy.canLock(id: boundary, info: info), .success)
-      strategy.lock(id: boundary, info: info)
+      XCTAssertEqual(strategy.canLock(boundaryId: boundary, info: info), .success)
+      strategy.lock(boundaryId: boundary, info: info)
     }
 
-    strategy.cleanUp(id: boundary)
+    strategy.cleanUp(boundaryId: boundary)
   }
 
   // MARK: - Cross-Boundary Tests
@@ -214,17 +214,17 @@ final class LockmanConcurrencyLimitedStrategyTests: XCTestCase {
       actionId: "upload3", group: TestConcurrencyGroup.fileOperations)
 
     // Fill boundary1 to limit
-    strategy.lock(id: boundary1, info: info1)
-    strategy.lock(id: boundary1, info: info2)
-    XCTAssertLockFailure(strategy.canLock(id: boundary1, info: info3))
+    strategy.lock(boundaryId: boundary1, info: info1)
+    strategy.lock(boundaryId: boundary1, info: info2)
+    XCTAssertLockFailure(strategy.canLock(boundaryId: boundary1, info: info3))
 
     // boundary2 should still allow locks
-    XCTAssertEqual(strategy.canLock(id: boundary2, info: info1), .success)
-    strategy.lock(id: boundary2, info: info1)
-    XCTAssertEqual(strategy.canLock(id: boundary2, info: info2), .success)
+    XCTAssertEqual(strategy.canLock(boundaryId: boundary2, info: info1), .success)
+    strategy.lock(boundaryId: boundary2, info: info1)
+    XCTAssertEqual(strategy.canLock(boundaryId: boundary2, info: info2), .success)
 
-    strategy.cleanUp(id: boundary1)
-    strategy.cleanUp(id: boundary2)
+    strategy.cleanUp(boundaryId: boundary1)
+    strategy.cleanUp(boundaryId: boundary2)
   }
 
   // MARK: - Unlock Behavior Tests
@@ -242,17 +242,17 @@ final class LockmanConcurrencyLimitedStrategyTests: XCTestCase {
       actionId: "upload3", group: TestConcurrencyGroup.fileOperations)
 
     // Fill to limit
-    strategy.lock(id: boundary, info: info1)
-    strategy.lock(id: boundary, info: info2)
-    XCTAssertLockFailure(strategy.canLock(id: boundary, info: info3))
+    strategy.lock(boundaryId: boundary, info: info1)
+    strategy.lock(boundaryId: boundary, info: info2)
+    XCTAssertLockFailure(strategy.canLock(boundaryId: boundary, info: info3))
 
     // Unlock one
-    strategy.unlock(id: boundary, info: info1)
+    strategy.unlock(boundaryId: boundary, info: info1)
 
     // Now third should succeed
-    XCTAssertEqual(strategy.canLock(id: boundary, info: info3), .success)
+    XCTAssertEqual(strategy.canLock(boundaryId: boundary, info: info3), .success)
 
-    strategy.cleanUp(id: boundary)
+    strategy.cleanUp(boundaryId: boundary)
   }
 
   // MARK: - CleanUp Tests
@@ -267,15 +267,15 @@ final class LockmanConcurrencyLimitedStrategyTests: XCTestCase {
     let info2 = LockmanConcurrencyLimitedInfo(
       actionId: "action2", group: TestConcurrencyGroup.apiRequests)
 
-    strategy.lock(id: boundary, info: info1)
-    strategy.lock(id: boundary, info: info2)
+    strategy.lock(boundaryId: boundary, info: info1)
+    strategy.lock(boundaryId: boundary, info: info2)
 
     // Clean up
-    strategy.cleanUp(id: boundary)
+    strategy.cleanUp(boundaryId: boundary)
 
     // Should be able to lock again
-    XCTAssertEqual(strategy.canLock(id: boundary, info: info1), .success)
-    XCTAssertEqual(strategy.canLock(id: boundary, info: info2), .success)
+    XCTAssertEqual(strategy.canLock(boundaryId: boundary, info: info1), .success)
+    XCTAssertEqual(strategy.canLock(boundaryId: boundary, info: info2), .success)
   }
 
   // MARK: - GetCurrentLocks Tests
@@ -289,8 +289,8 @@ final class LockmanConcurrencyLimitedStrategyTests: XCTestCase {
     let info2 = LockmanConcurrencyLimitedInfo(
       actionId: "action2", group: TestConcurrencyGroup.fileOperations)
 
-    strategy.lock(id: boundary, info: info1)
-    strategy.lock(id: boundary, info: info2)
+    strategy.lock(boundaryId: boundary, info: info1)
+    strategy.lock(boundaryId: boundary, info: info2)
 
     let allLocks = strategy.getCurrentLocks()
     let locks = allLocks[AnyLockmanBoundaryId(boundary)] ?? []
@@ -299,6 +299,6 @@ final class LockmanConcurrencyLimitedStrategyTests: XCTestCase {
     let actionIds = locks.compactMap { ($0 as? LockmanConcurrencyLimitedInfo)?.actionId }.sorted()
     XCTAssertEqual(actionIds, ["action1", "action2"])
 
-    strategy.cleanUp(id: boundary)
+    strategy.cleanUp(boundaryId: boundary)
   }
 }

--- a/Tests/LockmanTests/Core/Strategies/Core/LockmanStrategyContainerTests.swift
+++ b/Tests/LockmanTests/Core/Strategies/Core/LockmanStrategyContainerTests.swift
@@ -56,17 +56,17 @@ private class MockLockmanStrategy: LockmanStrategy, @unchecked Sendable {
     self.identifier = identifier
   }
 
-  func canLock<B: LockmanBoundaryId>(id _: B, info _: MockLockmanInfo) -> LockmanResult {
+  func canLock<B: LockmanBoundaryId>(boundaryId _: B, info _: MockLockmanInfo) -> LockmanResult {
     .success
   }
 
-  func lock<B: LockmanBoundaryId>(id: B, info: MockLockmanInfo) {
-    let anyId = AnyLockmanBoundaryId(id)
+  func lock<B: LockmanBoundaryId>(boundaryId: B, info: MockLockmanInfo) {
+    let anyId = AnyLockmanBoundaryId(boundaryId)
     lockState[anyId, default: []].append(info)
   }
 
-  func unlock<B: LockmanBoundaryId>(id: B, info _: MockLockmanInfo) {
-    let anyId = AnyLockmanBoundaryId(id)
+  func unlock<B: LockmanBoundaryId>(boundaryId: B, info _: MockLockmanInfo) {
+    let anyId = AnyLockmanBoundaryId(boundaryId)
     lockState[anyId]?.removeLast()
     if lockState[anyId]?.isEmpty == true {
       lockState.removeValue(forKey: anyId)
@@ -78,10 +78,10 @@ private class MockLockmanStrategy: LockmanStrategy, @unchecked Sendable {
     lockState.removeAll()
   }
 
-  func cleanUp<B: LockmanBoundaryId>(id: B) {
+  func cleanUp<B: LockmanBoundaryId>(boundaryId: B) {
     cleanUpWithIdCallCount += 1
-    lastCleanUpId = id
-    let anyId = AnyLockmanBoundaryId(id)
+    lastCleanUpId = boundaryId
+    let anyId = AnyLockmanBoundaryId(boundaryId)
     lockState.removeValue(forKey: anyId)
   }
 
@@ -127,17 +127,19 @@ private final class AnotherMockLockmanStrategy: LockmanStrategy, @unchecked Send
     self.identifier = identifier
   }
 
-  func canLock<B: LockmanBoundaryId>(id _: B, info _: AnotherMockLockmanInfo) -> LockmanResult {
+  func canLock<B: LockmanBoundaryId>(boundaryId _: B, info _: AnotherMockLockmanInfo)
+    -> LockmanResult
+  {
     .success
   }
 
-  func lock<B: LockmanBoundaryId>(id: B, info: AnotherMockLockmanInfo) {
-    let anyId = AnyLockmanBoundaryId(id)
+  func lock<B: LockmanBoundaryId>(boundaryId: B, info: AnotherMockLockmanInfo) {
+    let anyId = AnyLockmanBoundaryId(boundaryId)
     lockState[anyId, default: []].append(info)
   }
 
-  func unlock<B: LockmanBoundaryId>(id: B, info _: AnotherMockLockmanInfo) {
-    let anyId = AnyLockmanBoundaryId(id)
+  func unlock<B: LockmanBoundaryId>(boundaryId: B, info _: AnotherMockLockmanInfo) {
+    let anyId = AnyLockmanBoundaryId(boundaryId)
     lockState[anyId]?.removeLast()
     if lockState[anyId]?.isEmpty == true {
       lockState.removeValue(forKey: anyId)
@@ -149,10 +151,10 @@ private final class AnotherMockLockmanStrategy: LockmanStrategy, @unchecked Send
     lockState.removeAll()
   }
 
-  func cleanUp<B: LockmanBoundaryId>(id: B) {
+  func cleanUp<B: LockmanBoundaryId>(boundaryId: B) {
     cleanUpWithIdCallCount += 1
-    lastCleanUpId = id
-    let anyId = AnyLockmanBoundaryId(id)
+    lastCleanUpId = boundaryId
+    let anyId = AnyLockmanBoundaryId(boundaryId)
     lockState.removeValue(forKey: anyId)
   }
 
@@ -298,7 +300,7 @@ final class LockmanStrategyContainerTests: XCTestCase {
     try? container.register(mockStrategy)
     try? container.register(anotherStrategy)
 
-    container.cleanUp(id: boundaryId)
+    container.cleanUp(boundaryId: boundaryId)
 
     XCTAssertEqual(mockStrategy.cleanUpWithIdCallCount, 1)
     XCTAssertEqual(anotherStrategy.cleanUpWithIdCallCount, 1)
@@ -311,7 +313,7 @@ final class LockmanStrategyContainerTests: XCTestCase {
 
     // Should not crash
     container.cleanUp()
-    container.cleanUp(id: MockBoundaryId(value: "test"))
+    container.cleanUp(boundaryId: MockBoundaryId(value: "test"))
   }
 
   // MARK: - Type Safety Tests
@@ -470,7 +472,7 @@ final class LockmanStrategyContainerTests: XCTestCase {
 
       for i in 0..<10 {
         group.addTask {
-          container.cleanUp(id: MockBoundaryId(value: "\(i)"))
+          container.cleanUp(boundaryId: MockBoundaryId(value: "\(i)"))
         }
       }
     }

--- a/Tests/LockmanTests/Core/Strategies/Core/StrategyContainerErrorTests.swift
+++ b/Tests/LockmanTests/Core/Strategies/Core/StrategyContainerErrorTests.swift
@@ -11,12 +11,13 @@ final class StrategyContainerErrorTests: XCTestCase {
     typealias I = LockmanSingleExecutionInfo
     var strategyId: LockmanStrategyId { LockmanStrategyId(type: Self.self) }
     static func makeStrategyId() -> LockmanStrategyId { LockmanStrategyId(type: Self.self) }
-    func canLock<B: LockmanBoundaryId>(id _: B, info _: LockmanSingleExecutionInfo) -> LockmanResult
+    func canLock<B: LockmanBoundaryId>(boundaryId _: B, info _: LockmanSingleExecutionInfo)
+      -> LockmanResult
     { .success }
-    func lock<B: LockmanBoundaryId>(id _: B, info _: LockmanSingleExecutionInfo) {}
-    func unlock<B: LockmanBoundaryId>(id _: B, info _: LockmanSingleExecutionInfo) {}
+    func lock<B: LockmanBoundaryId>(boundaryId _: B, info _: LockmanSingleExecutionInfo) {}
+    func unlock<B: LockmanBoundaryId>(boundaryId _: B, info _: LockmanSingleExecutionInfo) {}
     func cleanUp() {}
-    func cleanUp<B: LockmanBoundaryId>(id _: B) {}
+    func cleanUp<B: LockmanBoundaryId>(boundaryId _: B) {}
     func getCurrentLocks() -> [AnyLockmanBoundaryId: [any LockmanInfo]] { [:] }
   }
 
@@ -24,13 +25,15 @@ final class StrategyContainerErrorTests: XCTestCase {
     typealias I = LockmanPriorityBasedInfo
     var strategyId: LockmanStrategyId { LockmanStrategyId(type: Self.self) }
     static func makeStrategyId() -> LockmanStrategyId { LockmanStrategyId(type: Self.self) }
-    func canLock<B: LockmanBoundaryId>(id _: B, info _: LockmanPriorityBasedInfo) -> LockmanResult {
+    func canLock<B: LockmanBoundaryId>(boundaryId _: B, info _: LockmanPriorityBasedInfo)
+      -> LockmanResult
+    {
       .success
     }
-    func lock<B: LockmanBoundaryId>(id _: B, info _: LockmanPriorityBasedInfo) {}
-    func unlock<B: LockmanBoundaryId>(id _: B, info _: LockmanPriorityBasedInfo) {}
+    func lock<B: LockmanBoundaryId>(boundaryId _: B, info _: LockmanPriorityBasedInfo) {}
+    func unlock<B: LockmanBoundaryId>(boundaryId _: B, info _: LockmanPriorityBasedInfo) {}
     func cleanUp() {}
-    func cleanUp<B: LockmanBoundaryId>(id _: B) {}
+    func cleanUp<B: LockmanBoundaryId>(boundaryId _: B) {}
     func getCurrentLocks() -> [AnyLockmanBoundaryId: [any LockmanInfo]] { [:] }
   }
 
@@ -38,12 +41,13 @@ final class StrategyContainerErrorTests: XCTestCase {
     typealias I = LockmanSingleExecutionInfo
     var strategyId: LockmanStrategyId { LockmanStrategyId(type: Self.self) }
     static func makeStrategyId() -> LockmanStrategyId { LockmanStrategyId(type: Self.self) }
-    func canLock<B: LockmanBoundaryId>(id _: B, info _: LockmanSingleExecutionInfo) -> LockmanResult
+    func canLock<B: LockmanBoundaryId>(boundaryId _: B, info _: LockmanSingleExecutionInfo)
+      -> LockmanResult
     { .success }
-    func lock<B: LockmanBoundaryId>(id _: B, info _: LockmanSingleExecutionInfo) {}
-    func unlock<B: LockmanBoundaryId>(id _: B, info _: LockmanSingleExecutionInfo) {}
+    func lock<B: LockmanBoundaryId>(boundaryId _: B, info _: LockmanSingleExecutionInfo) {}
+    func unlock<B: LockmanBoundaryId>(boundaryId _: B, info _: LockmanSingleExecutionInfo) {}
     func cleanUp() {}
-    func cleanUp<B: LockmanBoundaryId>(id _: B) {}
+    func cleanUp<B: LockmanBoundaryId>(boundaryId _: B) {}
     func getCurrentLocks() -> [AnyLockmanBoundaryId: [any LockmanInfo]] { [:] }
   }
 
@@ -471,6 +475,6 @@ final class StrategyContainerErrorTests: XCTestCase {
 
     // Cleanup should not crash
     container.cleanUp()
-    container.cleanUp(id: "test-boundary")
+    container.cleanUp(boundaryId: "test-boundary")
   }
 }

--- a/Tests/LockmanTests/Core/Strategies/DynamicConditionStrategy/LockmanDynamicConditionStrategyTests.swift
+++ b/Tests/LockmanTests/Core/Strategies/DynamicConditionStrategy/LockmanDynamicConditionStrategyTests.swift
@@ -71,12 +71,12 @@ final class LockmanDynamicConditionStrategyTests: XCTestCase {
       actionId: "test"
     )
 
-    XCTAssertEqual(strategy.canLock(id: boundary, info: info), .success)
+    XCTAssertEqual(strategy.canLock(boundaryId: boundary, info: info), .success)
 
     // Add multiple locks - should still succeed
-    strategy.lock(id: boundary, info: info)
+    strategy.lock(boundaryId: boundary, info: info)
     let info2 = LockmanDynamicConditionInfo(actionId: "test2")
-    XCTAssertEqual(strategy.canLock(id: boundary, info: info2), .success)
+    XCTAssertEqual(strategy.canLock(boundaryId: boundary, info: info2), .success)
   }
 
   func testcustomConditionIsEvaluated() {
@@ -98,8 +98,8 @@ final class LockmanDynamicConditionStrategyTests: XCTestCase {
     )
 
     // First lock succeeds
-    XCTAssertEqual(strategy.canLock(id: boundary, info: info1), .success)
-    strategy.lock(id: boundary, info: info1)
+    XCTAssertEqual(strategy.canLock(boundaryId: boundary, info: info1), .success)
+    strategy.lock(boundaryId: boundary, info: info1)
     currentCount.value += 1
 
     // Second lock succeeds
@@ -113,8 +113,8 @@ final class LockmanDynamicConditionStrategyTests: XCTestCase {
               actionId: "fetch", hint: "Count limit exceeded"))
       }
     )
-    XCTAssertEqual(strategy.canLock(id: boundary, info: info2), .success)
-    strategy.lock(id: boundary, info: info2)
+    XCTAssertEqual(strategy.canLock(boundaryId: boundary, info: info2), .success)
+    strategy.lock(boundaryId: boundary, info: info2)
     currentCount.value += 1
 
     // Third lock fails
@@ -128,7 +128,7 @@ final class LockmanDynamicConditionStrategyTests: XCTestCase {
               actionId: "fetch", hint: "Count limit exceeded"))
       }
     )
-    XCTAssertLockFailure(strategy.canLock(id: boundary, info: info3))
+    XCTAssertLockFailure(strategy.canLock(boundaryId: boundary, info: info3))
   }
 
   // MARK: - Business Logic Tests
@@ -150,7 +150,7 @@ final class LockmanDynamicConditionStrategyTests: XCTestCase {
       }
     )
 
-    XCTAssertEqual(strategy.canLock(id: boundary, info: highPriorityInfo), .success)
+    XCTAssertEqual(strategy.canLock(boundaryId: boundary, info: highPriorityInfo), .success)
 
     // Low priority action
     let lowPriority = 3
@@ -165,7 +165,7 @@ final class LockmanDynamicConditionStrategyTests: XCTestCase {
       }
     )
 
-    XCTAssertLockFailure(strategy.canLock(id: boundary, info: lowPriorityInfo))
+    XCTAssertLockFailure(strategy.canLock(boundaryId: boundary, info: lowPriorityInfo))
   }
 
   func testtimeBasedCondition() {
@@ -186,7 +186,7 @@ final class LockmanDynamicConditionStrategyTests: XCTestCase {
       }
     )
 
-    XCTAssertEqual(strategy.canLock(id: boundary, info: info), .success)
+    XCTAssertEqual(strategy.canLock(boundaryId: boundary, info: info), .success)
 
     // After hours
     let afterHour = 20  // 8 PM
@@ -201,7 +201,7 @@ final class LockmanDynamicConditionStrategyTests: XCTestCase {
       }
     )
 
-    XCTAssertLockFailure(strategy.canLock(id: boundary, info: afterHoursInfo))
+    XCTAssertLockFailure(strategy.canLock(boundaryId: boundary, info: afterHoursInfo))
   }
 
   // MARK: - Lock/Unlock Tests
@@ -224,8 +224,8 @@ final class LockmanDynamicConditionStrategyTests: XCTestCase {
     )
 
     // First lock should succeed
-    XCTAssertEqual(strategy.canLock(id: boundary, info: info), .success)
-    strategy.lock(id: boundary, info: info)
+    XCTAssertEqual(strategy.canLock(boundaryId: boundary, info: info), .success)
+    strategy.lock(boundaryId: boundary, info: info)
     isLocked.value = true
 
     // Second lock should fail
@@ -239,10 +239,10 @@ final class LockmanDynamicConditionStrategyTests: XCTestCase {
               actionId: "exclusive", hint: "Already locked"))
       }
     )
-    XCTAssertLockFailure(strategy.canLock(id: boundary, info: info2))
+    XCTAssertLockFailure(strategy.canLock(boundaryId: boundary, info: info2))
 
     // Unlock
-    strategy.unlock(id: boundary, info: info)
+    strategy.unlock(boundaryId: boundary, info: info)
     isLocked.value = false
 
     // Now should succeed again
@@ -256,7 +256,7 @@ final class LockmanDynamicConditionStrategyTests: XCTestCase {
               actionId: "exclusive", hint: "Already locked"))
       }
     )
-    XCTAssertEqual(strategy.canLock(id: boundary, info: info3), .success)
+    XCTAssertEqual(strategy.canLock(boundaryId: boundary, info: info3), .success)
   }
 
   // MARK: - Unlock Tests
@@ -267,8 +267,8 @@ final class LockmanDynamicConditionStrategyTests: XCTestCase {
     let info = LockmanDynamicConditionInfo(actionId: "task1")
 
     // Lock and verify it exists
-    XCTAssertEqual(strategy.canLock(id: boundary, info: info), .success)
-    strategy.lock(id: boundary, info: info)
+    XCTAssertEqual(strategy.canLock(boundaryId: boundary, info: info), .success)
+    strategy.lock(boundaryId: boundary, info: info)
 
     // Verify lock exists in internal state
     let locksBeforeUnlock = strategy.getCurrentLocks()[AnyLockmanBoundaryId(boundary)] ?? []
@@ -276,7 +276,7 @@ final class LockmanDynamicConditionStrategyTests: XCTestCase {
     XCTAssertEqual(locksBeforeUnlock.first?.actionId, "task1")
 
     // Unlock
-    strategy.unlock(id: boundary, info: info)
+    strategy.unlock(boundaryId: boundary, info: info)
 
     // Verify lock is removed from internal state
     let locksAfterUnlock = strategy.getCurrentLocks()[AnyLockmanBoundaryId(boundary)] ?? []
@@ -284,7 +284,7 @@ final class LockmanDynamicConditionStrategyTests: XCTestCase {
       locksAfterUnlock.isEmpty, "Lock should be removed from internal state after unlock")
 
     // Verify can lock again
-    XCTAssertEqual(strategy.canLock(id: boundary, info: info), .success)
+    XCTAssertEqual(strategy.canLock(boundaryId: boundary, info: info), .success)
   }
 
   func testUnlockRemovesAllLocksWithSameActionId() {
@@ -296,8 +296,8 @@ final class LockmanDynamicConditionStrategyTests: XCTestCase {
     let info2 = LockmanDynamicConditionInfo(actionId: "task2")
 
     // Lock both
-    strategy.lock(id: boundary, info: info1)
-    strategy.lock(id: boundary, info: info2)
+    strategy.lock(boundaryId: boundary, info: info1)
+    strategy.lock(boundaryId: boundary, info: info2)
 
     // Verify both locks exist
     let locksBeforeUnlock = strategy.getCurrentLocks()[AnyLockmanBoundaryId(boundary)] ?? []
@@ -307,7 +307,7 @@ final class LockmanDynamicConditionStrategyTests: XCTestCase {
     let infoWithSameActionId = LockmanDynamicConditionInfo(actionId: "task1")
 
     // Unlock with an info that has the same actionId (but different uniqueId)
-    strategy.unlock(id: boundary, info: infoWithSameActionId)
+    strategy.unlock(boundaryId: boundary, info: infoWithSameActionId)
 
     // Verify that all locks with actionId "task1" are removed
     let locksAfterUnlock = strategy.getCurrentLocks()[AnyLockmanBoundaryId(boundary)] ?? []
@@ -327,17 +327,17 @@ final class LockmanDynamicConditionStrategyTests: XCTestCase {
     let info4 = LockmanDynamicConditionInfo(actionId: "differentAction")
 
     // Lock all four
-    strategy.lock(id: boundary, info: info1)
-    strategy.lock(id: boundary, info: info2)
-    strategy.lock(id: boundary, info: info3)
-    strategy.lock(id: boundary, info: info4)
+    strategy.lock(boundaryId: boundary, info: info1)
+    strategy.lock(boundaryId: boundary, info: info2)
+    strategy.lock(boundaryId: boundary, info: info3)
+    strategy.lock(boundaryId: boundary, info: info4)
 
     // Verify all four locks exist
     let locks = strategy.getCurrentLocks()[AnyLockmanBoundaryId(boundary)] ?? []
     XCTAssertEqual(locks.count, 4)
 
     // Unlock with any info that has the shared actionId
-    strategy.unlock(id: boundary, info: info1)
+    strategy.unlock(boundaryId: boundary, info: info1)
 
     // Verify all locks with the shared actionId are removed at once
     let remainingLocks = strategy.getCurrentLocks()[AnyLockmanBoundaryId(boundary)] ?? []
@@ -351,7 +351,7 @@ final class LockmanDynamicConditionStrategyTests: XCTestCase {
     let info = LockmanDynamicConditionInfo(actionId: "task1")
 
     // Try to unlock without locking first
-    strategy.unlock(id: boundary, info: info)
+    strategy.unlock(boundaryId: boundary, info: info)
 
     // Should not crash and state should be empty
     let locks = strategy.getCurrentLocks()[AnyLockmanBoundaryId(boundary)] ?? []
@@ -368,7 +368,7 @@ final class LockmanDynamicConditionStrategyTests: XCTestCase {
     for i in 0..<iterations {
       let info = LockmanDynamicConditionInfo(actionId: "task\(i)")
       infos.append(info)
-      strategy.lock(id: boundary, info: info)
+      strategy.lock(boundaryId: boundary, info: info)
     }
 
     // Verify all locks exist
@@ -379,7 +379,7 @@ final class LockmanDynamicConditionStrategyTests: XCTestCase {
     await withTaskGroup(of: Void.self) { group in
       for info in infos {
         group.addTask {
-          strategy.unlock(id: boundary, info: info)
+          strategy.unlock(boundaryId: boundary, info: info)
         }
       }
     }
@@ -399,8 +399,8 @@ final class LockmanDynamicConditionStrategyTests: XCTestCase {
     let info1 = LockmanDynamicConditionInfo(actionId: "task1")
     let info2 = LockmanDynamicConditionInfo(actionId: "task2")
 
-    strategy.lock(id: boundary1, info: info1)
-    strategy.lock(id: boundary2, info: info2)
+    strategy.lock(boundaryId: boundary1, info: info1)
+    strategy.lock(boundaryId: boundary2, info: info2)
 
     // Cleanup all
     strategy.cleanUp()
@@ -415,8 +415,8 @@ final class LockmanDynamicConditionStrategyTests: XCTestCase {
       }
     )
 
-    XCTAssertEqual(strategy.canLock(id: boundary1, info: checkInfo), .success)
-    XCTAssertEqual(strategy.canLock(id: boundary2, info: checkInfo), .success)
+    XCTAssertEqual(strategy.canLock(boundaryId: boundary1, info: checkInfo), .success)
+    XCTAssertEqual(strategy.canLock(boundaryId: boundary2, info: checkInfo), .success)
   }
 
   func testcleanupForSpecificBoundary() {
@@ -428,16 +428,16 @@ final class LockmanDynamicConditionStrategyTests: XCTestCase {
     let info1 = LockmanDynamicConditionInfo(actionId: "task1")
     let info2 = LockmanDynamicConditionInfo(actionId: "task2")
 
-    strategy.lock(id: boundary1, info: info1)
-    strategy.lock(id: boundary2, info: info2)
+    strategy.lock(boundaryId: boundary1, info: info1)
+    strategy.lock(boundaryId: boundary2, info: info2)
 
     // Cleanup only boundary1
-    strategy.cleanUp(id: boundary1)
+    strategy.cleanUp(boundaryId: boundary1)
 
     // Verify cleanup worked (we can't directly check state, so just ensure no crash)
     let checkInfo = LockmanDynamicConditionInfo(actionId: "check")
-    XCTAssertEqual(strategy.canLock(id: boundary1, info: checkInfo), .success)
-    XCTAssertEqual(strategy.canLock(id: boundary2, info: checkInfo), .success)
+    XCTAssertEqual(strategy.canLock(boundaryId: boundary1, info: checkInfo), .success)
+    XCTAssertEqual(strategy.canLock(boundaryId: boundary2, info: checkInfo), .success)
   }
 
   // MARK: - Complex Condition Tests
@@ -472,14 +472,14 @@ final class LockmanDynamicConditionStrategyTests: XCTestCase {
     // First few requests succeed
     for _ in 0..<quota {
       let info = makeInfo()
-      XCTAssertEqual(strategy.canLock(id: boundary, info: info), .success)
-      strategy.lock(id: boundary, info: info)
+      XCTAssertEqual(strategy.canLock(boundaryId: boundary, info: info), .success)
+      strategy.lock(boundaryId: boundary, info: info)
       requestCount.value += 1
     }
 
     // Next request fails
     let failInfo = makeInfo()
-    XCTAssertLockFailure(strategy.canLock(id: boundary, info: failInfo))
+    XCTAssertLockFailure(strategy.canLock(boundaryId: boundary, info: failInfo))
   }
 
   func testfailureWithCustomReason() {
@@ -495,7 +495,7 @@ final class LockmanDynamicConditionStrategyTests: XCTestCase {
       }
     )
 
-    let result = strategy.canLock(id: boundary, info: info)
+    let result = strategy.canLock(boundaryId: boundary, info: info)
     XCTAssertLockFailure(result)
   }
 
@@ -522,8 +522,8 @@ final class LockmanDynamicConditionStrategyTests: XCTestCase {
     )
 
     // User1 makes a request
-    XCTAssertEqual(strategy.canLock(id: boundary1, info: user1Info), .success)
-    strategy.lock(id: boundary1, info: user1Info)
+    XCTAssertEqual(strategy.canLock(boundaryId: boundary1, info: user1Info), .success)
+    strategy.lock(boundaryId: boundary1, info: user1Info)
     user1Count.value += 1
 
     // User2 can still make requests
@@ -537,8 +537,8 @@ final class LockmanDynamicConditionStrategyTests: XCTestCase {
               actionId: "request", hint: "User limit reached"))
       }
     )
-    XCTAssertEqual(strategy.canLock(id: boundary2, info: user2Info), .success)
-    strategy.lock(id: boundary2, info: user2Info)
+    XCTAssertEqual(strategy.canLock(boundaryId: boundary2, info: user2Info), .success)
+    strategy.lock(boundaryId: boundary2, info: user2Info)
     user2Count.value += 1
 
     // User1 second request fails
@@ -552,7 +552,7 @@ final class LockmanDynamicConditionStrategyTests: XCTestCase {
               actionId: "request", hint: "User limit reached"))
       }
     )
-    XCTAssertLockFailure(strategy.canLock(id: boundary1, info: user1Info2))
+    XCTAssertLockFailure(strategy.canLock(boundaryId: boundary1, info: user1Info2))
   }
 
   // MARK: - Thread Safety Tests
@@ -571,11 +571,11 @@ final class LockmanDynamicConditionStrategyTests: XCTestCase {
 
           // Random operations
           if i % 3 == 0 {
-            _ = strategy.canLock(id: boundary, info: info)
+            _ = strategy.canLock(boundaryId: boundary, info: info)
           } else if i % 3 == 1 {
-            strategy.lock(id: boundary, info: info)
+            strategy.lock(boundaryId: boundary, info: info)
           } else {
-            strategy.unlock(id: boundary, info: info)
+            strategy.unlock(boundaryId: boundary, info: info)
           }
         }
       }
@@ -583,7 +583,7 @@ final class LockmanDynamicConditionStrategyTests: XCTestCase {
 
     // Verify strategy is still functional
     let info = LockmanDynamicConditionInfo(actionId: "final")
-    XCTAssertEqual(strategy.canLock(id: boundary, info: info), .success)
+    XCTAssertEqual(strategy.canLock(boundaryId: boundary, info: info), .success)
   }
 
   // MARK: - Unique ID Tests

--- a/Tests/LockmanTests/Core/Strategies/GroupCoordinationStrategy/LockmanGroupCoordinatedActionTests.swift
+++ b/Tests/LockmanTests/Core/Strategies/GroupCoordinationStrategy/LockmanGroupCoordinatedActionTests.swift
@@ -250,17 +250,17 @@ final class LockmanGroupCoordinatedActionTests: XCTestCase {
 
     // Leader can start
     let startInfo = startAction.lockmanInfo
-    XCTAssertEqual(strategy.canLock(id: boundaryId, info: startInfo), .success)
-    strategy.lock(id: boundaryId, info: startInfo)
+    XCTAssertEqual(strategy.canLock(boundaryId: boundaryId, info: startInfo), .success)
+    strategy.lock(boundaryId: boundaryId, info: startInfo)
 
     // Member can join
     let progressInfo = progressAction.lockmanInfo
-    XCTAssertEqual(strategy.canLock(id: boundaryId, info: progressInfo), .success)
-    strategy.lock(id: boundaryId, info: progressInfo)
+    XCTAssertEqual(strategy.canLock(boundaryId: boundaryId, info: progressInfo), .success)
+    strategy.lock(boundaryId: boundaryId, info: progressInfo)
 
     // Clean up
-    strategy.unlock(id: boundaryId, info: startInfo)
-    strategy.unlock(id: boundaryId, info: progressInfo)
+    strategy.unlock(boundaryId: boundaryId, info: startInfo)
+    strategy.unlock(boundaryId: boundaryId, info: progressInfo)
   }
 
   func testParameterizedActionsCreateIsolatedGroups() {
@@ -279,18 +279,20 @@ final class LockmanGroupCoordinatedActionTests: XCTestCase {
     XCTAssertEqual(detailInfo.groupIds, [AnyLockmanGroupId("navigation-detail")])
     XCTAssertEqual(settingsInfo.groupIds, [AnyLockmanGroupId("navigation-settings")])
 
-    XCTAssertEqual(strategy.canLock(id: boundaryId, info: detailInfo), .success)
-    strategy.lock(id: boundaryId, info: detailInfo)
+    XCTAssertEqual(strategy.canLock(boundaryId: boundaryId, info: detailInfo), .success)
+    strategy.lock(boundaryId: boundaryId, info: detailInfo)
 
-    XCTAssertEqual(strategy.canLock(id: boundaryId, info: settingsInfo), .success)
-    strategy.lock(id: boundaryId, info: settingsInfo)
+    XCTAssertEqual(strategy.canLock(boundaryId: boundaryId, info: settingsInfo), .success)
+    strategy.lock(boundaryId: boundaryId, info: settingsInfo)
 
     // Members join correct groups
     let animateDetail = NavigationAction.animateTransition(screenId: "detail")
     let animateSettings = NavigationAction.animateTransition(screenId: "settings")
 
-    XCTAssertEqual(strategy.canLock(id: boundaryId, info: animateDetail.lockmanInfo), .success)
-    XCTAssertEqual(strategy.canLock(id: boundaryId, info: animateSettings.lockmanInfo), .success)
+    XCTAssertEqual(
+      strategy.canLock(boundaryId: boundaryId, info: animateDetail.lockmanInfo), .success)
+    XCTAssertEqual(
+      strategy.canLock(boundaryId: boundaryId, info: animateSettings.lockmanInfo), .success)
   }
 
   // MARK: - Multiple Groups Tests

--- a/Tests/LockmanTests/Core/Strategies/GroupCoordinationStrategy/LockmanGroupCoordinationStrategyTests.swift
+++ b/Tests/LockmanTests/Core/Strategies/GroupCoordinationStrategy/LockmanGroupCoordinationStrategyTests.swift
@@ -47,7 +47,7 @@ final class LockmanGroupCoordinationStrategyTests: XCTestCase {
       coordinationRole: .leader(.emptyGroup)
     )
 
-    XCTAssertEqual(strategy.canLock(id: boundaryId, info: leaderInfo), .success)
+    XCTAssertEqual(strategy.canLock(boundaryId: boundaryId, info: leaderInfo), .success)
   }
 
   func testNoneRoleCanAlwaysJoinGroup() {
@@ -61,8 +61,8 @@ final class LockmanGroupCoordinationStrategyTests: XCTestCase {
       coordinationRole: .none
     )
 
-    XCTAssertEqual(strategy.canLock(id: boundaryId, info: none1), .success)
-    strategy.lock(id: boundaryId, info: none1)
+    XCTAssertEqual(strategy.canLock(boundaryId: boundaryId, info: none1), .success)
+    strategy.lock(boundaryId: boundaryId, info: none1)
 
     // Second none action can also lock (concurrent execution)
     let none2 = LockmanGroupCoordinatedInfo(
@@ -71,8 +71,8 @@ final class LockmanGroupCoordinationStrategyTests: XCTestCase {
       coordinationRole: .none
     )
 
-    XCTAssertEqual(strategy.canLock(id: boundaryId, info: none2), .success)
-    strategy.lock(id: boundaryId, info: none2)
+    XCTAssertEqual(strategy.canLock(boundaryId: boundaryId, info: none2), .success)
+    strategy.lock(boundaryId: boundaryId, info: none2)
 
     // Third none action can also lock
     let none3 = LockmanGroupCoordinatedInfo(
@@ -81,7 +81,7 @@ final class LockmanGroupCoordinationStrategyTests: XCTestCase {
       coordinationRole: .none
     )
 
-    XCTAssertEqual(strategy.canLock(id: boundaryId, info: none3), .success)
+    XCTAssertEqual(strategy.canLock(boundaryId: boundaryId, info: none3), .success)
   }
 
   func testLeaderCannotLockWhenGroupHasMembers() {
@@ -95,8 +95,8 @@ final class LockmanGroupCoordinationStrategyTests: XCTestCase {
       coordinationRole: .leader(.emptyGroup)
     )
 
-    XCTAssertEqual(strategy.canLock(id: boundaryId, info: leader1), .success)
-    strategy.lock(id: boundaryId, info: leader1)
+    XCTAssertEqual(strategy.canLock(boundaryId: boundaryId, info: leader1), .success)
+    strategy.lock(boundaryId: boundaryId, info: leader1)
 
     // Second leader should fail
     let leader2 = LockmanGroupCoordinatedInfo(
@@ -105,7 +105,7 @@ final class LockmanGroupCoordinationStrategyTests: XCTestCase {
       coordinationRole: .leader(.emptyGroup)
     )
 
-    XCTAssertLockFailure(strategy.canLock(id: boundaryId, info: leader2))
+    XCTAssertLockFailure(strategy.canLock(boundaryId: boundaryId, info: leader2))
   }
 
   func testMemberCannotLockWhenGroupIsEmpty() {
@@ -118,7 +118,7 @@ final class LockmanGroupCoordinationStrategyTests: XCTestCase {
       coordinationRole: .member
     )
 
-    XCTAssertLockFailure(strategy.canLock(id: boundaryId, info: memberInfo))
+    XCTAssertLockFailure(strategy.canLock(boundaryId: boundaryId, info: memberInfo))
   }
 
   func testMemberCanLockWhenGroupHasMembers() {
@@ -132,7 +132,7 @@ final class LockmanGroupCoordinationStrategyTests: XCTestCase {
       coordinationRole: .none
     )
 
-    strategy.lock(id: boundaryId, info: leaderInfo)
+    strategy.lock(boundaryId: boundaryId, info: leaderInfo)
 
     // Member can join
     let memberInfo = LockmanGroupCoordinatedInfo(
@@ -141,7 +141,7 @@ final class LockmanGroupCoordinationStrategyTests: XCTestCase {
       coordinationRole: .member
     )
 
-    XCTAssertEqual(strategy.canLock(id: boundaryId, info: memberInfo), .success)
+    XCTAssertEqual(strategy.canLock(boundaryId: boundaryId, info: memberInfo), .success)
   }
 
   func testMultipleMembersCanJoinActiveGroup() {
@@ -154,7 +154,7 @@ final class LockmanGroupCoordinationStrategyTests: XCTestCase {
       groupId: "group1",
       coordinationRole: .none
     )
-    strategy.lock(id: boundaryId, info: leader)
+    strategy.lock(boundaryId: boundaryId, info: leader)
 
     // Multiple members
     let member1 = LockmanGroupCoordinatedInfo(
@@ -168,11 +168,11 @@ final class LockmanGroupCoordinationStrategyTests: XCTestCase {
       coordinationRole: .member
     )
 
-    XCTAssertEqual(strategy.canLock(id: boundaryId, info: member1), .success)
-    strategy.lock(id: boundaryId, info: member1)
+    XCTAssertEqual(strategy.canLock(boundaryId: boundaryId, info: member1), .success)
+    strategy.lock(boundaryId: boundaryId, info: member1)
 
-    XCTAssertEqual(strategy.canLock(id: boundaryId, info: member2), .success)
-    strategy.lock(id: boundaryId, info: member2)
+    XCTAssertEqual(strategy.canLock(boundaryId: boundaryId, info: member2), .success)
+    strategy.lock(boundaryId: boundaryId, info: member2)
   }
 
   func testSameActionIdCannotExecuteTwiceInSameGroup() {
@@ -185,7 +185,7 @@ final class LockmanGroupCoordinationStrategyTests: XCTestCase {
       groupId: "group1",
       coordinationRole: .none
     )
-    strategy.lock(id: boundaryId, info: leader)
+    strategy.lock(boundaryId: boundaryId, info: leader)
 
     // First action locks successfully
     let action1 = LockmanGroupCoordinatedInfo(
@@ -193,8 +193,8 @@ final class LockmanGroupCoordinationStrategyTests: XCTestCase {
       groupId: "group1",
       coordinationRole: .member
     )
-    XCTAssertEqual(strategy.canLock(id: boundaryId, info: action1), .success)
-    strategy.lock(id: boundaryId, info: action1)
+    XCTAssertEqual(strategy.canLock(boundaryId: boundaryId, info: action1), .success)
+    strategy.lock(boundaryId: boundaryId, info: action1)
 
     // Second action with same ID fails
     let action2 = LockmanGroupCoordinatedInfo(
@@ -202,7 +202,7 @@ final class LockmanGroupCoordinationStrategyTests: XCTestCase {
       groupId: "group1",
       coordinationRole: .member
     )
-    XCTAssertLockFailure(strategy.canLock(id: boundaryId, info: action2))
+    XCTAssertLockFailure(strategy.canLock(boundaryId: boundaryId, info: action2))
   }
 
   // MARK: - Group Lifecycle Tests
@@ -217,7 +217,7 @@ final class LockmanGroupCoordinationStrategyTests: XCTestCase {
       groupId: "group1",
       coordinationRole: .leader(.emptyGroup)
     )
-    strategy.lock(id: boundaryId, info: leader)
+    strategy.lock(boundaryId: boundaryId, info: leader)
 
     // Member joins
     let member = LockmanGroupCoordinatedInfo(
@@ -225,10 +225,10 @@ final class LockmanGroupCoordinationStrategyTests: XCTestCase {
       groupId: "group1",
       coordinationRole: .member
     )
-    strategy.lock(id: boundaryId, info: member)
+    strategy.lock(boundaryId: boundaryId, info: member)
 
     // Leader unlocks
-    strategy.unlock(id: boundaryId, info: leader)
+    strategy.unlock(boundaryId: boundaryId, info: leader)
 
     // New member can still join
     let newMember = LockmanGroupCoordinatedInfo(
@@ -236,7 +236,7 @@ final class LockmanGroupCoordinationStrategyTests: XCTestCase {
       groupId: "group1",
       coordinationRole: .member
     )
-    XCTAssertEqual(strategy.canLock(id: boundaryId, info: newMember), .success)
+    XCTAssertEqual(strategy.canLock(boundaryId: boundaryId, info: newMember), .success)
 
     // New leader cannot start (group still has members)
     let newLeader = LockmanGroupCoordinatedInfo(
@@ -244,7 +244,7 @@ final class LockmanGroupCoordinationStrategyTests: XCTestCase {
       groupId: "group1",
       coordinationRole: .leader(.emptyGroup)
     )
-    XCTAssertLockFailure(strategy.canLock(id: boundaryId, info: newLeader))
+    XCTAssertLockFailure(strategy.canLock(boundaryId: boundaryId, info: newLeader))
   }
 
   func testGroupDissolvesWhenLastMemberUnlocks() {
@@ -268,14 +268,14 @@ final class LockmanGroupCoordinationStrategyTests: XCTestCase {
       coordinationRole: .member
     )
 
-    strategy.lock(id: boundaryId, info: leader)
-    strategy.lock(id: boundaryId, info: member1)
-    strategy.lock(id: boundaryId, info: member2)
+    strategy.lock(boundaryId: boundaryId, info: leader)
+    strategy.lock(boundaryId: boundaryId, info: member1)
+    strategy.lock(boundaryId: boundaryId, info: member2)
 
     // Unlock all members
-    strategy.unlock(id: boundaryId, info: leader)
-    strategy.unlock(id: boundaryId, info: member1)
-    strategy.unlock(id: boundaryId, info: member2)
+    strategy.unlock(boundaryId: boundaryId, info: leader)
+    strategy.unlock(boundaryId: boundaryId, info: member1)
+    strategy.unlock(boundaryId: boundaryId, info: member2)
 
     // New leader can now start (group is empty)
     let newLeader = LockmanGroupCoordinatedInfo(
@@ -283,7 +283,7 @@ final class LockmanGroupCoordinationStrategyTests: XCTestCase {
       groupId: "group1",
       coordinationRole: .none
     )
-    XCTAssertEqual(strategy.canLock(id: boundaryId, info: newLeader), .success)
+    XCTAssertEqual(strategy.canLock(boundaryId: boundaryId, info: newLeader), .success)
 
     // Member cannot join (group is empty)
     let newMember = LockmanGroupCoordinatedInfo(
@@ -291,7 +291,7 @@ final class LockmanGroupCoordinationStrategyTests: XCTestCase {
       groupId: "group1",
       coordinationRole: .member
     )
-    XCTAssertLockFailure(strategy.canLock(id: boundaryId, info: newMember))
+    XCTAssertLockFailure(strategy.canLock(boundaryId: boundaryId, info: newMember))
   }
 
   // MARK: - Multiple Groups Tests
@@ -315,11 +315,11 @@ final class LockmanGroupCoordinationStrategyTests: XCTestCase {
     )
 
     // Both can lock independently
-    XCTAssertEqual(strategy.canLock(id: boundaryId, info: group1Leader), .success)
-    strategy.lock(id: boundaryId, info: group1Leader)
+    XCTAssertEqual(strategy.canLock(boundaryId: boundaryId, info: group1Leader), .success)
+    strategy.lock(boundaryId: boundaryId, info: group1Leader)
 
-    XCTAssertEqual(strategy.canLock(id: boundaryId, info: group2Leader), .success)
-    strategy.lock(id: boundaryId, info: group2Leader)
+    XCTAssertEqual(strategy.canLock(boundaryId: boundaryId, info: group2Leader), .success)
+    strategy.lock(boundaryId: boundaryId, info: group2Leader)
 
     // Members for different groups
     let group1Member = LockmanGroupCoordinatedInfo(
@@ -333,8 +333,8 @@ final class LockmanGroupCoordinationStrategyTests: XCTestCase {
       coordinationRole: .member
     )
 
-    XCTAssertEqual(strategy.canLock(id: boundaryId, info: group1Member), .success)
-    XCTAssertEqual(strategy.canLock(id: boundaryId, info: group2Member), .success)
+    XCTAssertEqual(strategy.canLock(boundaryId: boundaryId, info: group1Member), .success)
+    XCTAssertEqual(strategy.canLock(boundaryId: boundaryId, info: group2Member), .success)
   }
 
   // MARK: - Boundary Isolation Tests
@@ -357,11 +357,11 @@ final class LockmanGroupCoordinationStrategyTests: XCTestCase {
     )
 
     // Both can lock in their respective boundaries
-    XCTAssertEqual(strategy.canLock(id: boundary1, info: leader1), .success)
-    strategy.lock(id: boundary1, info: leader1)
+    XCTAssertEqual(strategy.canLock(boundaryId: boundary1, info: leader1), .success)
+    strategy.lock(boundaryId: boundary1, info: leader1)
 
-    XCTAssertEqual(strategy.canLock(id: boundary2, info: leader2), .success)
-    strategy.lock(id: boundary2, info: leader2)
+    XCTAssertEqual(strategy.canLock(boundaryId: boundary2, info: leader2), .success)
+    strategy.lock(boundaryId: boundary2, info: leader2)
   }
 
   // MARK: - Cleanup Tests
@@ -382,8 +382,8 @@ final class LockmanGroupCoordinationStrategyTests: XCTestCase {
       coordinationRole: .none
     )
 
-    strategy.lock(id: boundaryId, info: leader1)
-    strategy.lock(id: boundaryId, info: leader2)
+    strategy.lock(boundaryId: boundaryId, info: leader1)
+    strategy.lock(boundaryId: boundaryId, info: leader2)
 
     // Clean up
     strategy.cleanUp()
@@ -400,8 +400,8 @@ final class LockmanGroupCoordinationStrategyTests: XCTestCase {
       coordinationRole: .none
     )
 
-    XCTAssertEqual(strategy.canLock(id: boundaryId, info: newLeader1), .success)
-    XCTAssertEqual(strategy.canLock(id: boundaryId, info: newLeader2), .success)
+    XCTAssertEqual(strategy.canLock(boundaryId: boundaryId, info: newLeader1), .success)
+    XCTAssertEqual(strategy.canLock(boundaryId: boundaryId, info: newLeader2), .success)
   }
 
   func testCleanUpWithBoundaryIdRemovesOnlyThatBoundary() {
@@ -421,11 +421,11 @@ final class LockmanGroupCoordinationStrategyTests: XCTestCase {
       coordinationRole: .none
     )
 
-    strategy.lock(id: boundary1, info: leader1)
-    strategy.lock(id: boundary2, info: leader2)
+    strategy.lock(boundaryId: boundary1, info: leader1)
+    strategy.lock(boundaryId: boundary2, info: leader2)
 
     // Clean up only boundary1
-    strategy.cleanUp(id: boundary1)
+    strategy.cleanUp(boundaryId: boundary1)
 
     // New leader can start in boundary1
     let newLeader1 = LockmanGroupCoordinatedInfo(
@@ -433,7 +433,7 @@ final class LockmanGroupCoordinationStrategyTests: XCTestCase {
       groupId: "group1",
       coordinationRole: .none
     )
-    XCTAssertEqual(strategy.canLock(id: boundary1, info: newLeader1), .success)
+    XCTAssertEqual(strategy.canLock(boundaryId: boundary1, info: newLeader1), .success)
 
     // boundary2 still has active group - .none actions can still join
     let newNone2 = LockmanGroupCoordinatedInfo(
@@ -441,7 +441,7 @@ final class LockmanGroupCoordinationStrategyTests: XCTestCase {
       groupId: "group1",
       coordinationRole: .none
     )
-    XCTAssertEqual(strategy.canLock(id: boundary2, info: newNone2), .success)
+    XCTAssertEqual(strategy.canLock(boundaryId: boundary2, info: newNone2), .success)
 
     // But a leader cannot start in boundary2
     let newLeader2 = LockmanGroupCoordinatedInfo(
@@ -449,7 +449,7 @@ final class LockmanGroupCoordinationStrategyTests: XCTestCase {
       groupId: "group1",
       coordinationRole: .leader(.emptyGroup)
     )
-    XCTAssertLockFailure(strategy.canLock(id: boundary2, info: newLeader2))
+    XCTAssertLockFailure(strategy.canLock(boundaryId: boundary2, info: newLeader2))
   }
 
   // MARK: - Multiple Groups Tests
@@ -466,8 +466,8 @@ final class LockmanGroupCoordinationStrategyTests: XCTestCase {
     )
 
     // Should succeed when all groups are empty
-    XCTAssertEqual(strategy.canLock(id: boundaryId, info: multiGroupLeader), .success)
-    strategy.lock(id: boundaryId, info: multiGroupLeader)
+    XCTAssertEqual(strategy.canLock(boundaryId: boundaryId, info: multiGroupLeader), .success)
+    strategy.lock(boundaryId: boundaryId, info: multiGroupLeader)
 
     // Member can join any of these groups now
     let member1 = LockmanGroupCoordinatedInfo(
@@ -481,8 +481,8 @@ final class LockmanGroupCoordinationStrategyTests: XCTestCase {
       coordinationRole: .member
     )
 
-    XCTAssertEqual(strategy.canLock(id: boundaryId, info: member1), .success)
-    XCTAssertEqual(strategy.canLock(id: boundaryId, info: member2), .success)
+    XCTAssertEqual(strategy.canLock(boundaryId: boundaryId, info: member1), .success)
+    XCTAssertEqual(strategy.canLock(boundaryId: boundaryId, info: member2), .success)
   }
 
   func testMultipleGroupsWithAndCondition() {
@@ -495,7 +495,7 @@ final class LockmanGroupCoordinationStrategyTests: XCTestCase {
       groupId: "group1",
       coordinationRole: .none
     )
-    strategy.lock(id: boundaryId, info: group1Leader)
+    strategy.lock(boundaryId: boundaryId, info: group1Leader)
 
     // Multi-group .none action can join
     let multiNone = LockmanGroupCoordinatedInfo(
@@ -503,7 +503,7 @@ final class LockmanGroupCoordinationStrategyTests: XCTestCase {
       groupIds: ["group1", "group2"],
       coordinationRole: .none
     )
-    XCTAssertEqual(strategy.canLock(id: boundaryId, info: multiNone), .success)
+    XCTAssertEqual(strategy.canLock(boundaryId: boundaryId, info: multiNone), .success)
 
     // But multi-group leader should fail because group1 is not empty
     let multiLeader = LockmanGroupCoordinatedInfo(
@@ -511,7 +511,7 @@ final class LockmanGroupCoordinationStrategyTests: XCTestCase {
       groupIds: ["group1", "group2"],
       coordinationRole: .leader(.emptyGroup)
     )
-    XCTAssertLockFailure(strategy.canLock(id: boundaryId, info: multiLeader))
+    XCTAssertLockFailure(strategy.canLock(boundaryId: boundaryId, info: multiLeader))
 
     // Multi-group member needs all groups to have members
     let multiMember = LockmanGroupCoordinatedInfo(
@@ -519,7 +519,7 @@ final class LockmanGroupCoordinationStrategyTests: XCTestCase {
       groupIds: ["group1", "group2"],
       coordinationRole: .member
     )
-    XCTAssertLockFailure(strategy.canLock(id: boundaryId, info: multiMember))
+    XCTAssertLockFailure(strategy.canLock(boundaryId: boundaryId, info: multiMember))
 
     // Start group2
     let group2Leader = LockmanGroupCoordinatedInfo(
@@ -527,10 +527,10 @@ final class LockmanGroupCoordinationStrategyTests: XCTestCase {
       groupId: "group2",
       coordinationRole: .none
     )
-    strategy.lock(id: boundaryId, info: group2Leader)
+    strategy.lock(boundaryId: boundaryId, info: group2Leader)
 
     // Now multi-group member can join
-    XCTAssertEqual(strategy.canLock(id: boundaryId, info: multiMember), .success)
+    XCTAssertEqual(strategy.canLock(boundaryId: boundaryId, info: multiMember), .success)
   }
 
   func testMaximum5GroupsValidation() {
@@ -590,7 +590,7 @@ final class LockmanGroupCoordinationStrategyTests: XCTestCase {
       groupIds: ["g1", "g2", "g3"],
       coordinationRole: .none
     )
-    strategy.lock(id: boundaryId, info: multiAction)
+    strategy.lock(boundaryId: boundaryId, info: multiAction)
 
     // Add members to each group
     let p1 = LockmanGroupCoordinatedInfo(
@@ -603,11 +603,11 @@ final class LockmanGroupCoordinationStrategyTests: XCTestCase {
       groupId: "g2",
       coordinationRole: .member
     )
-    strategy.lock(id: boundaryId, info: p1)
-    strategy.lock(id: boundaryId, info: p2)
+    strategy.lock(boundaryId: boundaryId, info: p1)
+    strategy.lock(boundaryId: boundaryId, info: p2)
 
     // Unlock multi-action
-    strategy.unlock(id: boundaryId, info: multiAction)
+    strategy.unlock(boundaryId: boundaryId, info: multiAction)
 
     // Members should still be able to join
     let newP1 = LockmanGroupCoordinatedInfo(
@@ -615,7 +615,7 @@ final class LockmanGroupCoordinationStrategyTests: XCTestCase {
       groupId: "g1",
       coordinationRole: .member
     )
-    XCTAssertEqual(strategy.canLock(id: boundaryId, info: newP1), .success)
+    XCTAssertEqual(strategy.canLock(boundaryId: boundaryId, info: newP1), .success)
 
     // .none actions can join g1 (still has p1)
     let newNone = LockmanGroupCoordinatedInfo(
@@ -623,7 +623,7 @@ final class LockmanGroupCoordinationStrategyTests: XCTestCase {
       groupId: "g1",
       coordinationRole: .none
     )
-    XCTAssertEqual(strategy.canLock(id: boundaryId, info: newNone), .success)
+    XCTAssertEqual(strategy.canLock(boundaryId: boundaryId, info: newNone), .success)
 
     // But new leader cannot start in g1 (still has p1)
     let newLeader = LockmanGroupCoordinatedInfo(
@@ -631,7 +631,7 @@ final class LockmanGroupCoordinationStrategyTests: XCTestCase {
       groupId: "g1",
       coordinationRole: .leader(.emptyGroup)
     )
-    XCTAssertLockFailure(strategy.canLock(id: boundaryId, info: newLeader))
+    XCTAssertLockFailure(strategy.canLock(boundaryId: boundaryId, info: newLeader))
 
     // g3 should be empty now (only had the multi-action)
     let g3Init = LockmanGroupCoordinatedInfo(
@@ -639,7 +639,7 @@ final class LockmanGroupCoordinationStrategyTests: XCTestCase {
       groupId: "g3",
       coordinationRole: .none
     )
-    XCTAssertEqual(strategy.canLock(id: boundaryId, info: g3Init), .success)
+    XCTAssertEqual(strategy.canLock(boundaryId: boundaryId, info: g3Init), .success)
   }
 
   // MARK: - Integration Tests
@@ -673,23 +673,23 @@ final class LockmanGroupCoordinationStrategyTests: XCTestCase {
     )
 
     // Start navigation
-    XCTAssertEqual(strategy.canLock(id: boundaryId, info: navLeader), .success)
-    strategy.lock(id: boundaryId, info: navLeader)
+    XCTAssertEqual(strategy.canLock(boundaryId: boundaryId, info: navLeader), .success)
+    strategy.lock(boundaryId: boundaryId, info: navLeader)
 
     // Start data loading (different group)
-    XCTAssertEqual(strategy.canLock(id: boundaryId, info: dataLeader), .success)
-    strategy.lock(id: boundaryId, info: dataLeader)
+    XCTAssertEqual(strategy.canLock(boundaryId: boundaryId, info: dataLeader), .success)
+    strategy.lock(boundaryId: boundaryId, info: dataLeader)
 
     // Add members to both groups
-    XCTAssertEqual(strategy.canLock(id: boundaryId, info: navAnimation), .success)
-    strategy.lock(id: boundaryId, info: navAnimation)
+    XCTAssertEqual(strategy.canLock(boundaryId: boundaryId, info: navAnimation), .success)
+    strategy.lock(boundaryId: boundaryId, info: navAnimation)
 
-    XCTAssertEqual(strategy.canLock(id: boundaryId, info: dataProgress), .success)
-    strategy.lock(id: boundaryId, info: dataProgress)
+    XCTAssertEqual(strategy.canLock(boundaryId: boundaryId, info: dataProgress), .success)
+    strategy.lock(boundaryId: boundaryId, info: dataProgress)
 
     // Navigation completes
-    strategy.unlock(id: boundaryId, info: navLeader)
-    strategy.unlock(id: boundaryId, info: navAnimation)
+    strategy.unlock(boundaryId: boundaryId, info: navLeader)
+    strategy.unlock(boundaryId: boundaryId, info: navAnimation)
 
     // New navigation can start
     let newNavLeader = LockmanGroupCoordinatedInfo(
@@ -697,7 +697,7 @@ final class LockmanGroupCoordinationStrategyTests: XCTestCase {
       groupId: "navigation",
       coordinationRole: .none
     )
-    XCTAssertEqual(strategy.canLock(id: boundaryId, info: newNavLeader), .success)
+    XCTAssertEqual(strategy.canLock(boundaryId: boundaryId, info: newNavLeader), .success)
 
     // Data loading still active
     let dataError = LockmanGroupCoordinatedInfo(
@@ -705,7 +705,7 @@ final class LockmanGroupCoordinationStrategyTests: XCTestCase {
       groupId: "dataLoading",
       coordinationRole: .member
     )
-    XCTAssertEqual(strategy.canLock(id: boundaryId, info: dataError), .success)
+    XCTAssertEqual(strategy.canLock(boundaryId: boundaryId, info: dataError), .success)
   }
 
   // MARK: - Thread Safety Tests
@@ -720,7 +720,7 @@ final class LockmanGroupCoordinationStrategyTests: XCTestCase {
       groupId: "concurrentGroup",
       coordinationRole: .none
     )
-    strategy.lock(id: boundaryId, info: leader)
+    strategy.lock(boundaryId: boundaryId, info: leader)
 
     // Concurrent member attempts
     await withTaskGroup(of: Bool.self) { group in
@@ -732,11 +732,11 @@ final class LockmanGroupCoordinationStrategyTests: XCTestCase {
             coordinationRole: .member
           )
 
-          if strategy.canLock(id: boundaryId, info: member) == .success {
-            strategy.lock(id: boundaryId, info: member)
+          if strategy.canLock(boundaryId: boundaryId, info: member) == .success {
+            strategy.lock(boundaryId: boundaryId, info: member)
             // Simulate some work
             try? await Task.sleep(nanoseconds: 1_000_000)  // 1ms
-            strategy.unlock(id: boundaryId, info: member)
+            strategy.unlock(boundaryId: boundaryId, info: member)
             return true
           }
           return false
@@ -769,8 +769,8 @@ final class LockmanGroupCoordinationStrategyTests: XCTestCase {
     )
 
     // Can join empty group
-    XCTAssertEqual(strategy.canLock(id: boundaryId, info: emptyGroupLeader), .success)
-    strategy.lock(id: boundaryId, info: emptyGroupLeader)
+    XCTAssertEqual(strategy.canLock(boundaryId: boundaryId, info: emptyGroupLeader), .success)
+    strategy.lock(boundaryId: boundaryId, info: emptyGroupLeader)
 
     // Another leader with .emptyGroup should fail (group not empty)
     let otherLeader = LockmanGroupCoordinatedInfo(
@@ -778,7 +778,7 @@ final class LockmanGroupCoordinationStrategyTests: XCTestCase {
       groupId: "group1",
       coordinationRole: .leader(.emptyGroup)
     )
-    XCTAssertLockFailure(strategy.canLock(id: boundaryId, info: otherLeader))
+    XCTAssertLockFailure(strategy.canLock(boundaryId: boundaryId, info: otherLeader))
 
     // Member can join
     let member = LockmanGroupCoordinatedInfo(
@@ -786,7 +786,7 @@ final class LockmanGroupCoordinationStrategyTests: XCTestCase {
       groupId: "group1",
       coordinationRole: .member
     )
-    XCTAssertEqual(strategy.canLock(id: boundaryId, info: member), .success)
+    XCTAssertEqual(strategy.canLock(boundaryId: boundaryId, info: member), .success)
 
     // .none can join
     let noneAction = LockmanGroupCoordinatedInfo(
@@ -794,7 +794,7 @@ final class LockmanGroupCoordinationStrategyTests: XCTestCase {
       groupId: "group1",
       coordinationRole: .none
     )
-    XCTAssertEqual(strategy.canLock(id: boundaryId, info: noneAction), .success)
+    XCTAssertEqual(strategy.canLock(boundaryId: boundaryId, info: noneAction), .success)
   }
 
   func testLeaderWithoutMembersPolicyAllowsOtherLeaders() {
@@ -808,8 +808,8 @@ final class LockmanGroupCoordinationStrategyTests: XCTestCase {
       coordinationRole: .leader(.withoutMembers)
     )
 
-    XCTAssertEqual(strategy.canLock(id: boundaryId, info: exclusiveLeader), .success)
-    strategy.lock(id: boundaryId, info: exclusiveLeader)
+    XCTAssertEqual(strategy.canLock(boundaryId: boundaryId, info: exclusiveLeader), .success)
+    strategy.lock(boundaryId: boundaryId, info: exclusiveLeader)
 
     // Another leader can join (no members present)
     let otherLeader = LockmanGroupCoordinatedInfo(
@@ -817,8 +817,8 @@ final class LockmanGroupCoordinationStrategyTests: XCTestCase {
       groupId: "group1",
       coordinationRole: .leader(.withoutMembers)
     )
-    XCTAssertEqual(strategy.canLock(id: boundaryId, info: otherLeader), .success)
-    strategy.lock(id: boundaryId, info: otherLeader)
+    XCTAssertEqual(strategy.canLock(boundaryId: boundaryId, info: otherLeader), .success)
+    strategy.lock(boundaryId: boundaryId, info: otherLeader)
 
     // Now member joins
     let member = LockmanGroupCoordinatedInfo(
@@ -826,8 +826,8 @@ final class LockmanGroupCoordinationStrategyTests: XCTestCase {
       groupId: "group1",
       coordinationRole: .member
     )
-    XCTAssertEqual(strategy.canLock(id: boundaryId, info: member), .success)
-    strategy.lock(id: boundaryId, info: member)
+    XCTAssertEqual(strategy.canLock(boundaryId: boundaryId, info: member), .success)
+    strategy.lock(boundaryId: boundaryId, info: member)
 
     // New leader with .withoutMembers should fail (members present)
     let newLeader = LockmanGroupCoordinatedInfo(
@@ -835,7 +835,7 @@ final class LockmanGroupCoordinationStrategyTests: XCTestCase {
       groupId: "group1",
       coordinationRole: .leader(.withoutMembers)
     )
-    XCTAssertLockFailure(strategy.canLock(id: boundaryId, info: newLeader))
+    XCTAssertLockFailure(strategy.canLock(boundaryId: boundaryId, info: newLeader))
   }
 
   func testLeaderWithoutLeaderPolicyBlocksOtherLeaders() {
@@ -849,8 +849,8 @@ final class LockmanGroupCoordinationStrategyTests: XCTestCase {
       coordinationRole: .leader(.withoutLeader)
     )
 
-    XCTAssertEqual(strategy.canLock(id: boundaryId, info: exclusiveLeader), .success)
-    strategy.lock(id: boundaryId, info: exclusiveLeader)
+    XCTAssertEqual(strategy.canLock(boundaryId: boundaryId, info: exclusiveLeader), .success)
+    strategy.lock(boundaryId: boundaryId, info: exclusiveLeader)
 
     // Another leader should be blocked
     let otherLeader = LockmanGroupCoordinatedInfo(
@@ -858,7 +858,7 @@ final class LockmanGroupCoordinationStrategyTests: XCTestCase {
       groupId: "group1",
       coordinationRole: .leader(.emptyGroup)
     )
-    XCTAssertLockFailure(strategy.canLock(id: boundaryId, info: otherLeader))
+    XCTAssertLockFailure(strategy.canLock(boundaryId: boundaryId, info: otherLeader))
 
     // .none actions should succeed (not blocked by leadersOnly)
     let noneAction = LockmanGroupCoordinatedInfo(
@@ -866,7 +866,7 @@ final class LockmanGroupCoordinationStrategyTests: XCTestCase {
       groupId: "group1",
       coordinationRole: .none
     )
-    XCTAssertEqual(strategy.canLock(id: boundaryId, info: noneAction), .success)
+    XCTAssertEqual(strategy.canLock(boundaryId: boundaryId, info: noneAction), .success)
 
     // Member should succeed
     let member = LockmanGroupCoordinatedInfo(
@@ -874,7 +874,7 @@ final class LockmanGroupCoordinationStrategyTests: XCTestCase {
       groupId: "group1",
       coordinationRole: .member
     )
-    XCTAssertEqual(strategy.canLock(id: boundaryId, info: member), .success)
+    XCTAssertEqual(strategy.canLock(boundaryId: boundaryId, info: member), .success)
   }
 
   func testNormalLeaderDoesNotBlockOthers() {
@@ -888,8 +888,8 @@ final class LockmanGroupCoordinationStrategyTests: XCTestCase {
       coordinationRole: .none
     )
 
-    XCTAssertEqual(strategy.canLock(id: boundaryId, info: normalLeader), .success)
-    strategy.lock(id: boundaryId, info: normalLeader)
+    XCTAssertEqual(strategy.canLock(boundaryId: boundaryId, info: normalLeader), .success)
+    strategy.lock(boundaryId: boundaryId, info: normalLeader)
 
     // Member should succeed
     let member1 = LockmanGroupCoordinatedInfo(
@@ -897,8 +897,8 @@ final class LockmanGroupCoordinationStrategyTests: XCTestCase {
       groupId: "group1",
       coordinationRole: .member
     )
-    XCTAssertEqual(strategy.canLock(id: boundaryId, info: member1), .success)
-    strategy.lock(id: boundaryId, info: member1)
+    XCTAssertEqual(strategy.canLock(boundaryId: boundaryId, info: member1), .success)
+    strategy.lock(boundaryId: boundaryId, info: member1)
 
     // Another member should succeed
     let member2 = LockmanGroupCoordinatedInfo(
@@ -906,7 +906,7 @@ final class LockmanGroupCoordinationStrategyTests: XCTestCase {
       groupId: "group1",
       coordinationRole: .member
     )
-    XCTAssertEqual(strategy.canLock(id: boundaryId, info: member2), .success)
+    XCTAssertEqual(strategy.canLock(boundaryId: boundaryId, info: member2), .success)
   }
 
   func testLeaderWithMultipleGroups() {
@@ -920,8 +920,8 @@ final class LockmanGroupCoordinationStrategyTests: XCTestCase {
       coordinationRole: .leader(.emptyGroup)
     )
 
-    XCTAssertEqual(strategy.canLock(id: boundaryId, info: multiGroupLeader), .success)
-    strategy.lock(id: boundaryId, info: multiGroupLeader)
+    XCTAssertEqual(strategy.canLock(boundaryId: boundaryId, info: multiGroupLeader), .success)
+    strategy.lock(boundaryId: boundaryId, info: multiGroupLeader)
 
     // Member in group1 can join
     let member1 = LockmanGroupCoordinatedInfo(
@@ -929,7 +929,7 @@ final class LockmanGroupCoordinationStrategyTests: XCTestCase {
       groupId: "group1",
       coordinationRole: .member
     )
-    XCTAssertEqual(strategy.canLock(id: boundaryId, info: member1), .success)
+    XCTAssertEqual(strategy.canLock(boundaryId: boundaryId, info: member1), .success)
 
     // Member in group2 can also join
     let member2 = LockmanGroupCoordinatedInfo(
@@ -937,7 +937,7 @@ final class LockmanGroupCoordinationStrategyTests: XCTestCase {
       groupId: "group2",
       coordinationRole: .member
     )
-    XCTAssertEqual(strategy.canLock(id: boundaryId, info: member2), .success)
+    XCTAssertEqual(strategy.canLock(boundaryId: boundaryId, info: member2), .success)
 
     // Member in different group should succeed
     let member3 = LockmanGroupCoordinatedInfo(
@@ -951,9 +951,9 @@ final class LockmanGroupCoordinationStrategyTests: XCTestCase {
       groupId: "group3",
       coordinationRole: .none
     )
-    XCTAssertEqual(strategy.canLock(id: boundaryId, info: leader3), .success)
-    strategy.lock(id: boundaryId, info: leader3)
-    XCTAssertEqual(strategy.canLock(id: boundaryId, info: member3), .success)
+    XCTAssertEqual(strategy.canLock(boundaryId: boundaryId, info: leader3), .success)
+    strategy.lock(boundaryId: boundaryId, info: leader3)
+    XCTAssertEqual(strategy.canLock(boundaryId: boundaryId, info: member3), .success)
   }
 
   func testExclusiveModeSelfDoesNotBlockItself() {
@@ -967,7 +967,7 @@ final class LockmanGroupCoordinationStrategyTests: XCTestCase {
       coordinationRole: .leader(.emptyGroup)
     )
 
-    strategy.lock(id: boundaryId, info: exclusiveLeader)
+    strategy.lock(boundaryId: boundaryId, info: exclusiveLeader)
 
     // Same action should not be blocked by its own exclusivity
     // (but will fail due to duplicate actionId rule)
@@ -977,7 +977,7 @@ final class LockmanGroupCoordinationStrategyTests: XCTestCase {
       coordinationRole: .leader(.emptyGroup)
     )
 
-    if case .failure(let error) = strategy.canLock(id: boundaryId, info: sameLock) {
+    if case .failure(let error) = strategy.canLock(boundaryId: boundaryId, info: sameLock) {
       // Should fail due to actionAlreadyInGroup, not blockedByExclusiveLeader
       XCTAssertTrue(error is LockmanGroupCoordinationError)
       if let coordinationError = error as? LockmanGroupCoordinationError {
@@ -1004,7 +1004,7 @@ final class LockmanGroupCoordinationStrategyTests: XCTestCase {
       groupId: "group1",
       coordinationRole: .leader(.emptyGroup)
     )
-    strategy.lock(id: boundaryId, info: leader1)
+    strategy.lock(boundaryId: boundaryId, info: leader1)
 
     // Add a member
     let member = LockmanGroupCoordinatedInfo(
@@ -1012,7 +1012,7 @@ final class LockmanGroupCoordinationStrategyTests: XCTestCase {
       groupId: "group1",
       coordinationRole: .member
     )
-    strategy.lock(id: boundaryId, info: member)
+    strategy.lock(boundaryId: boundaryId, info: member)
 
     // Test .emptyGroup policy failure
     let emptyGroupLeader = LockmanGroupCoordinatedInfo(
@@ -1020,7 +1020,7 @@ final class LockmanGroupCoordinationStrategyTests: XCTestCase {
       groupId: "group1",
       coordinationRole: .leader(.emptyGroup)
     )
-    if case .failure(let error) = strategy.canLock(id: boundaryId, info: emptyGroupLeader) {
+    if case .failure(let error) = strategy.canLock(boundaryId: boundaryId, info: emptyGroupLeader) {
       XCTAssertTrue(error is LockmanGroupCoordinationError)
     } else {
       XCTFail("Expected failure for .emptyGroup policy")
@@ -1032,7 +1032,9 @@ final class LockmanGroupCoordinationStrategyTests: XCTestCase {
       groupId: "group1",
       coordinationRole: .leader(.withoutMembers)
     )
-    if case .failure(let error) = strategy.canLock(id: boundaryId, info: withoutMembersLeader) {
+    if case .failure(let error) = strategy.canLock(
+      boundaryId: boundaryId, info: withoutMembersLeader)
+    {
       XCTAssertTrue(error is LockmanGroupCoordinationError)
     } else {
       XCTFail("Expected failure for .withoutMembers policy")
@@ -1044,7 +1046,9 @@ final class LockmanGroupCoordinationStrategyTests: XCTestCase {
       groupId: "group1",
       coordinationRole: .leader(.withoutLeader)
     )
-    if case .failure(let error) = strategy.canLock(id: boundaryId, info: withoutLeaderLeader) {
+    if case .failure(let error) = strategy.canLock(
+      boundaryId: boundaryId, info: withoutLeaderLeader)
+    {
       XCTAssertTrue(error is LockmanGroupCoordinationError)
     } else {
       XCTFail("Expected failure for .withoutLeader policy")

--- a/Tests/LockmanTests/Core/Strategies/PriorityBasedStrategy/LockmanPriorityBasedInfoTests.swift
+++ b/Tests/LockmanTests/Core/Strategies/PriorityBasedStrategy/LockmanPriorityBasedInfoTests.swift
@@ -443,15 +443,15 @@ final class LockmanPriorityBasedInfoIntegrationTests: XCTestCase {
       }
 
       // Test basic locking behavior
-      XCTAssertEqual(resolvedStrategy.canLock(id: boundaryId, info: info1), .success)
-      resolvedStrategy.lock(id: boundaryId, info: info1)
+      XCTAssertEqual(resolvedStrategy.canLock(boundaryId: boundaryId, info: info1), .success)
+      resolvedStrategy.lock(boundaryId: boundaryId, info: info1)
 
       // None priority always succeeds
-      XCTAssertEqual(resolvedStrategy.canLock(id: boundaryId, info: info3), .success)
+      XCTAssertEqual(resolvedStrategy.canLock(boundaryId: boundaryId, info: info3), .success)
 
       // Higher priority preempts lower priority
       if case .successWithPrecedingCancellation = resolvedStrategy.canLock(
-        id: boundaryId, info: info2)
+        boundaryId: boundaryId, info: info2)
       {
         // Success - expected behavior
       } else {
@@ -472,27 +472,27 @@ final class LockmanPriorityBasedInfoIntegrationTests: XCTestCase {
     let anotherLowInfo = TestInfoFactory.lowExclusive("lowExc2")
 
     // None priority always succeeds
-    XCTAssertEqual(strategy.canLock(id: boundaryId, info: noneInfo), .success)
+    XCTAssertEqual(strategy.canLock(boundaryId: boundaryId, info: noneInfo), .success)
 
     // First low priority succeeds
-    XCTAssertEqual(strategy.canLock(id: boundaryId, info: lowExclusiveInfo), .success)
-    strategy.lock(id: boundaryId, info: lowExclusiveInfo)
+    XCTAssertEqual(strategy.canLock(boundaryId: boundaryId, info: lowExclusiveInfo), .success)
+    strategy.lock(boundaryId: boundaryId, info: lowExclusiveInfo)
 
     // High priority preempts low priority
     if case .successWithPrecedingCancellation = strategy.canLock(
-      id: boundaryId, info: highReplaceableInfo)
+      boundaryId: boundaryId, info: highReplaceableInfo)
     {
       // Success - expected behavior
     } else {
       XCTFail("Expected successWithPrecedingCancellation")
     }
-    strategy.lock(id: boundaryId, info: highReplaceableInfo)
+    strategy.lock(boundaryId: boundaryId, info: highReplaceableInfo)
 
     // Another low priority fails against high priority
-    XCTAssertLockFailure(strategy.canLock(id: boundaryId, info: anotherLowInfo))
+    XCTAssertLockFailure(strategy.canLock(boundaryId: boundaryId, info: anotherLowInfo))
 
     // None priority still succeeds
-    XCTAssertEqual(strategy.canLock(id: boundaryId, info: noneInfo), .success)
+    XCTAssertEqual(strategy.canLock(boundaryId: boundaryId, info: noneInfo), .success)
 
     strategy.cleanUp()
   }
@@ -505,20 +505,20 @@ final class LockmanPriorityBasedInfoIntegrationTests: XCTestCase {
     let info = TestInfoFactory.highExclusive("shared")
 
     // Same info can be locked on different boundaries
-    XCTAssertEqual(strategy.canLock(id: boundary1, info: info), .success)
-    strategy.lock(id: boundary1, info: info)
+    XCTAssertEqual(strategy.canLock(boundaryId: boundary1, info: info), .success)
+    strategy.lock(boundaryId: boundary1, info: info)
 
-    XCTAssertEqual(strategy.canLock(id: boundary2, info: info), .success)
-    strategy.lock(id: boundary2, info: info)
+    XCTAssertEqual(strategy.canLock(boundaryId: boundary2, info: info), .success)
+    strategy.lock(boundaryId: boundary2, info: info)
 
     // But duplicate on same boundary fails
-    XCTAssertLockFailure(strategy.canLock(id: boundary1, info: info))
-    XCTAssertLockFailure(strategy.canLock(id: boundary2, info: info))
+    XCTAssertLockFailure(strategy.canLock(boundaryId: boundary1, info: info))
+    XCTAssertLockFailure(strategy.canLock(boundaryId: boundary2, info: info))
 
     // Cleanup only affects specific boundary
-    strategy.cleanUp(id: boundary1)
-    XCTAssertEqual(strategy.canLock(id: boundary1, info: info), .success)
-    XCTAssertLockFailure(strategy.canLock(id: boundary2, info: info))  // Still locked
+    strategy.cleanUp(boundaryId: boundary1)
+    XCTAssertEqual(strategy.canLock(boundaryId: boundary1, info: info), .success)
+    XCTAssertLockFailure(strategy.canLock(boundaryId: boundary2, info: info))  // Still locked
 
     strategy.cleanUp()
   }

--- a/Tests/LockmanTests/Core/Strategies/PriorityBasedStrategy/LockmanPriorityBasedStrategyTests.swift
+++ b/Tests/LockmanTests/Core/Strategies/PriorityBasedStrategy/LockmanPriorityBasedStrategyTests.swift
@@ -87,9 +87,9 @@ final class LockmanPriorityBasedStrategyTests: XCTestCase {
 
     // Verify state isolation
     let info = TestInfoFactory.highExclusive("test")
-    strategy1.lock(id: TestBoundaryId.default, info: info)
+    strategy1.lock(boundaryId: TestBoundaryId.default, info: info)
 
-    XCTAssertEqual(strategy2.canLock(id: TestBoundaryId.default, info: info), .success)
+    XCTAssertEqual(strategy2.canLock(boundaryId: TestBoundaryId.default, info: info), .success)
 
     strategy1.cleanUp()
   }
@@ -118,13 +118,13 @@ final class LockmanPriorityBasedStrategyTests: XCTestCase {
     let highInfo = TestInfoFactory.highExclusive("blocker")
 
     // None priority succeeds on empty state
-    XCTAssertEqual(strategy.canLock(id: id, info: noneInfo), .success)
+    XCTAssertEqual(strategy.canLock(boundaryId: id, info: noneInfo), .success)
 
     // Lock with high priority to create contention
-    strategy.lock(id: id, info: highInfo)
+    strategy.lock(boundaryId: id, info: highInfo)
 
     // None priority should still succeed
-    XCTAssertEqual(strategy.canLock(id: id, info: noneInfo), .success)
+    XCTAssertEqual(strategy.canLock(boundaryId: id, info: noneInfo), .success)
 
     strategy.cleanUp()
   }
@@ -139,9 +139,9 @@ final class LockmanPriorityBasedStrategyTests: XCTestCase {
     ]
 
     for info in testCases {
-      XCTAssertEqual(strategy.canLock(id: id, info: info), .success)
-      strategy.lock(id: id, info: info)
-      strategy.unlock(id: id, info: info)
+      XCTAssertEqual(strategy.canLock(boundaryId: id, info: info), .success)
+      strategy.lock(boundaryId: id, info: info)
+      strategy.unlock(boundaryId: id, info: info)
     }
   }
 
@@ -151,10 +151,10 @@ final class LockmanPriorityBasedStrategyTests: XCTestCase {
     let info1 = TestInfoFactory.highExclusive("duplicate")
     let info2 = TestInfoFactory.highExclusive("duplicate")  // Same action ID
 
-    strategy.lock(id: id, info: info1)
-    XCTAssertLockFailure(strategy.canLock(id: id, info: info2))
+    strategy.lock(boundaryId: id, info: info1)
+    XCTAssertLockFailure(strategy.canLock(boundaryId: id, info: info2))
 
-    strategy.unlock(id: id, info: info1)
+    strategy.unlock(boundaryId: id, info: info1)
   }
 
   // MARK: - Priority Hierarchy
@@ -169,8 +169,9 @@ final class LockmanPriorityBasedStrategyTests: XCTestCase {
     ]
 
     for (lowerInfo, higherInfo) in testCases {
-      strategy.lock(id: id, info: lowerInfo)
-      if case .successWithPrecedingCancellation = strategy.canLock(id: id, info: higherInfo) {
+      strategy.lock(boundaryId: id, info: lowerInfo)
+      if case .successWithPrecedingCancellation = strategy.canLock(boundaryId: id, info: higherInfo)
+      {
         // Success - expected behavior
       } else {
         XCTFail("Expected successWithPrecedingCancellation")
@@ -189,8 +190,8 @@ final class LockmanPriorityBasedStrategyTests: XCTestCase {
     ]
 
     for (higherInfo, lowerInfo) in testCases {
-      strategy.lock(id: id, info: higherInfo)
-      XCTAssertLockFailure(strategy.canLock(id: id, info: lowerInfo))
+      strategy.lock(boundaryId: id, info: higherInfo)
+      XCTAssertLockFailure(strategy.canLock(boundaryId: id, info: lowerInfo))
       strategy.cleanUp()
     }
   }
@@ -207,9 +208,9 @@ final class LockmanPriorityBasedStrategyTests: XCTestCase {
     ]
 
     for (firstInfo, secondInfo) in testCases {
-      strategy.lock(id: id, info: firstInfo)
+      strategy.lock(boundaryId: id, info: firstInfo)
       // Second action follows first action's exclusive behavior
-      XCTAssertLockFailure(strategy.canLock(id: id, info: secondInfo))
+      XCTAssertLockFailure(strategy.canLock(boundaryId: id, info: secondInfo))
       strategy.cleanUp()
     }
   }
@@ -224,9 +225,10 @@ final class LockmanPriorityBasedStrategyTests: XCTestCase {
     ]
 
     for (firstInfo, secondInfo) in testCases {
-      strategy.lock(id: id, info: firstInfo)
+      strategy.lock(boundaryId: id, info: firstInfo)
       // Second action follows first action's replaceable behavior
-      if case .successWithPrecedingCancellation = strategy.canLock(id: id, info: secondInfo) {
+      if case .successWithPrecedingCancellation = strategy.canLock(boundaryId: id, info: secondInfo)
+      {
         // Success - expected behavior
       } else {
         XCTFail("Expected successWithPrecedingCancellation")
@@ -242,12 +244,12 @@ final class LockmanPriorityBasedStrategyTests: XCTestCase {
     let id = TestBoundaryId.default
     let info = TestInfoFactory.highExclusive("test")
 
-    XCTAssertEqual(strategy.canLock(id: id, info: info), .success)
-    strategy.lock(id: id, info: info)
-    XCTAssertLockFailure(strategy.canLock(id: id, info: info))
+    XCTAssertEqual(strategy.canLock(boundaryId: id, info: info), .success)
+    strategy.lock(boundaryId: id, info: info)
+    XCTAssertLockFailure(strategy.canLock(boundaryId: id, info: info))
 
-    strategy.unlock(id: id, info: info)
-    XCTAssertEqual(strategy.canLock(id: id, info: info), .success)
+    strategy.unlock(boundaryId: id, info: info)
+    XCTAssertEqual(strategy.canLock(boundaryId: id, info: info), .success)
   }
 
   func testUnlockWithNonePriorityIsSafeNoop() {
@@ -256,12 +258,12 @@ final class LockmanPriorityBasedStrategyTests: XCTestCase {
     let noneInfo = TestInfoFactory.none()
     let highInfo = TestInfoFactory.highExclusive("high")
 
-    strategy.lock(id: id, info: highInfo)
-    strategy.unlock(id: id, info: noneInfo)  // Should not affect state
+    strategy.lock(boundaryId: id, info: highInfo)
+    strategy.unlock(boundaryId: id, info: noneInfo)  // Should not affect state
 
-    XCTAssertLockFailure(strategy.canLock(id: id, info: highInfo))
+    XCTAssertLockFailure(strategy.canLock(boundaryId: id, info: highInfo))
 
-    strategy.unlock(id: id, info: highInfo)
+    strategy.unlock(boundaryId: id, info: highInfo)
   }
 
   // MARK: - Boundary Isolation
@@ -273,14 +275,14 @@ final class LockmanPriorityBasedStrategyTests: XCTestCase {
     let info = TestInfoFactory.highExclusive("shared")
 
     // Same info can be locked on different boundaries
-    strategy.lock(id: id1, info: info)
-    XCTAssertEqual(strategy.canLock(id: id2, info: info), .success)
-    strategy.lock(id: id2, info: info)
+    strategy.lock(boundaryId: id1, info: info)
+    XCTAssertEqual(strategy.canLock(boundaryId: id2, info: info), .success)
+    strategy.lock(boundaryId: id2, info: info)
 
     // Unlock only affects specific boundary
-    strategy.unlock(id: id1, info: info)
-    XCTAssertEqual(strategy.canLock(id: id1, info: info), .success)
-    XCTAssertLockFailure(strategy.canLock(id: id2, info: info))
+    strategy.unlock(boundaryId: id1, info: info)
+    XCTAssertEqual(strategy.canLock(boundaryId: id1, info: info), .success)
+    XCTAssertLockFailure(strategy.canLock(boundaryId: id2, info: info))
 
     strategy.cleanUp()
   }
@@ -293,13 +295,13 @@ final class LockmanPriorityBasedStrategyTests: XCTestCase {
     let id2 = TestBoundaryId.boundary2
     let info = TestInfoFactory.highExclusive("action")
 
-    strategy.lock(id: id1, info: info)
-    strategy.lock(id: id2, info: info)
+    strategy.lock(boundaryId: id1, info: info)
+    strategy.lock(boundaryId: id2, info: info)
 
     strategy.cleanUp()
 
-    XCTAssertEqual(strategy.canLock(id: id1, info: info), .success)
-    XCTAssertEqual(strategy.canLock(id: id2, info: info), .success)
+    XCTAssertEqual(strategy.canLock(boundaryId: id1, info: info), .success)
+    XCTAssertEqual(strategy.canLock(boundaryId: id2, info: info), .success)
   }
 
   func testBoundarySpecificCleanupPreservesOtherBoundaries() {
@@ -308,13 +310,13 @@ final class LockmanPriorityBasedStrategyTests: XCTestCase {
     let id2 = TestBoundaryId.boundary2
     let info = TestInfoFactory.highExclusive("action")
 
-    strategy.lock(id: id1, info: info)
-    strategy.lock(id: id2, info: info)
+    strategy.lock(boundaryId: id1, info: info)
+    strategy.lock(boundaryId: id2, info: info)
 
-    strategy.cleanUp(id: id1)
+    strategy.cleanUp(boundaryId: id1)
 
-    XCTAssertEqual(strategy.canLock(id: id1, info: info), .success)
-    XCTAssertLockFailure(strategy.canLock(id: id2, info: info))
+    XCTAssertEqual(strategy.canLock(boundaryId: id1, info: info), .success)
+    XCTAssertLockFailure(strategy.canLock(boundaryId: id2, info: info))
 
     strategy.cleanUp()
   }
@@ -329,21 +331,21 @@ final class LockmanPriorityBasedStrategyTests: XCTestCase {
     let highInfo = TestInfoFactory.highExclusive("high")
 
     // Start with low priority
-    strategy.lock(id: id, info: lowInfo)
+    strategy.lock(boundaryId: id, info: lowInfo)
 
     // None priority always succeeds
-    XCTAssertEqual(strategy.canLock(id: id, info: noneInfo), .success)
+    XCTAssertEqual(strategy.canLock(boundaryId: id, info: noneInfo), .success)
 
     // High priority preempts low priority
-    if case .successWithPrecedingCancellation = strategy.canLock(id: id, info: highInfo) {
+    if case .successWithPrecedingCancellation = strategy.canLock(boundaryId: id, info: highInfo) {
       // Success - expected behavior
     } else {
       XCTFail("Expected successWithPrecedingCancellation")
     }
-    strategy.lock(id: id, info: highInfo)
+    strategy.lock(boundaryId: id, info: highInfo)
 
     // Low priority now fails against high priority
-    XCTAssertLockFailure(strategy.canLock(id: id, info: lowInfo))
+    XCTAssertLockFailure(strategy.canLock(boundaryId: id, info: lowInfo))
 
     strategy.cleanUp()
   }
@@ -358,26 +360,31 @@ final class LockmanPriorityBasedStrategyTests: XCTestCase {
     let highExclusive = TestInfoFactory.highExclusive("high2")
 
     // Start with low replaceable
-    strategy.lock(id: id, info: lowReplaceable)
+    strategy.lock(boundaryId: id, info: lowReplaceable)
 
     // Low exclusive can replace low replaceable
-    if case .successWithPrecedingCancellation = strategy.canLock(id: id, info: lowExclusive) {
+    if case .successWithPrecedingCancellation = strategy.canLock(boundaryId: id, info: lowExclusive)
+    {
       // Success - expected behavior
     } else {
       XCTFail("Expected successWithPrecedingCancellation")
     }
-    strategy.lock(id: id, info: lowExclusive)
+    strategy.lock(boundaryId: id, info: lowExclusive)
 
     // High replaceable preempts low exclusive
-    if case .successWithPrecedingCancellation = strategy.canLock(id: id, info: highReplaceable) {
+    if case .successWithPrecedingCancellation = strategy.canLock(
+      boundaryId: id, info: highReplaceable)
+    {
       // Success - expected behavior
     } else {
       XCTFail("Expected successWithPrecedingCancellation")
     }
-    strategy.lock(id: id, info: highReplaceable)
+    strategy.lock(boundaryId: id, info: highReplaceable)
 
     // High exclusive can replace high replaceable
-    if case .successWithPrecedingCancellation = strategy.canLock(id: id, info: highExclusive) {
+    if case .successWithPrecedingCancellation = strategy.canLock(
+      boundaryId: id, info: highExclusive)
+    {
       // Success - expected behavior
     } else {
       XCTFail("Expected successWithPrecedingCancellation")
@@ -398,7 +405,7 @@ final class LockmanPriorityBasedStrategyTests: XCTestCase {
       for i in 0..<10 {
         group.addTask {
           let info = TestInfoFactory.highExclusive("action\(i)")
-          return strategy.canLock(id: id, info: info)
+          return strategy.canLock(boundaryId: id, info: info)
         }
       }
 
@@ -425,17 +432,17 @@ final class LockmanPriorityBasedStrategyTests: XCTestCase {
     ) { group in
       group.addTask {
         let info = TestInfoFactory.lowReplaceable("low")
-        return ("low", strategy.canLock(id: id, info: info))
+        return ("low", strategy.canLock(boundaryId: id, info: info))
       }
 
       group.addTask {
         let info = TestInfoFactory.highExclusive("high")
-        return ("high", strategy.canLock(id: id, info: info))
+        return ("high", strategy.canLock(boundaryId: id, info: info))
       }
 
       group.addTask {
         let info = TestInfoFactory.none("none")
-        return ("none", strategy.canLock(id: id, info: info))
+        return ("none", strategy.canLock(boundaryId: id, info: info))
       }
 
       var results: [(String, LockmanResult)] = []
@@ -474,18 +481,19 @@ final class LockmanPriorityBasedStrategyTests: XCTestCase {
     let lowExclusive = TestInfoFactory.lowExclusive("lowExcl")
 
     // Lock with replaceable behavior
-    strategy.lock(id: id, info: lowReplaceable)
+    strategy.lock(boundaryId: id, info: lowReplaceable)
 
     // Exclusive can replace replaceable
-    if case .successWithPrecedingCancellation = strategy.canLock(id: id, info: lowExclusive) {
+    if case .successWithPrecedingCancellation = strategy.canLock(boundaryId: id, info: lowExclusive)
+    {
       // Success - expected behavior
     } else {
       XCTFail("Expected successWithPrecedingCancellation")
     }
-    strategy.lock(id: id, info: lowExclusive)
+    strategy.lock(boundaryId: id, info: lowExclusive)
 
     // Now replaceable cannot replace exclusive
-    XCTAssertLockFailure(strategy.canLock(id: id, info: lowReplaceable))
+    XCTAssertLockFailure(strategy.canLock(boundaryId: id, info: lowReplaceable))
 
     strategy.cleanUp()
   }
@@ -498,11 +506,11 @@ final class LockmanPriorityBasedStrategyTests: XCTestCase {
 
     // Lock a low priority action
     let lowAction = TestInfoFactory.lowExclusive("lowAction")
-    strategy.lock(id: id, info: lowAction)
+    strategy.lock(boundaryId: id, info: lowAction)
 
     // Try to lock a high priority action
     let highAction = TestInfoFactory.highExclusive("highAction")
-    let result = strategy.canLock(id: id, info: highAction)
+    let result = strategy.canLock(boundaryId: id, info: highAction)
 
     // Should succeed with preceding cancellation
     switch result {
@@ -533,11 +541,11 @@ final class LockmanPriorityBasedStrategyTests: XCTestCase {
 
     // Lock a replaceable action
     let replaceableAction = TestInfoFactory.lowReplaceable("replaceableAction")
-    strategy.lock(id: id, info: replaceableAction)
+    strategy.lock(boundaryId: id, info: replaceableAction)
 
     // Try to lock another low priority action (should replace the existing one)
     let newAction = TestInfoFactory.lowExclusive("newAction")
-    let result = strategy.canLock(id: id, info: newAction)
+    let result = strategy.canLock(boundaryId: id, info: newAction)
 
     // Should succeed with preceding cancellation
     switch result {

--- a/Tests/LockmanTests/Core/Strategies/SingleExecutionStrategy/LockmanSingleExecutionActionTests.swift
+++ b/Tests/LockmanTests/Core/Strategies/SingleExecutionStrategy/LockmanSingleExecutionActionTests.swift
@@ -153,11 +153,11 @@ final class LockmanSingleExecutionActionTests: XCTestCase {
         let boundaryId = "test-boundary"
         let info = action.lockmanInfo
 
-        XCTAssertEqual(strategy.canLock(id: boundaryId, info: info), .success)
-        strategy.lock(id: boundaryId, info: info)
-        XCTAssertLockFailure(strategy.canLock(id: boundaryId, info: info))
-        strategy.unlock(id: boundaryId, info: info)
-        XCTAssertEqual(strategy.canLock(id: boundaryId, info: info), .success)
+        XCTAssertEqual(strategy.canLock(boundaryId: boundaryId, info: info), .success)
+        strategy.lock(boundaryId: boundaryId, info: info)
+        XCTAssertLockFailure(strategy.canLock(boundaryId: boundaryId, info: info))
+        strategy.unlock(boundaryId: boundaryId, info: info)
+        XCTAssertEqual(strategy.canLock(boundaryId: boundaryId, info: info), .success)
       } catch {
         XCTFail("Strategy resolution should succeed")
       }
@@ -173,15 +173,15 @@ final class LockmanSingleExecutionActionTests: XCTestCase {
     let action2 = ParameterizedAction.fetchUser(id: "123")
 
     // First lock should succeed
-    XCTAssertEqual(strategy.canLock(id: boundaryId, info: action1.lockmanInfo), .success)
-    strategy.lock(id: boundaryId, info: action1.lockmanInfo)
+    XCTAssertEqual(strategy.canLock(boundaryId: boundaryId, info: action1.lockmanInfo), .success)
+    strategy.lock(boundaryId: boundaryId, info: action1.lockmanInfo)
 
     // Second lock should fail (boundary is locked)
-    XCTAssertLockFailure(strategy.canLock(id: boundaryId, info: action2.lockmanInfo))
+    XCTAssertLockFailure(strategy.canLock(boundaryId: boundaryId, info: action2.lockmanInfo))
 
     // Different action should also fail (boundary is locked)
     let action3 = ParameterizedAction.fetchUser(id: "456")
-    XCTAssertLockFailure(strategy.canLock(id: boundaryId, info: action3.lockmanInfo))
+    XCTAssertLockFailure(strategy.canLock(boundaryId: boundaryId, info: action3.lockmanInfo))
 
     // Cleanup
     strategy.cleanUp()

--- a/Tests/LockmanTests/Core/Strategies/SingleExecutionStrategy/LockmanSingleExecutionInfoTests.swift
+++ b/Tests/LockmanTests/Core/Strategies/SingleExecutionStrategy/LockmanSingleExecutionInfoTests.swift
@@ -264,21 +264,21 @@ final class LockmanSingleExecutionInfoIntegrationTests: XCTestCase {
     let info2 = LockmanSingleExecutionInfo(actionId: "action2", mode: .boundary)
 
     // First lock should succeed
-    XCTAssertEqual(strategy.canLock(id: boundaryId, info: info1), .success)
-    strategy.lock(id: boundaryId, info: info1)
+    XCTAssertEqual(strategy.canLock(boundaryId: boundaryId, info: info1), .success)
+    strategy.lock(boundaryId: boundaryId, info: info1)
 
     // Different action should fail (boundary is locked)
-    XCTAssertLockFailure(strategy.canLock(id: boundaryId, info: info2))
+    XCTAssertLockFailure(strategy.canLock(boundaryId: boundaryId, info: info2))
 
     // Unlock first
-    strategy.unlock(id: boundaryId, info: info1)
+    strategy.unlock(boundaryId: boundaryId, info: info1)
 
     // Now second action should succeed
-    XCTAssertEqual(strategy.canLock(id: boundaryId, info: info2), .success)
-    strategy.lock(id: boundaryId, info: info2)
+    XCTAssertEqual(strategy.canLock(boundaryId: boundaryId, info: info2), .success)
+    strategy.lock(boundaryId: boundaryId, info: info2)
 
     // Cleanup
-    strategy.unlock(id: boundaryId, info: info2)
+    strategy.unlock(boundaryId: boundaryId, info: info2)
   }
 
   func testComplexIntegrationScenario() {
@@ -290,19 +290,19 @@ final class LockmanSingleExecutionInfoIntegrationTests: XCTestCase {
     let stringInfo = LockmanSingleExecutionInfo(actionId: "stringAction", mode: .boundary)
 
     // Lock different actions on different boundaries
-    strategy.lock(id: boundaryId1, info: stringInfo)
+    strategy.lock(boundaryId: boundaryId1, info: stringInfo)
 
     // Same actions on different boundaries should be allowed
-    XCTAssertEqual(strategy.canLock(id: boundaryId2, info: stringInfo), .success)
+    XCTAssertEqual(strategy.canLock(boundaryId: boundaryId2, info: stringInfo), .success)
 
     // Any action on same boundary should fail
-    XCTAssertLockFailure(strategy.canLock(id: boundaryId1, info: stringInfo))
+    XCTAssertLockFailure(strategy.canLock(boundaryId: boundaryId1, info: stringInfo))
 
     // Cleanup one boundary
-    strategy.cleanUp(id: boundaryId1)
+    strategy.cleanUp(boundaryId: boundaryId1)
 
     // Now should be able to lock on boundary1 again
-    XCTAssertEqual(strategy.canLock(id: boundaryId1, info: stringInfo), .success)
+    XCTAssertEqual(strategy.canLock(boundaryId: boundaryId1, info: stringInfo), .success)
 
     // Full cleanup
     strategy.cleanUp()
@@ -319,9 +319,9 @@ final class LockmanSingleExecutionInfoIntegrationTests: XCTestCase {
       for i in 0..<10 {
         group.addTask {
           let info = LockmanSingleExecutionInfo(actionId: "action_\(i)", mode: .boundary)
-          let result = strategy.canLock(id: boundaryId, info: info)
+          let result = strategy.canLock(boundaryId: boundaryId, info: info)
           if result == .success {
-            strategy.lock(id: boundaryId, info: info)
+            strategy.lock(boundaryId: boundaryId, info: info)
             return ("action_\(i)", true)
           }
           return ("action_\(i)", false)
@@ -351,7 +351,7 @@ final class LockmanSingleExecutionInfoIntegrationTests: XCTestCase {
     )
 
     // Cleanup - both specific boundary and general cleanup
-    strategy.cleanUp(id: boundaryId)
+    strategy.cleanUp(boundaryId: boundaryId)
     strategy.cleanUp()
   }
 

--- a/Tests/LockmanTests/Core/Strategies/SingleExecutionStrategy/LockmanSingleExecutionStrategyTests.swift
+++ b/Tests/LockmanTests/Core/Strategies/SingleExecutionStrategy/LockmanSingleExecutionStrategyTests.swift
@@ -62,10 +62,10 @@ final class LockmanSingleExecutionStrategyTests: XCTestCase {
     let info2 = LockmanSingleExecutionInfo(actionId: "action2", mode: .boundary)
 
     // Lock first action
-    strategy.lock(id: id, info: info1)
+    strategy.lock(boundaryId: id, info: info1)
 
     // Different action should fail in boundary mode
-    XCTAssertLockFailure(strategy.canLock(id: id, info: info2))
+    XCTAssertLockFailure(strategy.canLock(boundaryId: id, info: info2))
 
     // Cleanup
     strategy.cleanUp()
@@ -78,7 +78,7 @@ final class LockmanSingleExecutionStrategyTests: XCTestCase {
     let id = TestBoundaryId("test")
     let info = LockmanSingleExecutionInfo(actionId: "action", mode: .boundary)
 
-    let result = strategy.canLock(id: id, info: info)
+    let result = strategy.canLock(boundaryId: id, info: info)
     XCTAssertEqual(result, .success)
   }
 
@@ -88,16 +88,16 @@ final class LockmanSingleExecutionStrategyTests: XCTestCase {
     let info = LockmanSingleExecutionInfo(actionId: "action", mode: .boundary)
 
     // First lock should succeed
-    let result1 = strategy.canLock(id: id, info: info)
+    let result1 = strategy.canLock(boundaryId: id, info: info)
     XCTAssertEqual(result1, .success)
-    strategy.lock(id: id, info: info)
+    strategy.lock(boundaryId: id, info: info)
 
     // Second lock should fail
-    let result2 = strategy.canLock(id: id, info: info)
+    let result2 = strategy.canLock(boundaryId: id, info: info)
     XCTAssertLockFailure(result2)
 
     // Cleanup for isolation
-    strategy.unlock(id: id, info: info)
+    strategy.unlock(boundaryId: id, info: info)
   }
 
   func testAnySecondLockOnSameBoundaryFails() {
@@ -107,16 +107,16 @@ final class LockmanSingleExecutionStrategyTests: XCTestCase {
     let info2 = LockmanSingleExecutionInfo(actionId: "action1", mode: .boundary)  // Same actionId
 
     // First lock should succeed
-    let result1 = strategy.canLock(id: id, info: info1)
+    let result1 = strategy.canLock(boundaryId: id, info: info1)
     XCTAssertEqual(result1, .success)
-    strategy.lock(id: id, info: info1)
+    strategy.lock(boundaryId: id, info: info1)
 
     // Second lock should fail (any lock fails when boundary is locked)
-    let result2 = strategy.canLock(id: id, info: info2)
+    let result2 = strategy.canLock(boundaryId: id, info: info2)
     XCTAssertLockFailure(result2)
 
     // Cleanup
-    strategy.unlock(id: id, info: info1)
+    strategy.unlock(boundaryId: id, info: info1)
   }
 
   // MARK: - Unlock Tests
@@ -127,15 +127,15 @@ final class LockmanSingleExecutionStrategyTests: XCTestCase {
     let info = LockmanSingleExecutionInfo(actionId: "action", mode: .boundary)
 
     // Lock
-    let result1 = strategy.canLock(id: id, info: info)
+    let result1 = strategy.canLock(boundaryId: id, info: info)
     XCTAssertEqual(result1, .success)
-    strategy.lock(id: id, info: info)
+    strategy.lock(boundaryId: id, info: info)
 
     // Unlock
-    strategy.unlock(id: id, info: info)
+    strategy.unlock(boundaryId: id, info: info)
 
     // Lock again should succeed
-    let result2 = strategy.canLock(id: id, info: info)
+    let result2 = strategy.canLock(boundaryId: id, info: info)
     XCTAssertEqual(result2, .success)
   }
 
@@ -145,10 +145,10 @@ final class LockmanSingleExecutionStrategyTests: XCTestCase {
     let info = LockmanSingleExecutionInfo(actionId: "action", mode: .boundary)
 
     // Should not crash
-    strategy.unlock(id: id, info: info)
+    strategy.unlock(boundaryId: id, info: info)
 
     // Should still be able to lock after invalid unlock
-    let result = strategy.canLock(id: id, info: info)
+    let result = strategy.canLock(boundaryId: id, info: info)
     XCTAssertEqual(result, .success)
   }
 
@@ -161,18 +161,18 @@ final class LockmanSingleExecutionStrategyTests: XCTestCase {
     let info = LockmanSingleExecutionInfo(actionId: "action", mode: .boundary)
 
     // Lock with id1
-    let result1 = strategy.canLock(id: id1, info: info)
+    let result1 = strategy.canLock(boundaryId: id1, info: info)
     XCTAssertEqual(result1, .success)
-    strategy.lock(id: id1, info: info)
+    strategy.lock(boundaryId: id1, info: info)
 
     // Lock with id2 should also succeed (different boundary)
-    let result2 = strategy.canLock(id: id2, info: info)
+    let result2 = strategy.canLock(boundaryId: id2, info: info)
     XCTAssertEqual(result2, .success)
-    strategy.lock(id: id2, info: info)
+    strategy.lock(boundaryId: id2, info: info)
 
     // Cleanup
-    strategy.unlock(id: id1, info: info)
-    strategy.unlock(id: id2, info: info)
+    strategy.unlock(boundaryId: id1, info: info)
+    strategy.unlock(boundaryId: id2, info: info)
   }
 
   func testUnlockAffectsOnlySpecificBoundary() {
@@ -182,22 +182,22 @@ final class LockmanSingleExecutionStrategyTests: XCTestCase {
     let info = LockmanSingleExecutionInfo(actionId: "action", mode: .boundary)
 
     // Lock both boundaries
-    strategy.lock(id: id1, info: info)
-    strategy.lock(id: id2, info: info)
+    strategy.lock(boundaryId: id1, info: info)
+    strategy.lock(boundaryId: id2, info: info)
 
     // Unlock only id1
-    strategy.unlock(id: id1, info: info)
+    strategy.unlock(boundaryId: id1, info: info)
 
     // id1 should be able to lock again
-    let result1 = strategy.canLock(id: id1, info: info)
+    let result1 = strategy.canLock(boundaryId: id1, info: info)
     XCTAssertEqual(result1, .success)
 
     // id2 should still be locked
-    let result2 = strategy.canLock(id: id2, info: info)
+    let result2 = strategy.canLock(boundaryId: id2, info: info)
     XCTAssertLockFailure(result2)
 
     // Cleanup id2
-    strategy.unlock(id: id2, info: info)
+    strategy.unlock(boundaryId: id2, info: info)
   }
 
   // MARK: - CleanUp Tests
@@ -209,15 +209,15 @@ final class LockmanSingleExecutionStrategyTests: XCTestCase {
     let info = LockmanSingleExecutionInfo(actionId: "action", mode: .boundary)
 
     // Lock multiple boundaries
-    strategy.lock(id: id1, info: info)
-    strategy.lock(id: id2, info: info)
+    strategy.lock(boundaryId: id1, info: info)
+    strategy.lock(boundaryId: id2, info: info)
 
     // Clean up all
     strategy.cleanUp()
 
     // Both should be able to lock again
-    let result1 = strategy.canLock(id: id1, info: info)
-    let result2 = strategy.canLock(id: id2, info: info)
+    let result1 = strategy.canLock(boundaryId: id1, info: info)
+    let result2 = strategy.canLock(boundaryId: id2, info: info)
 
     XCTAssertEqual(result1, .success)
     XCTAssertEqual(result2, .success)
@@ -230,22 +230,22 @@ final class LockmanSingleExecutionStrategyTests: XCTestCase {
     let info = LockmanSingleExecutionInfo(actionId: "action", mode: .boundary)
 
     // Lock both boundaries
-    strategy.lock(id: id1, info: info)
-    strategy.lock(id: id2, info: info)
+    strategy.lock(boundaryId: id1, info: info)
+    strategy.lock(boundaryId: id2, info: info)
 
     // Clean up only id1
-    strategy.cleanUp(id: id1)
+    strategy.cleanUp(boundaryId: id1)
 
     // id1 should be able to lock again
-    let result1 = strategy.canLock(id: id1, info: info)
+    let result1 = strategy.canLock(boundaryId: id1, info: info)
     XCTAssertEqual(result1, .success)
 
     // id2 should still be locked
-    let result2 = strategy.canLock(id: id2, info: info)
+    let result2 = strategy.canLock(boundaryId: id2, info: info)
     XCTAssertLockFailure(result2)
 
     // Cleanup id2
-    strategy.cleanUp(id: id2)
+    strategy.cleanUp(boundaryId: id2)
   }
 
   // MARK: - Lock/Unlock Sequence Tests
@@ -258,16 +258,16 @@ final class LockmanSingleExecutionStrategyTests: XCTestCase {
     // Test multiple cycles
     for _ in 0..<3 {
       // Lock should succeed
-      let lockResult = strategy.canLock(id: id, info: info)
+      let lockResult = strategy.canLock(boundaryId: id, info: info)
       XCTAssertEqual(lockResult, .success)
-      strategy.lock(id: id, info: info)
+      strategy.lock(boundaryId: id, info: info)
 
       // Duplicate lock should fail
-      let duplicateResult = strategy.canLock(id: id, info: info)
+      let duplicateResult = strategy.canLock(boundaryId: id, info: info)
       XCTAssertLockFailure(duplicateResult)
 
       // Unlock
-      strategy.unlock(id: id, info: info)
+      strategy.unlock(boundaryId: id, info: info)
     }
   }
 
@@ -279,24 +279,24 @@ final class LockmanSingleExecutionStrategyTests: XCTestCase {
     let action3 = LockmanSingleExecutionInfo(actionId: "action3", mode: .boundary)
 
     // Lock action1
-    XCTAssertEqual(strategy.canLock(id: id, info: action1), .success)
-    strategy.lock(id: id, info: action1)
+    XCTAssertEqual(strategy.canLock(boundaryId: id, info: action1), .success)
+    strategy.lock(boundaryId: id, info: action1)
 
     // Lock action2 should fail (boundary is locked)
-    XCTAssertLockFailure(strategy.canLock(id: id, info: action2))
+    XCTAssertLockFailure(strategy.canLock(boundaryId: id, info: action2))
 
     // Unlock action1
-    strategy.unlock(id: id, info: action1)
+    strategy.unlock(boundaryId: id, info: action1)
 
     // Now action2 should succeed
-    XCTAssertEqual(strategy.canLock(id: id, info: action2), .success)
-    strategy.lock(id: id, info: action2)
+    XCTAssertEqual(strategy.canLock(boundaryId: id, info: action2), .success)
+    strategy.lock(boundaryId: id, info: action2)
 
     // action3 should fail
-    XCTAssertLockFailure(strategy.canLock(id: id, info: action3))
+    XCTAssertLockFailure(strategy.canLock(boundaryId: id, info: action3))
 
     // Cleanup
-    strategy.unlock(id: id, info: action2)
+    strategy.unlock(boundaryId: id, info: action2)
   }
 
   // MARK: - State Management Tests
@@ -306,11 +306,11 @@ final class LockmanSingleExecutionStrategyTests: XCTestCase {
     let id = TestBoundaryId("empty")
 
     // Cleanup on empty boundary should not crash
-    strategy.cleanUp(id: id)
+    strategy.cleanUp(boundaryId: id)
 
     // Should still be able to use the boundary
     let info = LockmanSingleExecutionInfo(actionId: "test", mode: .boundary)
-    XCTAssertEqual(strategy.canLock(id: id, info: info), .success)
+    XCTAssertEqual(strategy.canLock(boundaryId: id, info: info), .success)
   }
 
   // MARK: - Boundary Lock Tests
@@ -323,18 +323,18 @@ final class LockmanSingleExecutionStrategyTests: XCTestCase {
     let info3 = LockmanSingleExecutionInfo(actionId: "action3", mode: .boundary)
 
     // First lock succeeds
-    XCTAssertEqual(strategy.canLock(id: id, info: info1), .success)
-    strategy.lock(id: id, info: info1)
+    XCTAssertEqual(strategy.canLock(boundaryId: id, info: info1), .success)
+    strategy.lock(boundaryId: id, info: info1)
 
     // All other actions should fail regardless of actionId
-    XCTAssertLockFailure(strategy.canLock(id: id, info: info2))
-    XCTAssertLockFailure(strategy.canLock(id: id, info: info3))
+    XCTAssertLockFailure(strategy.canLock(boundaryId: id, info: info2))
+    XCTAssertLockFailure(strategy.canLock(boundaryId: id, info: info3))
 
     // Even same actionId should fail
-    XCTAssertLockFailure(strategy.canLock(id: id, info: info1))
+    XCTAssertLockFailure(strategy.canLock(boundaryId: id, info: info1))
 
     // Cleanup
-    strategy.unlock(id: id, info: info1)
+    strategy.unlock(boundaryId: id, info: info1)
   }
 
   func testAllowsLockAfterUnlock() {
@@ -344,15 +344,15 @@ final class LockmanSingleExecutionStrategyTests: XCTestCase {
     let info2 = LockmanSingleExecutionInfo(actionId: "action2", mode: .boundary)
 
     // Lock and unlock first action
-    strategy.lock(id: id, info: info1)
-    strategy.unlock(id: id, info: info1)
+    strategy.lock(boundaryId: id, info: info1)
+    strategy.unlock(boundaryId: id, info: info1)
 
     // Second action should now succeed
-    XCTAssertEqual(strategy.canLock(id: id, info: info2), .success)
-    strategy.lock(id: id, info: info2)
+    XCTAssertEqual(strategy.canLock(boundaryId: id, info: info2), .success)
+    strategy.lock(boundaryId: id, info: info2)
 
     // Cleanup
-    strategy.unlock(id: id, info: info2)
+    strategy.unlock(boundaryId: id, info: info2)
   }
 
   func testSharedInstanceBehavior() {
@@ -362,13 +362,13 @@ final class LockmanSingleExecutionStrategyTests: XCTestCase {
     let info2 = LockmanSingleExecutionInfo(actionId: "action2", mode: .boundary)
 
     // Lock first action
-    strategy.lock(id: id, info: info1)
+    strategy.lock(boundaryId: id, info: info1)
 
     // Different action should fail
-    XCTAssertLockFailure(strategy.canLock(id: id, info: info2))
+    XCTAssertLockFailure(strategy.canLock(boundaryId: id, info: info2))
 
     // Cleanup
-    strategy.cleanUp(id: id)
+    strategy.cleanUp(boundaryId: id)
   }
 
   // MARK: - Thread Safety Tests
@@ -382,9 +382,9 @@ final class LockmanSingleExecutionStrategyTests: XCTestCase {
         group.addTask {
           let id = TestBoundaryId("test\(i)")
           let info = LockmanSingleExecutionInfo(actionId: "action", mode: .boundary)
-          let result = strategy.canLock(id: id, info: info)
+          let result = strategy.canLock(boundaryId: id, info: info)
           if result == .success {
-            strategy.lock(id: id, info: info)
+            strategy.lock(boundaryId: id, info: info)
           }
           return result == .success
         }
@@ -415,7 +415,7 @@ final class LockmanSingleExecutionStrategyTests: XCTestCase {
       for _ in 0..<5 {
         group.addTask {
           let info = LockmanSingleExecutionInfo(actionId: "action", mode: .boundary)
-          return strategy.canLock(id: id, info: info)
+          return strategy.canLock(boundaryId: id, info: info)
         }
       }
 
@@ -447,7 +447,7 @@ final class LockmanSingleExecutionStrategyTests: XCTestCase {
       for i in 0..<5 {
         group.addTask {
           let info = LockmanSingleExecutionInfo(actionId: "action\(i)", mode: .boundary)
-          let result = strategy.canLock(id: id, info: info)
+          let result = strategy.canLock(boundaryId: id, info: info)
           return ("action\(i)", result)
         }
       }
@@ -477,17 +477,17 @@ final class LockmanSingleExecutionStrategyTests: XCTestCase {
     let action2 = LockmanSingleExecutionInfo(actionId: "action2", mode: .boundary)
 
     // Test that the strategy correctly uses its internal state
-    XCTAssertEqual(strategy.canLock(id: id, info: action1), .success)
-    strategy.lock(id: id, info: action1)
+    XCTAssertEqual(strategy.canLock(boundaryId: id, info: action1), .success)
+    strategy.lock(boundaryId: id, info: action1)
 
     // Second action should fail (boundary is locked)
-    XCTAssertLockFailure(strategy.canLock(id: id, info: action2))
+    XCTAssertLockFailure(strategy.canLock(boundaryId: id, info: action2))
 
     // Unlock and verify state changes
-    strategy.unlock(id: id, info: action1)
+    strategy.unlock(boundaryId: id, info: action1)
 
     // Now action2 should succeed
-    XCTAssertEqual(strategy.canLock(id: id, info: action2), .success)
+    XCTAssertEqual(strategy.canLock(boundaryId: id, info: action2), .success)
 
     strategy.cleanUp()
   }
@@ -502,9 +502,9 @@ final class LockmanSingleExecutionStrategyTests: XCTestCase {
     for i in 0..<100 {
       let info = LockmanSingleExecutionInfo(actionId: "action\(i)", mode: .boundary)
 
-      XCTAssertEqual(strategy.canLock(id: id, info: info), .success)
-      strategy.lock(id: id, info: info)
-      strategy.unlock(id: id, info: info)
+      XCTAssertEqual(strategy.canLock(boundaryId: id, info: info), .success)
+      strategy.lock(boundaryId: id, info: info)
+      strategy.unlock(boundaryId: id, info: info)
     }
 
     let duration = Date().timeIntervalSince(startTime)
@@ -523,18 +523,18 @@ final class LockmanSingleExecutionStrategyTests: XCTestCase {
       boundaries.append(id)
 
       let info = LockmanSingleExecutionInfo(actionId: "action", mode: .boundary)
-      strategy.lock(id: id, info: info)
+      strategy.lock(boundaryId: id, info: info)
     }
 
     // Cleanup half of them
     for i in 0..<25 {
-      strategy.cleanUp(id: boundaries[i])
+      strategy.cleanUp(boundaryId: boundaries[i])
     }
 
     // Verify remaining boundaries are still locked
     for i in 25..<50 {
       let info = LockmanSingleExecutionInfo(actionId: "action", mode: .boundary)
-      XCTAssertLockFailure(strategy.canLock(id: boundaries[i], info: info))
+      XCTAssertLockFailure(strategy.canLock(boundaryId: boundaries[i], info: info))
     }
 
     // Full cleanup
@@ -543,7 +543,7 @@ final class LockmanSingleExecutionStrategyTests: XCTestCase {
     // All should be unlocked now
     for boundary in boundaries {
       let info = LockmanSingleExecutionInfo(actionId: "action", mode: .boundary)
-      XCTAssertEqual(strategy.canLock(id: boundary, info: info), .success)
+      XCTAssertEqual(strategy.canLock(boundaryId: boundary, info: info), .success)
     }
   }
 
@@ -556,12 +556,12 @@ final class LockmanSingleExecutionStrategyTests: XCTestCase {
     let info2 = LockmanSingleExecutionInfo(actionId: "action2", mode: .none)
 
     // First lock succeeds
-    XCTAssertEqual(strategy.canLock(id: id, info: info1), .success)
-    strategy.lock(id: id, info: info1)
+    XCTAssertEqual(strategy.canLock(boundaryId: id, info: info1), .success)
+    strategy.lock(boundaryId: id, info: info1)
 
     // Second lock also succeeds with none mode
-    XCTAssertEqual(strategy.canLock(id: id, info: info2), .success)
-    strategy.lock(id: id, info: info2)
+    XCTAssertEqual(strategy.canLock(boundaryId: id, info: info2), .success)
+    strategy.lock(boundaryId: id, info: info2)
 
     // Cleanup
     strategy.cleanUp()
@@ -574,11 +574,11 @@ final class LockmanSingleExecutionStrategyTests: XCTestCase {
     let info2 = LockmanSingleExecutionInfo(actionId: "action2", mode: .boundary)
 
     // First lock succeeds
-    XCTAssertEqual(strategy.canLock(id: id, info: info1), .success)
-    strategy.lock(id: id, info: info1)
+    XCTAssertEqual(strategy.canLock(boundaryId: id, info: info1), .success)
+    strategy.lock(boundaryId: id, info: info1)
 
     // Second lock fails (different actionId but same boundary)
-    XCTAssertLockFailure(strategy.canLock(id: id, info: info2))
+    XCTAssertLockFailure(strategy.canLock(boundaryId: id, info: info2))
 
     // Cleanup
     strategy.cleanUp()
@@ -592,15 +592,15 @@ final class LockmanSingleExecutionStrategyTests: XCTestCase {
     let info3 = LockmanSingleExecutionInfo(actionId: "action1", mode: .action)
 
     // First lock succeeds
-    XCTAssertEqual(strategy.canLock(id: id, info: info1), .success)
-    strategy.lock(id: id, info: info1)
+    XCTAssertEqual(strategy.canLock(boundaryId: id, info: info1), .success)
+    strategy.lock(boundaryId: id, info: info1)
 
     // Different actionId succeeds
-    XCTAssertEqual(strategy.canLock(id: id, info: info2), .success)
-    strategy.lock(id: id, info: info2)
+    XCTAssertEqual(strategy.canLock(boundaryId: id, info: info2), .success)
+    strategy.lock(boundaryId: id, info: info2)
 
     // Same actionId as info1 fails
-    XCTAssertLockFailure(strategy.canLock(id: id, info: info3))
+    XCTAssertLockFailure(strategy.canLock(boundaryId: id, info: info3))
 
     // Cleanup
     strategy.cleanUp()
@@ -614,15 +614,15 @@ final class LockmanSingleExecutionStrategyTests: XCTestCase {
     let noneInfo = LockmanSingleExecutionInfo(actionId: "action3", mode: .none)
 
     // Action mode lock succeeds
-    XCTAssertEqual(strategy.canLock(id: id, info: actionInfo), .success)
-    strategy.lock(id: id, info: actionInfo)
+    XCTAssertEqual(strategy.canLock(boundaryId: id, info: actionInfo), .success)
+    strategy.lock(boundaryId: id, info: actionInfo)
 
     // None mode always succeeds
-    XCTAssertEqual(strategy.canLock(id: id, info: noneInfo), .success)
-    strategy.lock(id: id, info: noneInfo)
+    XCTAssertEqual(strategy.canLock(boundaryId: id, info: noneInfo), .success)
+    strategy.lock(boundaryId: id, info: noneInfo)
 
     // Boundary mode fails because locks exist
-    XCTAssertLockFailure(strategy.canLock(id: id, info: boundaryInfo))
+    XCTAssertLockFailure(strategy.canLock(boundaryId: id, info: boundaryInfo))
 
     // Cleanup
     strategy.cleanUp()

--- a/Tests/LockmanTests/TestHelpers/AsyncTestHelpers.swift
+++ b/Tests/LockmanTests/TestHelpers/AsyncTestHelpers.swift
@@ -137,12 +137,12 @@ enum LockTestHelpers {
     boundaryId: B,
     info: S.I
   ) throws {
-    let result = strategy.canLock(id: boundaryId, info: info)
+    let result = strategy.canLock(boundaryId: boundaryId, info: info)
     XCTAssertEqual(result, .success, "Should be able to acquire lock")
 
-    strategy.lock(id: boundaryId, info: info)
+    strategy.lock(boundaryId: boundaryId, info: info)
 
-    let lockedResult = strategy.canLock(id: boundaryId, info: info)
+    let lockedResult = strategy.canLock(boundaryId: boundaryId, info: info)
     // Check if it's a failure (with or without error)
     if case .failure = lockedResult {
       // Success - it's a failure as expected
@@ -150,9 +150,9 @@ enum LockTestHelpers {
       XCTFail("Should not be able to acquire locked resource")
     }
 
-    strategy.unlock(id: boundaryId, info: info)
+    strategy.unlock(boundaryId: boundaryId, info: info)
 
-    let unlockedResult = strategy.canLock(id: boundaryId, info: info)
+    let unlockedResult = strategy.canLock(boundaryId: boundaryId, info: info)
     XCTAssertEqual(unlockedResult, .success, "Should be able to acquire after unlock")
   }
 
@@ -164,7 +164,7 @@ enum LockTestHelpers {
     attempts: Int = 5
   ) async throws -> (successful: Int, failed: Int) {
     let results = try await AsyncTestHelpers.runConcurrentOperations(count: attempts) { _ in
-      strategy.canLock(id: boundaryId, info: info)
+      strategy.canLock(boundaryId: boundaryId, info: info)
     }
 
     let successful = results.filter {
@@ -190,7 +190,7 @@ enum LockTestHelpers {
     info: S.I,
     expectedLocked: Bool
   ) {
-    let result = strategy.canLock(id: boundaryId, info: info)
+    let result = strategy.canLock(boundaryId: boundaryId, info: info)
 
     if expectedLocked {
       // Check if it's a failure (with or without error)


### PR DESCRIPTION
## Summary
- Change all Lockman API parameter names from `id` to `boundaryId` for clearer semantic meaning
- This is a breaking change planned for v1.0 release

## Changes
### Core Protocol Updates
- Update `LockmanStrategy` protocol methods to use `boundaryId` parameter
- Update `AnyLockmanStrategy` type erasure wrapper

### Strategy Implementations
- Update all 6 strategy implementations:
  - `LockmanSingleExecutionStrategy`
  - `LockmanPriorityBasedStrategy`
  - `LockmanConcurrencyLimitedStrategy`
  - `LockmanGroupCoordinationStrategy`
  - `LockmanDynamicConditionStrategy`
  - `LockmanCompositeStrategy`

### Public API Updates
- `Effect.withLock` methods now use `boundaryId:` parameter
- `Effect.concatenateWithLock` now uses `boundaryId:` parameter
- `ReduceWithLock` methods now use `boundaryId:` parameter
- `LockmanUnlock` constructor now uses `boundaryId:` parameter
- `LockmanManager.withBoundaryLock` now uses `boundaryId:` parameter

### Documentation Updates
- Updated all DocC documentation examples (13 occurrences across 8 files)
- Updated all code examples to use the new parameter name

## Migration Guide
Update all calls from:
```swift
.withLock(
  operation: { send in /* ... */ },
  action: action,
  cancelID: BoundaryID.search
)
```

To:
```swift
.withLock(
  operation: { send in /* ... */ },
  action: action,
  boundaryId: BoundaryID.search
)
```

## Testing
- All 578 tests pass successfully
- Example apps (Strategies) build successfully
- Benchmarks build successfully

## Compatibility
This is a **breaking change** that requires all users to update their code. This change is part of the v1.0 roadmap (Feature 2 in CLAUDE_WIP.md).