### PR TITLE
feat: add Effect.lock() method chain API

### DIFF
--- a/Tests/LockmanTests/Composable/EffectLockMethodTests.swift
+++ b/Tests/LockmanTests/Composable/EffectLockMethodTests.swift
@@ -79,7 +79,7 @@ final class EffectLockMethodTests: XCTestCase {
     try? container.register(strategy)
 
     await LockmanManager.withTestContainer(container) {
-      let store = TestStore(
+      let store = await TestStore(
         initialState: TestFeature.State()
       ) {
         TestFeature()
@@ -138,7 +138,7 @@ final class EffectLockMethodTests: XCTestCase {
     try? container.register(strategy)
 
     await LockmanManager.withTestContainer(container) {
-      let store = TestStore(
+      let store = await TestStore(
         initialState: TestFeature.State()
       ) {
         TestFeatureWithLockFailure()

--- a/Tests/LockmanTests/Composable/EffectLockMethodTests.swift
+++ b/Tests/LockmanTests/Composable/EffectLockMethodTests.swift
@@ -1,0 +1,167 @@
+import ComposableArchitecture
+import XCTest
+
+@testable import Lockman
+
+// MARK: - Test Feature
+
+@Reducer
+private struct TestFeature {
+  struct State: Equatable {
+    var count = 0
+    var isLoading = false
+  }
+  
+  enum Action: Equatable {
+    case fetch
+    case fetchCompleted(Int)
+    case lockFailed
+  }
+  
+  var body: some Reducer<State, Action> {
+    Reduce { state, action in
+      switch action {
+      case .fetch:
+        state.isLoading = true
+        return .run { send in
+          try await Task.sleep(nanoseconds: 100_000_000) // 0.1 seconds
+          await send(.fetchCompleted(42))
+        }
+        .lock(
+          action: action,
+          boundaryId: CancelID.fetch
+        )
+        
+      case .fetchCompleted(let value):
+        state.isLoading = false
+        state.count = value
+        return .none
+        
+      case .lockFailed:
+        state.isLoading = false
+        return .none
+      }
+    }
+  }
+  
+  enum CancelID: LockmanBoundaryId {
+    case fetch
+  }
+}
+
+// MARK: - LockmanAction Implementation
+
+extension TestFeature.Action: LockmanAction {
+  var lockmanInfo: LockmanSingleExecutionInfo {
+    switch self {
+    case .fetch:
+      return LockmanSingleExecutionInfo(
+        actionId: "fetch",
+        mode: .boundary
+      )
+    case .fetchCompleted, .lockFailed:
+      return LockmanSingleExecutionInfo(
+        actionId: "other",
+        mode: .action
+      )
+    }
+  }
+}
+
+// MARK: - Tests
+
+final class EffectLockMethodTests: XCTestCase {
+  
+  // MARK: - Basic Functionality Tests
+  
+  func testLockMethodAppliesLockToEffect() async {
+    let container = LockmanStrategyContainer()
+    let strategy = LockmanSingleExecutionStrategy()
+    try? container.register(strategy)
+    
+    await LockmanManager.withTestContainer(container) {
+      let store = TestStore(
+        initialState: TestFeature.State()
+      ) {
+        TestFeature()
+      }
+      
+      // First fetch should succeed
+      await store.send(.fetch) {
+        $0.isLoading = true
+      }
+      
+      await store.receive(\.fetchCompleted) {
+        $0.isLoading = false
+        $0.count = 42
+      }
+    }
+  }
+  
+  func testLockMethodPreventsDoubleExecution() async {
+    // Create a feature with lock failure handling
+    struct TestFeatureWithLockFailure: Reducer {
+      typealias State = TestFeature.State
+      typealias Action = TestFeature.Action
+      
+      var body: some Reducer<State, Action> {
+        Reduce { state, action in
+          switch action {
+          case .fetch:
+            state.isLoading = true
+            return .run { send in
+              try await Task.sleep(nanoseconds: 200_000_000) // 0.2 seconds
+              await send(.fetchCompleted(42))
+            }
+            .lock(
+              action: action,
+              boundaryId: TestFeature.CancelID.fetch,
+              lockFailure: { _, send in
+                await send(.lockFailed)
+              }
+            )
+            
+          case .fetchCompleted(let value):
+            state.isLoading = false
+            state.count = value
+            return .none
+            
+          case .lockFailed:
+            // Second fetch was blocked
+            return .none
+          }
+        }
+      }
+    }
+    
+    let container = LockmanStrategyContainer()
+    let strategy = LockmanSingleExecutionStrategy()
+    try? container.register(strategy)
+    
+    await LockmanManager.withTestContainer(container) {
+      let store = TestStore(
+        initialState: TestFeature.State()
+      ) {
+        TestFeatureWithLockFailure()
+      }
+      
+      // First fetch starts
+      await store.send(.fetch) {
+        $0.isLoading = true
+      }
+      
+      // Second fetch should be blocked
+      await store.send(.fetch)
+      
+      // Should receive lock failed for second attempt
+      await store.receive(\.lockFailed)
+      
+      // First fetch completes
+      await store.receive(\.fetchCompleted) {
+        $0.isLoading = false
+        $0.count = 42
+      }
+    }
+  }
+  
+}

--- a/Tests/LockmanTests/Composable/EffectLockMethodTests.swift
+++ b/Tests/LockmanTests/Composable/EffectLockMethodTests.swift
@@ -5,53 +5,12 @@ import XCTest
 
 // MARK: - Test Feature
 
-@Reducer
-private struct TestFeature {
-  struct State: Equatable {
-    var count = 0
-    var isLoading = false
-  }
-  
-  enum Action: Equatable {
-    case fetch
-    case fetchCompleted(Int)
-    case lockFailed
-  }
-  
-  var body: some Reducer<State, Action> {
-    Reduce { state, action in
-      switch action {
-      case .fetch:
-        state.isLoading = true
-        return .run { send in
-          try await Task.sleep(nanoseconds: 100_000_000) // 0.1 seconds
-          await send(.fetchCompleted(42))
-        }
-        .lock(
-          action: action,
-          boundaryId: CancelID.fetch
-        )
-        
-      case .fetchCompleted(let value):
-        state.isLoading = false
-        state.count = value
-        return .none
-        
-      case .lockFailed:
-        state.isLoading = false
-        return .none
-      }
-    }
-  }
-  
-  enum CancelID: LockmanBoundaryId {
-    case fetch
-  }
-}
+@CasePathable
+private enum TestFeatureAction: Equatable, LockmanAction {
+  case fetch
+  case fetchCompleted(Int)
+  case lockFailed
 
-// MARK: - LockmanAction Implementation
-
-extension TestFeature.Action: LockmanAction {
   var lockmanInfo: LockmanSingleExecutionInfo {
     switch self {
     case .fetch:
@@ -68,64 +27,104 @@ extension TestFeature.Action: LockmanAction {
   }
 }
 
+private enum TestFeatureCancelID: LockmanBoundaryId {
+  case fetch
+}
+
+@Reducer
+private struct TestFeature {
+  struct State: Equatable {
+    var count = 0
+    var isLoading = false
+  }
+
+  typealias Action = TestFeatureAction
+
+  var body: some Reducer<State, Action> {
+    Reduce { state, action in
+      switch action {
+      case .fetch:
+        state.isLoading = true
+        return .run { send in
+          try await Task.sleep(nanoseconds: 100_000_000)  // 0.1 seconds
+          await send(.fetchCompleted(42))
+        }
+        .lock(
+          action: action,
+          boundaryId: TestFeatureCancelID.fetch
+        )
+
+      case .fetchCompleted(let value):
+        state.isLoading = false
+        state.count = value
+        return .none
+
+      case .lockFailed:
+        state.isLoading = false
+        return .none
+      }
+    }
+  }
+}
+
 // MARK: - Tests
 
 final class EffectLockMethodTests: XCTestCase {
-  
+
   // MARK: - Basic Functionality Tests
-  
+
   func testLockMethodAppliesLockToEffect() async {
     let container = LockmanStrategyContainer()
     let strategy = LockmanSingleExecutionStrategy()
     try? container.register(strategy)
-    
+
     await LockmanManager.withTestContainer(container) {
       let store = TestStore(
         initialState: TestFeature.State()
       ) {
         TestFeature()
       }
-      
+
       // First fetch should succeed
       await store.send(.fetch) {
         $0.isLoading = true
       }
-      
+
       await store.receive(\.fetchCompleted) {
         $0.isLoading = false
         $0.count = 42
       }
     }
   }
-  
+
   func testLockMethodPreventsDoubleExecution() async {
     // Create a feature with lock failure handling
     struct TestFeatureWithLockFailure: Reducer {
       typealias State = TestFeature.State
       typealias Action = TestFeature.Action
-      
+
       var body: some Reducer<State, Action> {
         Reduce { state, action in
           switch action {
           case .fetch:
             state.isLoading = true
             return .run { send in
-              try await Task.sleep(nanoseconds: 200_000_000) // 0.2 seconds
+              try await Task.sleep(nanoseconds: 200_000_000)  // 0.2 seconds
               await send(.fetchCompleted(42))
             }
             .lock(
               action: action,
-              boundaryId: TestFeature.CancelID.fetch,
+              boundaryId: TestFeatureCancelID.fetch,
               lockFailure: { _, send in
                 await send(.lockFailed)
               }
             )
-            
+
           case .fetchCompleted(let value):
             state.isLoading = false
             state.count = value
             return .none
-            
+
           case .lockFailed:
             // Second fetch was blocked
             return .none
@@ -133,29 +132,29 @@ final class EffectLockMethodTests: XCTestCase {
         }
       }
     }
-    
+
     let container = LockmanStrategyContainer()
     let strategy = LockmanSingleExecutionStrategy()
     try? container.register(strategy)
-    
+
     await LockmanManager.withTestContainer(container) {
       let store = TestStore(
         initialState: TestFeature.State()
       ) {
         TestFeatureWithLockFailure()
       }
-      
+
       // First fetch starts
       await store.send(.fetch) {
         $0.isLoading = true
       }
-      
+
       // Second fetch should be blocked
       await store.send(.fetch)
-      
+
       // Should receive lock failed for second attempt
       await store.receive(\.lockFailed)
-      
+
       // First fetch completes
       await store.receive(\.fetchCompleted) {
         $0.isLoading = false
@@ -163,5 +162,5 @@ final class EffectLockMethodTests: XCTestCase {
       }
     }
   }
-  
+
 }


### PR DESCRIPTION
## Summary
- Add `Effect.lock()` method as a chainable alternative to `withLock`
- Implement Feature 4 from the v1.0 roadmap (CLAUDE_WIP.md)
- Provides a more natural, method chain style API for lock management

## Changes
### New API
Added `Effect.lock()` extension method that allows method chaining:
```swift
return .run { send in
  // async operation
}
.lock(action: action, boundaryId: Feature.self)
```

### Implementation Details
- The method internally uses `concatenateWithLock` for reliability
- Maintains full compatibility with existing `withLock` features
- Supports all the same parameters: `unlockOption`, `handleCancellationErrors`, `lockFailure`

### Testing
- Added comprehensive tests in `EffectLockMethodTests.swift`
- Tests cover basic functionality and double execution prevention
- All existing tests continue to pass

## Migration Guide
The new API is additive and doesn't break existing code. Users can choose between:

**Existing style:**
```swift
.withLock(
  operation: { send in /* ... */ },
  action: action,
  boundaryId: Feature.self
)
```

**New method chain style:**
```swift
.run { send in /* ... */ }
.lock(action: action, boundaryId: Feature.self)
```

## Related
- Part of v1.0 roadmap (Feature 4)
- Will be used as foundation for Feature 3 (Reducer.lock())

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>