### PR TITLE
fix: configure Lockman.xcworkspace for proper SPM build support

### DIFF
--- a/Lockman.xcworkspace/contents.xcworkspacedata
+++ b/Lockman.xcworkspace/contents.xcworkspacedata
@@ -2,9 +2,9 @@
 <Workspace
    version = "1.0">
    <FileRef
-      location = "group:Examples/Strategies/Strategies.xcodeproj">
+      location = "group:">
    </FileRef>
    <FileRef
-      location = "group:">
+      location = "group:Examples/Strategies/Strategies.xcodeproj">
    </FileRef>
 </Workspace>

--- a/Lockman.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Lockman.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Lockman.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/Lockman.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEWorkspaceSharedSettings_AutocreateContextsIfNeeded</key>
+	<false/>
+</dict>
+</plist>

--- a/Lockman.xcworkspace/xcshareddata/xcschemes/Lockman.xcscheme
+++ b/Lockman.xcworkspace/xcshareddata/xcschemes/Lockman.xcscheme
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1600"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "Lockman"
+               BuildableName = "Lockman"
+               BlueprintName = "Lockman"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "LockmanTests"
+               BuildableName = "LockmanTests"
+               BlueprintName = "LockmanTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "LockmanMacrosTests"
+               BuildableName = "LockmanMacrosTests"
+               BlueprintName = "LockmanMacrosTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "Lockman"
+            BuildableName = "Lockman"
+            BlueprintName = "Lockman"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
## Summary
- Fix Lockman.xcworkspace configuration to enable proper SPM builds and tests
- Add missing xcshareddata configuration files matching TCA structure
- Create proper scheme configuration for build and test actions

## Changes
- **xcshareddata/IDEWorkspaceChecks.plist**: Add IDE workspace integrity checks
- **xcshareddata/WorkspaceSettings.xcsettings**: Configure workspace settings with AutocreateContextsIfNeeded disabled
- **xcshareddata/xcschemes/Lockman.xcscheme**: Create proper scheme with BuildAction and TestAction configuration matching TCA pattern
- **contents.xcworkspacedata**: Reorder to prioritize SPM package root over Examples

## Test Plan
- [x] Verify Lockman.xcworkspace builds successfully with `xcodebuild test`
- [x] Confirm scheme configuration matches TCA structure
- [x] Ensure all test targets (LockmanTests, LockmanMacrosTests) are properly configured

🤖 Generated with [Claude Code](https://claude.ai/code)