### PR TITLE
chore: prepare for 1.0.0 release

### DIFF
--- a/Docs/README_de.md
+++ b/Docs/README_de.md
@@ -226,7 +226,7 @@ Fügen Sie die Abhängigkeit zu Ihrer Package.swift-Datei hinzu:
 
 ```swift
 dependencies: [
-  .package(url: "https://github.com/takeshishimada/Lockman", from: "0.13.4")
+  .package(url: "https://github.com/takeshishimada/Lockman", from: "1.0.0")
 ]
 ```
 
@@ -254,6 +254,7 @@ Fügen Sie die Abhängigkeit zu Ihrem Target hinzu:
 
 | Lockman | The Composable Architecture |
 |---------|----------------------------|
+| 1.0.0   | 1.20.2                     |
 | 0.13.4  | 1.20.2                     |
 | 0.13.3  | 1.20.2                     |
 | 0.13.2  | 1.20.2                     |

--- a/Docs/README_es.md
+++ b/Docs/README_es.md
@@ -226,7 +226,7 @@ Agrega la dependencia a tu archivo Package.swift:
 
 ```swift
 dependencies: [
-  .package(url: "https://github.com/takeshishimada/Lockman", from: "0.13.4")
+  .package(url: "https://github.com/takeshishimada/Lockman", from: "1.0.0")
 ]
 ```
 
@@ -254,6 +254,7 @@ Agrega la dependencia a tu objetivo:
 
 | Lockman | The Composable Architecture |
 |---------|----------------------------|
+| 1.0.0   | 1.20.2                     |
 | 0.13.4  | 1.20.2                     |
 | 0.13.3  | 1.20.2                     |
 | 0.13.2  | 1.20.2                     |

--- a/Docs/README_fr.md
+++ b/Docs/README_fr.md
@@ -226,7 +226,7 @@ Ajoutez la dépendance à votre fichier Package.swift :
 
 ```swift
 dependencies: [
-  .package(url: "https://github.com/takeshishimada/Lockman", from: "0.13.4")
+  .package(url: "https://github.com/takeshishimada/Lockman", from: "1.0.0")
 ]
 ```
 
@@ -254,6 +254,7 @@ Ajoutez la dépendance à votre cible :
 
 | Lockman | The Composable Architecture |
 |---------|----------------------------|
+| 1.0.0   | 1.20.2                     |
 | 0.13.4  | 1.20.2                     |
 | 0.13.3  | 1.20.2                     |
 | 0.13.2  | 1.20.2                     |

--- a/Docs/README_it.md
+++ b/Docs/README_it.md
@@ -226,7 +226,7 @@ Aggiungi la dipendenza al tuo file Package.swift:
 
 ```swift
 dependencies: [
-  .package(url: "https://github.com/takeshishimada/Lockman", from: "0.13.4")
+  .package(url: "https://github.com/takeshishimada/Lockman", from: "1.0.0")
 ]
 ```
 
@@ -254,6 +254,7 @@ Aggiungi la dipendenza al tuo target:
 
 | Lockman | The Composable Architecture |
 |---------|----------------------------|
+| 1.0.0   | 1.20.2                     |
 | 0.13.4  | 1.20.2                     |
 | 0.13.3  | 1.20.2                     |
 | 0.13.2  | 1.20.2                     |

--- a/Docs/README_ja.md
+++ b/Docs/README_ja.md
@@ -224,7 +224,7 @@ Package.swiftファイルに依存関係を追加：
 
 ```swift
 dependencies: [
-  .package(url: "https://github.com/takeshishimada/Lockman", from: "0.13.4")
+  .package(url: "https://github.com/takeshishimada/Lockman", from: "1.0.0")
 ]
 ```
 
@@ -252,6 +252,7 @@ dependencies: [
 
 | Lockman | The Composable Architecture |
 |---------|----------------------------|
+| 1.0.0   | 1.20.2                     |
 | 0.13.4  | 1.20.2                     |
 | 0.13.3  | 1.20.2                     |
 | 0.13.2  | 1.20.2                     |

--- a/Docs/README_ko.md
+++ b/Docs/README_ko.md
@@ -226,7 +226,7 @@ Package.swift 파일에 종속성을 추가하세요:
 
 ```swift
 dependencies: [
-  .package(url: "https://github.com/takeshishimada/Lockman", from: "0.13.4")
+  .package(url: "https://github.com/takeshishimada/Lockman", from: "1.0.0")
 ]
 ```
 
@@ -254,6 +254,7 @@ dependencies: [
 
 | Lockman | The Composable Architecture |
 |---------|----------------------------|
+| 1.0.0   | 1.20.2                     |
 | 0.13.4  | 1.20.2                     |
 | 0.13.3  | 1.20.2                     |
 | 0.13.2  | 1.20.2                     |

--- a/Docs/README_pt-BR.md
+++ b/Docs/README_pt-BR.md
@@ -226,7 +226,7 @@ Adicione a dependência ao seu arquivo Package.swift:
 
 ```swift
 dependencies: [
-  .package(url: "https://github.com/takeshishimada/Lockman", from: "0.13.4")
+  .package(url: "https://github.com/takeshishimada/Lockman", from: "1.0.0")
 ]
 ```
 
@@ -254,6 +254,7 @@ Adicione a dependência ao seu alvo:
 
 | Lockman | The Composable Architecture |
 |---------|----------------------------|
+| 1.0.0   | 1.20.2                     |
 | 0.13.4  | 1.20.2                     |
 | 0.13.3  | 1.20.2                     |
 | 0.13.2  | 1.20.2                     |

--- a/Docs/README_zh-CN.md
+++ b/Docs/README_zh-CN.md
@@ -226,7 +226,7 @@ https://github.com/takeshishimada/Lockman
 
 ```swift
 dependencies: [
-  .package(url: "https://github.com/takeshishimada/Lockman", from: "0.13.4")
+  .package(url: "https://github.com/takeshishimada/Lockman", from: "1.0.0")
 ]
 ```
 
@@ -254,6 +254,7 @@ dependencies: [
 
 | Lockman | The Composable Architecture |
 |---------|----------------------------|
+| 1.0.0   | 1.20.2                     |
 | 0.13.4  | 1.20.2                     |
 | 0.13.3  | 1.20.2                     |
 | 0.13.2  | 1.20.2                     |

--- a/Docs/README_zh-TW.md
+++ b/Docs/README_zh-TW.md
@@ -226,7 +226,7 @@ https://github.com/takeshishimada/Lockman
 
 ```swift
 dependencies: [
-  .package(url: "https://github.com/takeshishimada/Lockman", from: "0.13.4")
+  .package(url: "https://github.com/takeshishimada/Lockman", from: "1.0.0")
 ]
 ```
 
@@ -254,6 +254,7 @@ dependencies: [
 
 | Lockman | The Composable Architecture |
 |---------|----------------------------|
+| 1.0.0   | 1.20.2                     |
 | 0.13.4  | 1.20.2                     |
 | 0.13.3  | 1.20.2                     |
 | 0.13.2  | 1.20.2                     |

--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ Add the dependency to your Package.swift file:
 
 ```swift
 dependencies: [
-  .package(url: "https://github.com/takeshishimada/Lockman", from: "0.13.4")
+  .package(url: "https://github.com/takeshishimada/Lockman", from: "1.0.0")
 ]
 ```
 
@@ -252,7 +252,7 @@ Add the dependency to your target:
 
 | Lockman | The Composable Architecture |
 |---------|----------------------------|
-| 0.13.4  | 1.20.2                     |
+| 1.0.0   | 1.20.2                     |
 | 0.12.0  | 1.20.1                     |
 | 0.11.0  | 1.19.1                     |
 | 0.10.0  | 1.19.0                     |
@@ -264,6 +264,7 @@ Add the dependency to your target:
 
 | Lockman | The Composable Architecture |
 |---------|----------------------------|
+| 0.13.4  | 1.20.2                     |
 | 0.13.3  | 1.20.2                     |
 | 0.13.2  | 1.20.2                     |
 | 0.13.1  | 1.20.2                     |


### PR DESCRIPTION
## Summary
Prepare for the Lockman 1.0.0 release by updating version references in all documentation.

## Changes
- Updated installation instructions from `0.13.4` to `1.0.0` in all README files
- Added `1.0.0` to version compatibility tables
- Moved `0.13.4` to "Other versions" section in main README

## Release Checklist
After this PR is merged:
- [ ] Create and push tag: `git tag -a 1.0.0 -m "Release version 1.0.0"`
- [ ] Push tag: `git push origin 1.0.0`
- [ ] Create GitHub release from tag
- [ ] Generate release notes highlighting breaking changes
- [ ] Update DocC documentation site

## Breaking Changes in 1.0.0
As documented in the [migration guide](https://takeshishimada.github.io/Lockman/1.0.0/documentation/lockman/migrationguides/migratingto1.0):
- `concatenateWithLock` → `withLock(concatenating:)`
- Error handling improvements with `LockmanCancellationError`
- `id` → `boundaryId` parameter rename
- `Reducer.withLock` → `Reducer.lock`

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>