### PR TITLE
refactor\!: rename concatenateWithLock to withLock(concatenating:)

### DIFF
--- a/Sources/Lockman/Core/LockmanManager.swift
+++ b/Sources/Lockman/Core/LockmanManager.swift
@@ -13,7 +13,7 @@ public enum LockmanManager {
   struct Configuration: Sendable {
     /// The default unlock option to use when not explicitly specified.
     ///
-    /// This value is used by all `withLock` and `concatenateWithLock` methods
+    /// This value is used by all `withLock` methods
     /// when the `unlockOption` parameter is not provided.
     ///
     /// Default value is `.immediate` for immediate unlock behavior.
@@ -40,7 +40,7 @@ public enum LockmanManager {
   public enum config {
     /// The default unlock option to use when not explicitly specified.
     ///
-    /// This value is used by all `withLock` and `concatenateWithLock` methods
+    /// This value is used by all `withLock` methods
     /// when the `unlockOption` parameter is not provided.
     ///
     /// Default value is `.immediate` for immediate unlock behavior.

--- a/Sources/Lockman/Documentation.docc/Lock.md
+++ b/Sources/Lockman/Documentation.docc/Lock.md
@@ -119,7 +119,7 @@ return .run { send in
 
 **Features:**
 - Method chain style for natural TCA integration
-- Internally uses `concatenateWithLock`
+- Internally uses `withLock(concatenating:)`
 - Same lock management guarantees as `withLock`
 
 ### withLock (Auto-release Version)
@@ -176,18 +176,18 @@ Used when you want to manually control the lock release timing. Parameters are t
 - Finer control possible
 - **Important**: You must call unlock() in all code paths (see [Unlock](<doc:Unlock>) page for details)
 
-### concatenateWithLock
+### withLock(concatenating:)
 
 Maintains the same lock while executing multiple Effects sequentially.
 
 ```swift
-.concatenateWithLock(
-  unlockOption: .immediate, // Optional: Lock release timing
-  operations: [
+.withLock(
+  concatenating: [
     .run { send in /* Processing 1 */ },
     .run { send in /* Processing 2 */ },
     .run { send in /* Processing 3 */ }
   ],
+  unlockOption: .immediate, // Optional: Lock release timing
   lockFailure: { error, send in /* Lock acquisition failure handling */ }, // Optional
   action: action,
   boundaryId: cancelID

--- a/Tests/LockmanTests/Composable/EffectLockmanErrorTests.swift
+++ b/Tests/LockmanTests/Composable/EffectLockmanErrorTests.swift
@@ -164,8 +164,8 @@ final class EffectLockmanErrorTests: XCTestCase {
       ]
 
       XCTExpectFailure("Effect.withLock strategy 'MockUnregisteredStrategy' not registered") {
-        let effect = Effect<Never>.concatenateWithLock(
-          operations: operations,
+        let effect = Effect<Never>.withLock(
+          concatenating: operations,
           action: action,
           boundaryId: cancelID
         )

--- a/Tests/LockmanTests/Composable/EffectLockmanTests.swift
+++ b/Tests/LockmanTests/Composable/EffectLockmanTests.swift
@@ -487,40 +487,40 @@ private struct TestConcatenateWithLockFeature {
     Reduce<State, Action> { state, action in
       switch action {
       case .executeConcatenateWithLock:
-        return .concatenateWithLock(
-          unlockOption: .immediate,
-          operations: [
+        return .withLock(
+          concatenating: [
             .send(.increment),
             .send(.increment),
           ],
+          unlockOption: .immediate,
           action: action,
           boundaryId: CancelID.userAction
         )
 
       case .executeConcatenateWithLockWithFailure:
-        return .concatenateWithLock(
-          unlockOption: .immediate,
-          operations: [
+        return .withLock(
+          concatenating: [
             .send(.operationFailed)
           ],
+          unlockOption: .immediate,
           action: action,
           boundaryId: CancelID.userAction
         )
 
       case .executeConcatenateWithLockWithCancel:
-        return .concatenateWithLock(
-          unlockOption: .immediate,
-          operations: [
+        return .withLock(
+          concatenating: [
             .send(.operationCanceled)
           ],
+          unlockOption: .immediate,
           action: action,
           boundaryId: CancelID.userAction
         )
 
       case .executeConcatenateWithLockEmpty:
-        return .concatenateWithLock(
+        return .withLock(
+          concatenating: [],
           unlockOption: .immediate,
-          operations: [],
           action: action,
           boundaryId: CancelID.userAction
         )

--- a/Tests/LockmanTests/Composable/Swift59CrashInvestigationTests.swift
+++ b/Tests/LockmanTests/Composable/Swift59CrashInvestigationTests.swift
@@ -14,27 +14,27 @@ private enum FiveNestedAction: Equatable {
   case more(MoreAction)
   case another(AnotherAction)
   case last(LastAction)
-  
+
   enum NestedAction: LockmanAction, Equatable {
     case test
-    
+
     var lockmanInfo: some LockmanInfo {
       LockmanSingleExecutionInfo(actionId: "nested", mode: .boundary)
     }
   }
-  
+
   enum OtherAction: Equatable {
     case test
   }
-  
+
   enum MoreAction: Equatable {
     case test
   }
-  
+
   enum AnotherAction: Equatable {
     case test
   }
-  
+
   enum LastAction: Equatable {
     case test
   }
@@ -49,31 +49,31 @@ private enum RootLockmanAction: LockmanAction, Equatable {
   case more(MoreAction)
   case another(AnotherAction)
   case last(LastAction)
-  
+
   var lockmanInfo: some LockmanInfo {
     LockmanSingleExecutionInfo(actionId: "root", mode: .boundary)
   }
-  
+
   enum NestedAction: LockmanAction, Equatable {
     case test
-    
+
     var lockmanInfo: some LockmanInfo {
       LockmanSingleExecutionInfo(actionId: "nested", mode: .boundary)
     }
   }
-  
+
   enum OtherAction: Equatable {
     case test
   }
-  
+
   enum MoreAction: Equatable {
     case test
   }
-  
+
   enum AnotherAction: Equatable {
     case test
   }
-  
+
   enum LastAction: Equatable {
     case test
   }
@@ -87,7 +87,7 @@ private struct TestState: Equatable {
 private struct FiveNestedReducer {
   typealias State = TestState
   typealias Action = FiveNestedAction
-  
+
   var body: some ReducerOf<Self> {
     EmptyReducer()
   }
@@ -97,7 +97,7 @@ private struct FiveNestedReducer {
 private struct RootLockmanReducer {
   typealias State = TestState
   typealias Action = RootLockmanAction
-  
+
   var body: some ReducerOf<Self> {
     EmptyReducer()
   }
@@ -106,11 +106,11 @@ private struct RootLockmanReducer {
 // MARK: - Tests
 
 final class Swift59CrashInvestigationTests: XCTestCase {
-  
+
   // Test with 5 paths that caused crash in CI
   func testFivePathsCompilation() {
     let reducer = FiveNestedReducer()
-    
+
     // This compilation test verifies the 5-path overload works
     _ = reducer.lock(
       boundaryId: "test",
@@ -120,14 +120,14 @@ final class Swift59CrashInvestigationTests: XCTestCase {
       \.another,
       \.last
     )
-    
+
     XCTAssertTrue(true, "5-path compilation succeeded")
   }
-  
+
   // Test with root action conforming to LockmanAction
   func testRootLockmanActionWithFivePaths() {
     let reducer = RootLockmanReducer()
-    
+
     // This was the original crash case
     _ = reducer.lock(
       boundaryId: "test",
@@ -137,10 +137,10 @@ final class Swift59CrashInvestigationTests: XCTestCase {
       \.another,
       \.last
     )
-    
+
     XCTAssertTrue(true, "Root LockmanAction with 5 paths compilation succeeded")
   }
-  
+
   // Test actual usage with TestStore
   func testFivePathsWithTestStore() async {
     let store = await TestStore(initialState: TestState()) {
@@ -154,25 +154,25 @@ final class Swift59CrashInvestigationTests: XCTestCase {
           \.last
         )
     }
-    
+
     // Send various actions
     await store.send(.root)
     await store.send(.other(.test))
     await store.send(.more(.test))
-    
+
     XCTAssertTrue(true, "TestStore with 5 paths succeeded")
   }
-  
+
   // Test with explicit type annotations (Swift 5.9 workaround)
   func testFivePathsWithExplicitTypes() {
     let reducer = FiveNestedReducer()
-    
+
     let path1: CaseKeyPath<FiveNestedAction, FiveNestedAction.NestedAction> = \.nested
     let path2: CaseKeyPath<FiveNestedAction, FiveNestedAction.OtherAction> = \.other
     let path3: CaseKeyPath<FiveNestedAction, FiveNestedAction.MoreAction> = \.more
     let path4: CaseKeyPath<FiveNestedAction, FiveNestedAction.AnotherAction> = \.another
     let path5: CaseKeyPath<FiveNestedAction, FiveNestedAction.LastAction> = \.last
-    
+
     _ = reducer.lock(
       boundaryId: "test",
       for: path1,
@@ -181,10 +181,10 @@ final class Swift59CrashInvestigationTests: XCTestCase {
       path4,
       path5
     )
-    
+
     XCTAssertTrue(true, "Explicit types compilation succeeded")
   }
-  
+
   // Test with actual behavior similar to original crash
   func testComplexNestedBehavior() async {
     let store = await TestStore(initialState: TestState()) {
@@ -198,10 +198,10 @@ final class Swift59CrashInvestigationTests: XCTestCase {
           \.last
         )
     }
-    
+
     // Just test that the store can be created without crashing
     await store.send(.root)
-    
+
     XCTAssertTrue(true, "Complex nested behavior test succeeded")
   }
 }


### PR DESCRIPTION
## Summary
- Rename `concatenateWithLock` to `withLock(concatenating:)` for better API consistency
- This change creates a more Swifty API that follows standard Swift naming conventions

## Changes
- Renamed the method from `concatenateWithLock` to `withLock(concatenating:)`
- Updated parameter order to use Swift's parameter labeling conventions
- Updated all usages in tests and documentation
- No functional changes - purely a naming refactor

## Breaking Change
This is a breaking change. Users will need to update their code:

```swift
// Before
.concatenateWithLock(
  operations: [effect1, effect2],
  action: action,
  boundaryId: boundaryId
)

// After
.withLock(
  concatenating: [effect1, effect2],
  action: action,
  boundaryId: boundaryId
)
```

## Test Plan
- [x] All unit tests pass
- [x] Example projects build successfully
- [x] Documentation updated

🤖 Generated with [Claude Code](https://claude.ai/code)