### PR TITLE
docs: clean up CLAUDE.md and fix Makefile scheme name

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -215,9 +215,6 @@ When building example projects, use the following flags to skip macro validation
 ```bash
 # Skip macro validation for Strategies example
 xcodebuild build -scheme Strategies -configuration Debug -destination "platform=iOS Simulator,name=iPhone 16" -workspace Examples/Strategies/Strategies.xcodeproj/project.xcworkspace -skipMacroValidation
-
-# Skip macro validation for GitHubClient example  
-xcodebuild build -scheme GitHubClient -configuration Debug -destination "platform=iOS Simulator,name=iPhone 16" -workspace Examples/GitHubClient/GitHubClient.xcodeproj/project.xcworkspace -skipMacroValidation
 ```
 
 Note: The `-skipMacroValidation` flag prevents build failures due to macro approval requirements when building from command line.

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ DESTINATION = platform="$(PLATFORM_$(PLATFORM))"
 
 PLATFORM_ID = $(shell echo "$(DESTINATION)" | sed -E "s/.+,id=(.+)/\1/")
 
-SCHEME = Lockman-Package
+SCHEME = Lockman
 
 WORKSPACE = Lockman.xcworkspace
 


### PR DESCRIPTION
## Summary
This PR cleans up outdated references in CLAUDE.md and fixes the scheme name in Makefile.

## Changes
- **Removed GitHubClient example**: The GitHubClient example project no longer exists, so removed its build command from CLAUDE.md
- **Fixed scheme name**: Updated Makefile to use correct scheme name `Lockman` instead of `Lockman-Package`

## Impact
- Documentation is now accurate and reflects current project structure
- Makefile commands will work correctly with the proper scheme name

🤖 Generated with [Claude Code](https://claude.ai/code)