### PR TITLE
docs: sync all README translations to version 0.13.4

### DIFF
--- a/Docs/README_de.md
+++ b/Docs/README_de.md
@@ -215,7 +215,7 @@ Fügen Sie die Abhängigkeit zu Ihrer Package.swift-Datei hinzu:
 
 ```swift
 dependencies: [
-  .package(url: "https://github.com/takeshishimada/Lockman", from: "0.13.3")
+  .package(url: "https://github.com/takeshishimada/Lockman", from: "0.13.4")
 ]
 ```
 
@@ -243,6 +243,7 @@ Fügen Sie die Abhängigkeit zu Ihrem Target hinzu:
 
 | Lockman | The Composable Architecture |
 |---------|----------------------------|
+| 0.13.4  | 1.20.2                     |
 | 0.13.3  | 1.20.2                     |
 | 0.13.2  | 1.20.2                     |
 | 0.13.1  | 1.20.2                     |

--- a/Docs/README_es.md
+++ b/Docs/README_es.md
@@ -215,7 +215,7 @@ Agrega la dependencia a tu archivo Package.swift:
 
 ```swift
 dependencies: [
-  .package(url: "https://github.com/takeshishimada/Lockman", from: "0.13.3")
+  .package(url: "https://github.com/takeshishimada/Lockman", from: "0.13.4")
 ]
 ```
 
@@ -243,6 +243,7 @@ Agrega la dependencia a tu objetivo:
 
 | Lockman | The Composable Architecture |
 |---------|----------------------------|
+| 0.13.4  | 1.20.2                     |
 | 0.13.3  | 1.20.2                     |
 | 0.13.2  | 1.20.2                     |
 | 0.13.1  | 1.20.2                     |

--- a/Docs/README_fr.md
+++ b/Docs/README_fr.md
@@ -215,7 +215,7 @@ Ajoutez la dépendance à votre fichier Package.swift :
 
 ```swift
 dependencies: [
-  .package(url: "https://github.com/takeshishimada/Lockman", from: "0.13.3")
+  .package(url: "https://github.com/takeshishimada/Lockman", from: "0.13.4")
 ]
 ```
 
@@ -243,6 +243,7 @@ Ajoutez la dépendance à votre cible :
 
 | Lockman | The Composable Architecture |
 |---------|----------------------------|
+| 0.13.4  | 1.20.2                     |
 | 0.13.3  | 1.20.2                     |
 | 0.13.2  | 1.20.2                     |
 | 0.13.1  | 1.20.2                     |

--- a/Docs/README_it.md
+++ b/Docs/README_it.md
@@ -215,7 +215,7 @@ Aggiungi la dipendenza al tuo file Package.swift:
 
 ```swift
 dependencies: [
-  .package(url: "https://github.com/takeshishimada/Lockman", from: "0.13.3")
+  .package(url: "https://github.com/takeshishimada/Lockman", from: "0.13.4")
 ]
 ```
 
@@ -243,6 +243,7 @@ Aggiungi la dipendenza al tuo target:
 
 | Lockman | The Composable Architecture |
 |---------|----------------------------|
+| 0.13.4  | 1.20.2                     |
 | 0.13.3  | 1.20.2                     |
 | 0.13.2  | 1.20.2                     |
 | 0.13.1  | 1.20.2                     |

--- a/Docs/README_ja.md
+++ b/Docs/README_ja.md
@@ -213,7 +213,7 @@ Package.swiftファイルに依存関係を追加：
 
 ```swift
 dependencies: [
-  .package(url: "https://github.com/takeshishimada/Lockman", from: "0.13.3")
+  .package(url: "https://github.com/takeshishimada/Lockman", from: "0.13.4")
 ]
 ```
 
@@ -241,6 +241,7 @@ dependencies: [
 
 | Lockman | The Composable Architecture |
 |---------|----------------------------|
+| 0.13.4  | 1.20.2                     |
 | 0.13.3  | 1.20.2                     |
 | 0.13.2  | 1.20.2                     |
 | 0.13.1  | 1.20.2                     |

--- a/Docs/README_ko.md
+++ b/Docs/README_ko.md
@@ -215,7 +215,7 @@ Package.swift 파일에 종속성을 추가하세요:
 
 ```swift
 dependencies: [
-  .package(url: "https://github.com/takeshishimada/Lockman", from: "0.13.3")
+  .package(url: "https://github.com/takeshishimada/Lockman", from: "0.13.4")
 ]
 ```
 
@@ -243,6 +243,7 @@ dependencies: [
 
 | Lockman | The Composable Architecture |
 |---------|----------------------------|
+| 0.13.4  | 1.20.2                     |
 | 0.13.3  | 1.20.2                     |
 | 0.13.2  | 1.20.2                     |
 | 0.13.1  | 1.20.2                     |

--- a/Docs/README_pt-BR.md
+++ b/Docs/README_pt-BR.md
@@ -215,7 +215,7 @@ Adicione a dependência ao seu arquivo Package.swift:
 
 ```swift
 dependencies: [
-  .package(url: "https://github.com/takeshishimada/Lockman", from: "0.13.3")
+  .package(url: "https://github.com/takeshishimada/Lockman", from: "0.13.4")
 ]
 ```
 
@@ -243,6 +243,7 @@ Adicione a dependência ao seu alvo:
 
 | Lockman | The Composable Architecture |
 |---------|----------------------------|
+| 0.13.4  | 1.20.2                     |
 | 0.13.3  | 1.20.2                     |
 | 0.13.2  | 1.20.2                     |
 | 0.13.1  | 1.20.2                     |

--- a/Docs/README_zh-CN.md
+++ b/Docs/README_zh-CN.md
@@ -215,7 +215,7 @@ https://github.com/takeshishimada/Lockman
 
 ```swift
 dependencies: [
-  .package(url: "https://github.com/takeshishimada/Lockman", from: "0.13.3")
+  .package(url: "https://github.com/takeshishimada/Lockman", from: "0.13.4")
 ]
 ```
 
@@ -243,6 +243,7 @@ dependencies: [
 
 | Lockman | The Composable Architecture |
 |---------|----------------------------|
+| 0.13.4  | 1.20.2                     |
 | 0.13.3  | 1.20.2                     |
 | 0.13.2  | 1.20.2                     |
 | 0.13.1  | 1.20.2                     |

--- a/Docs/README_zh-TW.md
+++ b/Docs/README_zh-TW.md
@@ -215,7 +215,7 @@ https://github.com/takeshishimada/Lockman
 
 ```swift
 dependencies: [
-  .package(url: "https://github.com/takeshishimada/Lockman", from: "0.13.3")
+  .package(url: "https://github.com/takeshishimada/Lockman", from: "0.13.4")
 ]
 ```
 
@@ -243,6 +243,7 @@ dependencies: [
 
 | Lockman | The Composable Architecture |
 |---------|----------------------------|
+| 0.13.4  | 1.20.2                     |
 | 0.13.3  | 1.20.2                     |
 | 0.13.2  | 1.20.2                     |
 | 0.13.1  | 1.20.2                     |


### PR DESCRIPTION
## Summary
- Synchronize all translated README files with the main README.md version 0.13.4
- Update installation instructions and version compatibility tables across all languages

## Changes
- **Installation Instructions**: Updated from `0.13.3` to `0.13.4` in Package.swift examples
- **Version Compatibility Tables**: Added 0.13.4 entry at the top of compatibility tables

## Updated Languages
- 🇩🇪 German (README_de.md)
- 🇪🇸 Spanish (README_es.md) 
- 🇫🇷 French (README_fr.md)
- 🇮🇹 Italian (README_it.md)
- 🇯🇵 Japanese (README_ja.md)
- 🇰🇷 Korean (README_ko.md)
- 🇧🇷 Portuguese Brazil (README_pt-BR.md)
- 🇨🇳 Chinese Simplified (README_zh-CN.md)
- 🇹🇼 Chinese Traditional (README_zh-TW.md)

## Before
```swift
.package(url: "https://github.com/takeshishimada/Lockman", from: "0.13.3")
```

## After
```swift
.package(url: "https://github.com/takeshishimada/Lockman", from: "0.13.4")
```

🤖 Generated with [Claude Code](https://claude.ai/code)