### PR TITLE
fix: update workspace scheme from Lockman-Package to Lockman

### DIFF
--- a/.github/package.xcworkspace/xcshareddata/xcschemes/Lockman.xcscheme
+++ b/.github/package.xcworkspace/xcshareddata/xcschemes/Lockman.xcscheme
@@ -50,26 +50,6 @@
                ReferencedContainer = "container:..">
             </BuildableReference>
          </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "LockmanComposableTests"
-               BuildableName = "LockmanComposableTests"
-               BlueprintName = "LockmanComposableTests"
-               ReferencedContainer = "container:..">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "LockmanCoreTests"
-               BuildableName = "LockmanCoreTests"
-               BlueprintName = "LockmanCoreTests"
-               ReferencedContainer = "container:..">
-            </BuildableReference>
-         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/.github/package.xcworkspace/xcshareddata/xcschemes/Lockman.xcscheme
+++ b/.github/package.xcworkspace/xcshareddata/xcschemes/Lockman.xcscheme
@@ -1,22 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1600"
-   version = "2.1">
+   LastUpgradeVersion = "1640"
+   version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES"
       buildArchitectures = "Automatic">
       <BuildActionEntries>
-         <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
-            <TestPlanReference
-               reference = "container:.github/Lockman.xctestplan">
-            </TestPlanReference>
-         </BuildActionEntry>
          <BuildActionEntry
             buildForTesting = "YES"
             buildForRunning = "YES"
@@ -31,26 +21,17 @@
                ReferencedContainer = "container:..">
             </BuildableReference>
          </BuildActionEntry>
-         <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "NO"
-            buildForProfiling = "NO"
-            buildForArchiving = "NO"
-            buildForAnalyzing = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "LockmanTests"
-               BuildableName = "LockmanTests"
-               BlueprintName = "LockmanTests"
-               ReferencedContainer = "container:..">
-            </BuildableReference>
-         </BuildActionEntry>
-         <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "NO"
-            buildForProfiling = "NO"
-            buildForArchiving = "NO"
-            buildForAnalyzing = "NO">
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "LockmanMacrosTests"
@@ -58,13 +39,9 @@
                BlueprintName = "LockmanMacrosTests"
                ReferencedContainer = "container:..">
             </BuildableReference>
-         </BuildActionEntry>
-         <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "NO"
-            buildForProfiling = "NO"
-            buildForArchiving = "NO"
-            buildForAnalyzing = "NO">
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "LockmanTests"
@@ -72,20 +49,28 @@
                BlueprintName = "LockmanTests"
                ReferencedContainer = "container:..">
             </BuildableReference>
-         </BuildActionEntry>
-      </BuildActionEntries>
-   </BuildAction>
-   <TestAction
-      buildConfiguration = "Debug"
-      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
-      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
-      <TestPlans>
-         <TestPlanReference
-            reference = "container:Lockman.xctestplan"
-            default = "YES">
-         </TestPlanReference>
-      </TestPlans>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "LockmanComposableTests"
+               BuildableName = "LockmanComposableTests"
+               BlueprintName = "LockmanComposableTests"
+               ReferencedContainer = "container:..">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "LockmanCoreTests"
+               BuildableName = "LockmanCoreTests"
+               BlueprintName = "LockmanCoreTests"
+               ReferencedContainer = "container:..">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"


### PR DESCRIPTION
## Summary
- Rename workspace scheme from `Lockman-Package.xcscheme` to `Lockman.xcscheme`
- Update project structure for better consistency with naming conventions

## Changes
- **Renamed**: `.github/package.xcworkspace/xcshareddata/xcschemes/Lockman-Package.xcscheme` → `Lockman.xcscheme`
- Updated scheme configuration to match current project structure

## Test Plan
- [ ] Verify workspace builds correctly with new scheme name
- [ ] Confirm CI/CD pipeline works with updated scheme
- [ ] Test Makefile compatibility with scheme changes

🤖 Generated with [Claude Code](https://claude.ai/code)