### PR TITLE
fix: add missing .cancellable(id:) to run blocks in documentation and examples

### DIFF
--- a/Docs/README_de.md
+++ b/Docs/README_de.md
@@ -104,6 +104,7 @@ struct ProcessFeature {
                         try await Task.sleep(nanoseconds: 3_000_000_000)
                         await send(.internal(.processCompleted))
                     }
+                    .cancellable(id: CancelID.userAction)
                 }
                 
             case let .internal(internalAction):

--- a/Docs/README_es.md
+++ b/Docs/README_es.md
@@ -104,6 +104,7 @@ struct ProcessFeature {
                         try await Task.sleep(nanoseconds: 3_000_000_000)
                         await send(.internal(.processCompleted))
                     }
+                    .cancellable(id: CancelID.userAction)
                 }
                 
             case let .internal(internalAction):

--- a/Docs/README_fr.md
+++ b/Docs/README_fr.md
@@ -104,6 +104,7 @@ struct ProcessFeature {
                         try await Task.sleep(nanoseconds: 3_000_000_000)
                         await send(.internal(.processCompleted))
                     }
+                    .cancellable(id: CancelID.userAction)
                 }
                 
             case let .internal(internalAction):

--- a/Docs/README_it.md
+++ b/Docs/README_it.md
@@ -104,6 +104,7 @@ struct ProcessFeature {
                         try await Task.sleep(nanoseconds: 3_000_000_000)
                         await send(.internal(.processCompleted))
                     }
+                    .cancellable(id: CancelID.userAction)
                 }
                 
             case let .internal(internalAction):

--- a/Docs/README_ja.md
+++ b/Docs/README_ja.md
@@ -104,6 +104,7 @@ struct ProcessFeature {
                         try await Task.sleep(nanoseconds: 3_000_000_000)
                         await send(.internal(.processCompleted))
                     }
+                    .cancellable(id: CancelID.userAction)
                 }
                 
             case let .internal(internalAction):

--- a/Docs/README_ko.md
+++ b/Docs/README_ko.md
@@ -104,6 +104,7 @@ struct ProcessFeature {
                         try await Task.sleep(nanoseconds: 3_000_000_000)
                         await send(.internal(.processCompleted))
                     }
+                    .cancellable(id: CancelID.userAction)
                 }
                 
             case let .internal(internalAction):

--- a/Docs/README_pt-BR.md
+++ b/Docs/README_pt-BR.md
@@ -104,6 +104,7 @@ struct ProcessFeature {
                         try await Task.sleep(nanoseconds: 3_000_000_000)
                         await send(.internal(.processCompleted))
                     }
+                    .cancellable(id: CancelID.userAction)
                 }
                 
             case let .internal(internalAction):

--- a/Docs/README_zh-CN.md
+++ b/Docs/README_zh-CN.md
@@ -104,6 +104,7 @@ struct ProcessFeature {
                         try await Task.sleep(nanoseconds: 3_000_000_000)
                         await send(.internal(.processCompleted))
                     }
+                    .cancellable(id: CancelID.userAction)
                 }
                 
             case let .internal(internalAction):

--- a/Docs/README_zh-TW.md
+++ b/Docs/README_zh-TW.md
@@ -104,6 +104,7 @@ struct ProcessFeature {
                         try await Task.sleep(nanoseconds: 3_000_000_000)
                         await send(.internal(.processCompleted))
                     }
+                    .cancellable(id: CancelID.userAction)
                 }
                 
             case let .internal(internalAction):

--- a/Examples/Strategies/Strategies/01-SingleExecutionStrategy.swift
+++ b/Examples/Strategies/Strategies/01-SingleExecutionStrategy.swift
@@ -82,6 +82,7 @@ struct SingleExecutionStrategyFeature {
       } catch: { error, send in
         await send(.internal(.handleError(error)))
       }
+      .cancellable(id: CancelID.process)
     }
   }
 
@@ -112,6 +113,7 @@ struct SingleExecutionStrategyFeature {
             try await Task.sleep(nanoseconds: 2_000_000_000)  // 2 seconds
             await send(.internal(.clearTemporaryMessage))
           }
+          .cancellable(id: CancelID.process)
         } else {
           state.processStatus = .blocked
         }

--- a/Examples/Strategies/Strategies/02-PriorityBasedStrategy.swift
+++ b/Examples/Strategies/Strategies/02-PriorityBasedStrategy.swift
@@ -129,6 +129,7 @@ struct PriorityBasedStrategyFeature {
     } catch: { error, send in
       await send(.internal(.updateResult(button: buttonType, result: "Cancelled")))
     }
+    .cancellable(id: CancelID.priorityOperation)
   }
 
   // MARK: - Internal Action Handler

--- a/Examples/Strategies/Strategies/03-ConcurrencyLimitedStrategy.swift
+++ b/Examples/Strategies/Strategies/03-ConcurrencyLimitedStrategy.swift
@@ -182,6 +182,7 @@ struct ConcurrencyLimitedStrategyFeature {
       } catch: { error, send in
         await send(.internal(.downloadFailed(id: id, error: error.localizedDescription)))
       }
+      .cancellable(id: CancelID.downloads)
     }
   }
 

--- a/Examples/Strategies/Strategies/04-GroupCoordinationStrategy.swift
+++ b/Examples/Strategies/Strategies/04-GroupCoordinationStrategy.swift
@@ -138,6 +138,7 @@ struct GroupCoordinationStrategyFeature {
       } catch: { error, send in
         await send(.internal(.syncFailed(error.localizedDescription)))
       }
+      .cancellable(id: CancelID.sync)
 
     case .uploadDataTapped:
       return .run { send in
@@ -154,6 +155,7 @@ struct GroupCoordinationStrategyFeature {
         await send(
           .internal(.operationFailed(operation: "Upload", error: error.localizedDescription)))
       }
+      .cancellable(id: CancelID.upload)
 
     case .downloadDataTapped:
       return .run { send in
@@ -171,6 +173,7 @@ struct GroupCoordinationStrategyFeature {
         await send(
           .internal(.operationFailed(operation: "Download", error: error.localizedDescription)))
       }
+      .cancellable(id: CancelID.download)
 
     case .processDataTapped:
       return .run { send in
@@ -187,6 +190,7 @@ struct GroupCoordinationStrategyFeature {
         await send(
           .internal(.operationFailed(operation: "Process", error: error.localizedDescription)))
       }
+      .cancellable(id: CancelID.process)
 
     case .cancelSyncTapped:
       // Cancel all operations

--- a/Examples/Strategies/Strategies/05-DynamicConditionStrategy.swift
+++ b/Examples/Strategies/Strategies/05-DynamicConditionStrategy.swift
@@ -149,6 +149,7 @@ struct DynamicConditionStrategyFeature {
               error: error.localizedDescription
             )))
       }
+      .cancellable(id: CancelID.sync)
 
     case .toggleLoginTapped:
       state.$isLoggedIn.withLock { $0.toggle() }
@@ -178,6 +179,7 @@ struct DynamicConditionStrategyFeature {
               error: error.localizedDescription
             )))
       }
+      .cancellable(id: CancelID.maintenance)
 
     case .setHour(let hour):
       state.currentHour = hour
@@ -207,6 +209,7 @@ struct DynamicConditionStrategyFeature {
               error: error.localizedDescription
             )))
       }
+      .cancellable(id: CancelID.report)
 
     case .selectDay(let day):
       state.selectedDay = day

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ struct ProcessFeature {
                         try await Task.sleep(nanoseconds: 3_000_000_000)
                         await send(.internal(.processCompleted))
                     }
+                    .cancellable(id: CancelID.userAction)
                 }
                 
             case let .internal(internalAction):

--- a/Sources/Lockman/Documentation.docc/GettingStarted.md
+++ b/Sources/Lockman/Documentation.docc/GettingStarted.md
@@ -117,6 +117,7 @@ var body: some ReducerOf<Self> {
                 try await Task.sleep(nanoseconds: 3_000_000_000)
                 await send(.processCompleted)
             }
+            .cancellable(id: CancelID.userAction)
             
         case .processStart:
             state.isProcessing = true
@@ -165,6 +166,7 @@ case .startProcessButtonTapped:
         try await Task.sleep(nanoseconds: 3_000_000_000)
         await send(.processCompleted)
     }
+    .cancellable(id: CancelID.userAction)
     .lock(
         action: action,
         boundaryId: CancelID.userAction,


### PR DESCRIPTION
## Summary
Fixes critical issue where `.cancellable(id:)` modifier was missing from `.run` blocks in documentation and example code. This modifier is essential for proper effect cancellation in TCA when using Lockman's lock management.

## Problem
Without `.cancellable(id:)`, effects cannot be properly cancelled when:
- A higher priority action preempts a lower priority one
- Lock acquisition fails and existing effects need to be cancelled
- The boundary cancellation occurs

## Changes
- ✅ Fixed all README examples (main + 9 language versions)
- ✅ Fixed DocC documentation examples in GettingStarted.md
- ✅ Fixed all 5 Example project files:
  - 01-SingleExecutionStrategy.swift
  - 02-PriorityBasedStrategy.swift
  - 03-ConcurrencyLimitedStrategy.swift
  - 04-GroupCoordinationStrategy.swift
  - 05-DynamicConditionStrategy.swift

## Example Fix
```diff
 return .run { send in
   await send(.internal(.processStart))
   try await Task.sleep(nanoseconds: 3_000_000_000)
   await send(.internal(.processCompleted))
 }
+.cancellable(id: CancelID.userAction)
```

## Testing
- All examples now properly support effect cancellation
- Code has been formatted with `make format`

## Impact
This fix is critical for 1.0.0 release as it ensures documentation and examples demonstrate the correct usage pattern.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>