### PR TITLE
feat: implement Reducer.lock() method for automatic locking

### DIFF
--- a/Sources/Lockman/Composable/Reducer+Lockman.swift
+++ b/Sources/Lockman/Composable/Reducer+Lockman.swift
@@ -1,0 +1,129 @@
+import ComposableArchitecture
+import Foundation
+
+/// A reducer wrapper that applies Lockman locking to effects produced by actions conforming to `LockmanAction`.
+///
+/// `LockmanReducer` intercepts effects from the base reducer and automatically applies
+/// locking behavior to actions that implement the `LockmanAction` protocol. Actions that
+/// don't conform to `LockmanAction` pass through unchanged.
+///
+/// ## Example
+/// ```swift
+/// @Reducer
+/// struct Feature {
+///   struct State: Equatable { }
+///
+///   enum Action: LockmanAction {
+///     case fetch
+///     case fetchResponse(Result<Data, Error>)
+///
+///     var lockmanInfo: LockmanSingleExecutionInfo {
+///       switch self {
+///       case .fetch:
+///         return LockmanSingleExecutionInfo(actionId: "fetch", mode: .boundary)
+///       default:
+///         return LockmanSingleExecutionInfo(actionId: "other", mode: .none)
+///       }
+///     }
+///   }
+///
+///   var body: some ReducerOf<Self> {
+///     Reduce { state, action in
+///       switch action {
+///       case .fetch:
+///         return .run { send in
+///           // This effect will be automatically locked
+///           let data = try await fetchData()
+///           await send(.fetchResponse(.success(data)))
+///         }
+///       case .fetchResponse:
+///         return .none
+///       }
+///     }
+///     .lock(boundaryId: CancelID.feature)
+///   }
+/// }
+/// ```
+public struct LockmanReducer<Base: Reducer>: Reducer {
+  public typealias State = Base.State
+  public typealias Action = Base.Action
+
+  let base: Base
+  let boundaryId: any LockmanBoundaryId
+  let unlockOption: LockmanUnlockOption
+  let lockFailure: (@Sendable (_ error: any Error, _ send: Send<Action>) async -> Void)?
+
+  public var body: some ReducerOf<Self> {
+    Reduce { state, action in
+      // Get the base effect
+      let baseEffect = self.base.reduce(into: &state, action: action)
+
+      // Check if action implements LockmanAction
+      guard let lockmanAction = action as? any LockmanAction else {
+        // Not a LockmanAction, return effect as-is
+        return baseEffect
+      }
+
+      // Apply lock to the effect using Effect.lock()
+      return baseEffect.lock(
+        action: lockmanAction,
+        boundaryId: boundaryId,
+        unlockOption: unlockOption,
+        lockFailure: lockFailure
+      )
+    }
+  }
+}
+
+// MARK: - Reducer Extension
+
+extension Reducer {
+  /// Applies Lockman locking to effects produced by this reducer.
+  ///
+  /// This method wraps the reducer to automatically apply locking to any effects
+  /// produced by actions that conform to `LockmanAction`. Actions that don't
+  /// conform to `LockmanAction` pass through unchanged.
+  ///
+  /// The locking behavior is determined by the `lockmanInfo` property of each action.
+  /// When an effect is locked:
+  /// - If the lock is acquired successfully, the effect executes normally
+  /// - If the lock fails, the `lockFailure` callback is invoked (if provided)
+  /// - The lock is automatically released based on the `unlockOption`
+  ///
+  /// ## Usage
+  /// ```swift
+  /// var body: some ReducerOf<Self> {
+  ///   Reduce { state, action in
+  ///     // Your reducer logic
+  ///   }
+  ///   .lock(
+  ///     boundaryId: CancelID.feature,
+  ///     unlockOption: .immediate,
+  ///     lockFailure: { error, send in
+  ///       print("Lock failed: \(error)")
+  ///       await send(.lockFailureHandled)
+  ///     }
+  ///   )
+  /// }
+  /// ```
+  ///
+  /// - Parameters:
+  ///   - boundaryId: The boundary identifier for locking. All actions within this
+  ///     boundary will be subject to the locking rules defined in their `lockmanInfo`.
+  ///   - unlockOption: When to release the lock. Defaults to `.immediate`.
+  ///   - lockFailure: Optional callback invoked when lock acquisition fails.
+  ///     Receives the error and a send function to dispatch actions.
+  /// - Returns: A `LockmanReducer` that wraps this reducer with locking behavior.
+  public func lock(
+    boundaryId: any LockmanBoundaryId,
+    unlockOption: LockmanUnlockOption = .immediate,
+    lockFailure: (@Sendable (_ error: any Error, _ send: Send<Action>) async -> Void)? = nil
+  ) -> LockmanReducer<Self> {
+    LockmanReducer(
+      base: self,
+      boundaryId: boundaryId,
+      unlockOption: unlockOption,
+      lockFailure: lockFailure
+    )
+  }
+}

--- a/Tests/LockmanTests/Composable/EffectLockMethodTests.swift
+++ b/Tests/LockmanTests/Composable/EffectLockMethodTests.swift
@@ -79,7 +79,7 @@ final class EffectLockMethodTests: XCTestCase {
     try? container.register(strategy)
 
     await LockmanManager.withTestContainer(container) {
-      let store = TestStore(
+      let store = await TestStore(
         initialState: TestFeature.State()
       ) {
         TestFeature()
@@ -138,7 +138,7 @@ final class EffectLockMethodTests: XCTestCase {
     try? container.register(strategy)
 
     await LockmanManager.withTestContainer(container) {
-      let store = TestStore(
+      let store = await TestStore(
         initialState: TestFeature.State()
       ) {
         TestFeatureWithLockFailure()

--- a/Tests/LockmanTests/Composable/EffectLockMethodTests.swift
+++ b/Tests/LockmanTests/Composable/EffectLockMethodTests.swift
@@ -1,0 +1,167 @@
+import ComposableArchitecture
+import XCTest
+
+@testable import Lockman
+
+// MARK: - Test Feature
+
+@Reducer
+private struct TestFeature {
+  struct State: Equatable {
+    var count = 0
+    var isLoading = false
+  }
+  
+  enum Action: Equatable {
+    case fetch
+    case fetchCompleted(Int)
+    case lockFailed
+  }
+  
+  var body: some Reducer<State, Action> {
+    Reduce { state, action in
+      switch action {
+      case .fetch:
+        state.isLoading = true
+        return .run { send in
+          try await Task.sleep(nanoseconds: 100_000_000) // 0.1 seconds
+          await send(.fetchCompleted(42))
+        }
+        .lock(
+          action: action,
+          boundaryId: CancelID.fetch
+        )
+        
+      case .fetchCompleted(let value):
+        state.isLoading = false
+        state.count = value
+        return .none
+        
+      case .lockFailed:
+        state.isLoading = false
+        return .none
+      }
+    }
+  }
+  
+  enum CancelID: LockmanBoundaryId {
+    case fetch
+  }
+}
+
+// MARK: - LockmanAction Implementation
+
+extension TestFeature.Action: LockmanAction {
+  var lockmanInfo: LockmanSingleExecutionInfo {
+    switch self {
+    case .fetch:
+      return LockmanSingleExecutionInfo(
+        actionId: "fetch",
+        mode: .boundary
+      )
+    case .fetchCompleted, .lockFailed:
+      return LockmanSingleExecutionInfo(
+        actionId: "other",
+        mode: .action
+      )
+    }
+  }
+}
+
+// MARK: - Tests
+
+final class EffectLockMethodTests: XCTestCase {
+  
+  // MARK: - Basic Functionality Tests
+  
+  func testLockMethodAppliesLockToEffect() async {
+    let container = LockmanStrategyContainer()
+    let strategy = LockmanSingleExecutionStrategy()
+    try? container.register(strategy)
+    
+    await LockmanManager.withTestContainer(container) {
+      let store = TestStore(
+        initialState: TestFeature.State()
+      ) {
+        TestFeature()
+      }
+      
+      // First fetch should succeed
+      await store.send(.fetch) {
+        $0.isLoading = true
+      }
+      
+      await store.receive(\.fetchCompleted) {
+        $0.isLoading = false
+        $0.count = 42
+      }
+    }
+  }
+  
+  func testLockMethodPreventsDoubleExecution() async {
+    // Create a feature with lock failure handling
+    struct TestFeatureWithLockFailure: Reducer {
+      typealias State = TestFeature.State
+      typealias Action = TestFeature.Action
+      
+      var body: some Reducer<State, Action> {
+        Reduce { state, action in
+          switch action {
+          case .fetch:
+            state.isLoading = true
+            return .run { send in
+              try await Task.sleep(nanoseconds: 200_000_000) // 0.2 seconds
+              await send(.fetchCompleted(42))
+            }
+            .lock(
+              action: action,
+              boundaryId: TestFeature.CancelID.fetch,
+              lockFailure: { _, send in
+                await send(.lockFailed)
+              }
+            )
+            
+          case .fetchCompleted(let value):
+            state.isLoading = false
+            state.count = value
+            return .none
+            
+          case .lockFailed:
+            // Second fetch was blocked
+            return .none
+          }
+        }
+      }
+    }
+    
+    let container = LockmanStrategyContainer()
+    let strategy = LockmanSingleExecutionStrategy()
+    try? container.register(strategy)
+    
+    await LockmanManager.withTestContainer(container) {
+      let store = TestStore(
+        initialState: TestFeature.State()
+      ) {
+        TestFeatureWithLockFailure()
+      }
+      
+      // First fetch starts
+      await store.send(.fetch) {
+        $0.isLoading = true
+      }
+      
+      // Second fetch should be blocked
+      await store.send(.fetch)
+      
+      // Should receive lock failed for second attempt
+      await store.receive(\.lockFailed)
+      
+      // First fetch completes
+      await store.receive(\.fetchCompleted) {
+        $0.isLoading = false
+        $0.count = 42
+      }
+    }
+  }
+  
+}

--- a/Tests/LockmanTests/Composable/EffectLockMethodTests.swift
+++ b/Tests/LockmanTests/Composable/EffectLockMethodTests.swift
@@ -5,53 +5,12 @@ import XCTest
 
 // MARK: - Test Feature
 
-@Reducer
-private struct TestFeature {
-  struct State: Equatable {
-    var count = 0
-    var isLoading = false
-  }
-  
-  enum Action: Equatable {
-    case fetch
-    case fetchCompleted(Int)
-    case lockFailed
-  }
-  
-  var body: some Reducer<State, Action> {
-    Reduce { state, action in
-      switch action {
-      case .fetch:
-        state.isLoading = true
-        return .run { send in
-          try await Task.sleep(nanoseconds: 100_000_000) // 0.1 seconds
-          await send(.fetchCompleted(42))
-        }
-        .lock(
-          action: action,
-          boundaryId: CancelID.fetch
-        )
-        
-      case .fetchCompleted(let value):
-        state.isLoading = false
-        state.count = value
-        return .none
-        
-      case .lockFailed:
-        state.isLoading = false
-        return .none
-      }
-    }
-  }
-  
-  enum CancelID: LockmanBoundaryId {
-    case fetch
-  }
-}
+@CasePathable
+private enum TestFeatureAction: Equatable, LockmanAction {
+  case fetch
+  case fetchCompleted(Int)
+  case lockFailed
 
-// MARK: - LockmanAction Implementation
-
-extension TestFeature.Action: LockmanAction {
   var lockmanInfo: LockmanSingleExecutionInfo {
     switch self {
     case .fetch:
@@ -68,64 +27,104 @@ extension TestFeature.Action: LockmanAction {
   }
 }
 
+private enum TestFeatureCancelID: LockmanBoundaryId {
+  case fetch
+}
+
+@Reducer
+private struct TestFeature {
+  struct State: Equatable {
+    var count = 0
+    var isLoading = false
+  }
+
+  typealias Action = TestFeatureAction
+
+  var body: some Reducer<State, Action> {
+    Reduce { state, action in
+      switch action {
+      case .fetch:
+        state.isLoading = true
+        return .run { send in
+          try await Task.sleep(nanoseconds: 100_000_000)  // 0.1 seconds
+          await send(.fetchCompleted(42))
+        }
+        .lock(
+          action: action,
+          boundaryId: TestFeatureCancelID.fetch
+        )
+
+      case .fetchCompleted(let value):
+        state.isLoading = false
+        state.count = value
+        return .none
+
+      case .lockFailed:
+        state.isLoading = false
+        return .none
+      }
+    }
+  }
+}
+
 // MARK: - Tests
 
 final class EffectLockMethodTests: XCTestCase {
-  
+
   // MARK: - Basic Functionality Tests
-  
+
   func testLockMethodAppliesLockToEffect() async {
     let container = LockmanStrategyContainer()
     let strategy = LockmanSingleExecutionStrategy()
     try? container.register(strategy)
-    
+
     await LockmanManager.withTestContainer(container) {
       let store = TestStore(
         initialState: TestFeature.State()
       ) {
         TestFeature()
       }
-      
+
       // First fetch should succeed
       await store.send(.fetch) {
         $0.isLoading = true
       }
-      
+
       await store.receive(\.fetchCompleted) {
         $0.isLoading = false
         $0.count = 42
       }
     }
   }
-  
+
   func testLockMethodPreventsDoubleExecution() async {
     // Create a feature with lock failure handling
     struct TestFeatureWithLockFailure: Reducer {
       typealias State = TestFeature.State
       typealias Action = TestFeature.Action
-      
+
       var body: some Reducer<State, Action> {
         Reduce { state, action in
           switch action {
           case .fetch:
             state.isLoading = true
             return .run { send in
-              try await Task.sleep(nanoseconds: 200_000_000) // 0.2 seconds
+              try await Task.sleep(nanoseconds: 200_000_000)  // 0.2 seconds
               await send(.fetchCompleted(42))
             }
             .lock(
               action: action,
-              boundaryId: TestFeature.CancelID.fetch,
+              boundaryId: TestFeatureCancelID.fetch,
               lockFailure: { _, send in
                 await send(.lockFailed)
               }
             )
-            
+
           case .fetchCompleted(let value):
             state.isLoading = false
             state.count = value
             return .none
-            
+
           case .lockFailed:
             // Second fetch was blocked
             return .none
@@ -133,29 +132,29 @@ final class EffectLockMethodTests: XCTestCase {
         }
       }
     }
-    
+
     let container = LockmanStrategyContainer()
     let strategy = LockmanSingleExecutionStrategy()
     try? container.register(strategy)
-    
+
     await LockmanManager.withTestContainer(container) {
       let store = TestStore(
         initialState: TestFeature.State()
       ) {
         TestFeatureWithLockFailure()
       }
-      
+
       // First fetch starts
       await store.send(.fetch) {
         $0.isLoading = true
       }
-      
+
       // Second fetch should be blocked
       await store.send(.fetch)
-      
+
       // Should receive lock failed for second attempt
       await store.receive(\.lockFailed)
-      
+
       // First fetch completes
       await store.receive(\.fetchCompleted) {
         $0.isLoading = false
@@ -163,5 +162,5 @@ final class EffectLockMethodTests: XCTestCase {
       }
     }
   }
-  
+
 }

--- a/Tests/LockmanTests/Composable/ReducerLockMethodTests.swift
+++ b/Tests/LockmanTests/Composable/ReducerLockMethodTests.swift
@@ -1,0 +1,258 @@
+import ComposableArchitecture
+import XCTest
+
+@testable import Lockman
+
+// MARK: - Test Feature
+
+@CasePathable
+private enum TestReducerAction: Equatable, LockmanAction {
+  case lockableAction
+  case lockableResponse(Int)
+  case nonLockableAction
+  case nonLockableResponse(String)
+  case lockFailureAction
+
+  var lockmanInfo: LockmanSingleExecutionInfo {
+    switch self {
+    case .lockableAction:
+      return LockmanSingleExecutionInfo(
+        actionId: "lockable",
+        mode: .boundary
+      )
+    case .lockFailureAction:
+      return LockmanSingleExecutionInfo(
+        actionId: "failure",
+        mode: .boundary
+      )
+    default:
+      return LockmanSingleExecutionInfo(
+        actionId: "other",
+        mode: .none
+      )
+    }
+  }
+}
+
+private enum TestReducerCancelID: LockmanBoundaryId {
+  case feature
+}
+
+@Reducer
+private struct TestReducerFeature {
+  struct State: Equatable {
+    var count = 0
+    var text = ""
+    var lockFailureCount = 0
+  }
+
+  typealias Action = TestReducerAction
+
+  var body: some ReducerOf<Self> {
+    Reduce { state, action in
+      switch action {
+      case .lockableAction:
+        return .run { send in
+          try await Task.sleep(nanoseconds: 100_000_000)  // 0.1 seconds
+          await send(.lockableResponse(42))
+        }
+
+      case .lockableResponse(let value):
+        state.count = value
+        return .none
+
+      case .nonLockableAction:
+        return .run { send in
+          await send(.nonLockableResponse("done"))
+        }
+
+      case .nonLockableResponse(let text):
+        state.text = text
+        return .none
+
+      case .lockFailureAction:
+        return .run { send in
+          try await Task.sleep(nanoseconds: 100_000_000)
+          await send(.lockableResponse(99))
+        }
+      }
+    }
+  }
+}
+
+// MARK: - Tests
+
+final class ReducerLockMethodTests: XCTestCase {
+
+  // MARK: - Basic Functionality Tests
+
+  func testLockMethodAppliesLockToLockmanActions() async {
+    let container = LockmanStrategyContainer()
+    let strategy = LockmanSingleExecutionStrategy()
+    try? container.register(strategy)
+
+    await LockmanManager.withTestContainer(container) {
+      let store = await TestStore(
+        initialState: TestReducerFeature.State()
+      ) {
+        TestReducerFeature()
+          .lock(boundaryId: TestReducerCancelID.feature)
+      }
+
+      // Lockable action should work normally
+      await store.send(.lockableAction)
+      await store.receive(\.lockableResponse) {
+        $0.count = 42
+      }
+    }
+  }
+
+  func testNonLockmanActionsPassThrough() async {
+    let container = LockmanStrategyContainer()
+    let strategy = LockmanSingleExecutionStrategy()
+    try? container.register(strategy)
+
+    await LockmanManager.withTestContainer(container) {
+      let store = await TestStore(
+        initialState: TestReducerFeature.State()
+      ) {
+        TestReducerFeature()
+          .lock(boundaryId: TestReducerCancelID.feature)
+      }
+
+      // Non-lockable action should pass through without locking
+      await store.send(.nonLockableAction)
+      await store.receive(\.nonLockableResponse) {
+        $0.text = "done"
+      }
+    }
+  }
+
+  func testLockFailureCallback() async {
+    let container = LockmanStrategyContainer()
+    let strategy = LockmanSingleExecutionStrategy()
+    try? container.register(strategy)
+
+    let lockFailureExpectation = expectation(description: "Lock failure")
+    lockFailureExpectation.isInverted = false
+
+    await LockmanManager.withTestContainer(container) {
+      let store = await TestStore(
+        initialState: TestReducerFeature.State()
+      ) {
+        TestReducerFeature()
+          .lock(
+            boundaryId: TestReducerCancelID.feature,
+            lockFailure: { error, send in
+              lockFailureExpectation.fulfill()
+              // Could send an action here if needed, e.g.:
+              // await send(.lockFailureAction)
+            }
+          )
+      }
+
+      // Pre-lock the boundary
+      let info = LockmanSingleExecutionInfo(
+        actionId: "lockable",
+        mode: .boundary
+      )
+      _ = strategy.canLock(boundaryId: TestReducerCancelID.feature, info: info)
+      strategy.lock(boundaryId: TestReducerCancelID.feature, info: info)
+
+      // This should trigger lock failure
+      await store.send(.lockableAction)
+
+      // Wait for expectation
+      await fulfillment(of: [lockFailureExpectation], timeout: 1.0)
+
+      // Clean up
+      strategy.unlock(boundaryId: TestReducerCancelID.feature, info: info)
+    }
+  }
+
+  func testMultipleLockmanActionsWithSameBoundary() async {
+    let container = LockmanStrategyContainer()
+    let strategy = LockmanSingleExecutionStrategy()
+    try? container.register(strategy)
+
+    await LockmanManager.withTestContainer(container) {
+      let store = await TestStore(
+        initialState: TestReducerFeature.State()
+      ) {
+        TestReducerFeature()
+          .lock(boundaryId: TestReducerCancelID.feature)
+      }
+
+      // First lockable action
+      await store.send(.lockableAction)
+
+      // Second lockable action should be blocked (different action ID but same boundary)
+      await store.send(.lockFailureAction)
+
+      // First action completes
+      await store.receive(\.lockableResponse) {
+        $0.count = 42
+      }
+
+      // After first completes, another can execute
+      await store.send(.lockableAction)
+      await store.receive(\.lockableResponse)
+      // Count is already 42, so no state change expected
+    }
+  }
+
+  func testUnlockOptionIsRespected() async {
+    let container = LockmanStrategyContainer()
+    let strategy = LockmanSingleExecutionStrategy()
+    try? container.register(strategy)
+
+    await LockmanManager.withTestContainer(container) {
+      let store = await TestStore(
+        initialState: TestReducerFeature.State()
+      ) {
+        TestReducerFeature()
+          .lock(
+            boundaryId: TestReducerCancelID.feature,
+            unlockOption: .delayed(0.1)
+          )
+      }
+
+      // Send action with delayed unlock option
+      await store.send(.lockableAction)
+      await store.receive(\.lockableResponse) {
+        $0.count = 42
+      }
+
+      // Wait for delay to ensure unlock happens
+      try? await Task.sleep(nanoseconds: 200_000_000)  // 0.2 seconds
+
+      // Verify subsequent actions can execute
+      // (This tests that the lock was properly released)
+      await store.send(.lockableAction)
+      await store.receive(\.lockableResponse)
+      // Count is already 42, so no state change expected
+    }
+  }
+
+  func testReducerChaining() async {
+    let container = LockmanStrategyContainer()
+    let strategy = LockmanSingleExecutionStrategy()
+    try? container.register(strategy)
+
+    await LockmanManager.withTestContainer(container) {
+      // Test that LockmanReducer can be chained with other reducers
+      let store = await TestStore(
+        initialState: TestReducerFeature.State()
+      ) {
+        TestReducerFeature()
+          .lock(boundaryId: TestReducerCancelID.feature)
+          ._printChanges()  // Example of chaining
+      }
+
+      await store.send(.lockableAction)
+      await store.receive(\.lockableResponse) {
+        $0.count = 42
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
This PR implements Feature 3 of the v1.0 roadmap: Reducer-level locking with the `.lock()` method.

## Changes
- **Add `LockmanReducer` wrapper**: Automatically applies locking to effects from actions implementing `LockmanAction`
- **Leverage `Effect.lock()` internally**: Uses the previously implemented Effect.lock() to avoid code duplication
- **Support lock failure callbacks**: Provides `Send` function for dispatching actions on lock failure
- **Comprehensive test coverage**: All functionality tested including edge cases

## Technical Details
The implementation wraps the base reducer and intercepts effects:
- Actions conforming to `LockmanAction` have their effects automatically locked
- Non-`LockmanAction` effects pass through unchanged
- Uses the same locking infrastructure as Effect.lock() for consistency

## Usage Example
```swift
var body: some ReducerOf<Self> {
  Reduce { state, action in
    // Your reducer logic
  }
  .lock(
    boundaryId: CancelID.feature,
    unlockOption: .immediate,
    lockFailure: { error, send in
      await send(.lockFailureHandled)
    }
  )
}
```

## Testing
- ✅ All tests passing (6 test cases)
- ✅ Tested with latest TCA version (using await for TestStore)
- ✅ Cross-platform compatibility verified

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>