### PR TITLE
docs: reorganize README structure and update version compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,25 +254,25 @@ Add the dependency to your target:
 | Lockman | The Composable Architecture |
 |---------|----------------------------|
 | 1.3.0   | 1.20.2                     |
-| 1.2.0   | 1.20.2                     |
-| 1.1.0   | 1.20.2                     |
-| 1.0.0   | 1.20.2                     |
-| 0.12.0  | 1.20.1                     |
-| 0.11.0  | 1.19.1                     |
-| 0.10.0  | 1.19.0                     |
-| 0.9.0   | 1.18.0                     |
-| 0.8.0   | 1.17.1                     |
 
 <details>
 <summary>Other versions</summary>
 
 | Lockman | The Composable Architecture |
 |---------|----------------------------|
+| 1.2.0   | 1.20.2                     |
+| 1.1.0   | 1.20.2                     |
+| 1.0.0   | 1.20.2                     |
 | 0.13.4  | 1.20.2                     |
 | 0.13.3  | 1.20.2                     |
 | 0.13.2  | 1.20.2                     |
 | 0.13.1  | 1.20.2                     |
 | 0.13.0  | 1.20.2                     |
+| 0.12.0  | 1.20.1                     |
+| 0.11.0  | 1.19.1                     |
+| 0.10.0  | 1.19.0                     |
+| 0.9.0   | 1.18.0                     |
+| 0.8.0   | 1.17.1                     |
 | 0.7.0   | 1.17.1                     |
 | 0.6.0   | 1.17.1                     |
 | 0.5.0   | 1.17.1                     |
@@ -289,15 +289,15 @@ Add the dependency to your target:
 The following translations of this README have been contributed by members of the community:
 
 - [English](README.md)
-- [Japanese](Docs/README_ja.md)
-- [Simplified Chinese](Docs/README_zh-CN.md)
-- [Traditional Chinese](Docs/README_zh-TW.md)
-- [Spanish](Docs/README_es.md)
-- [French](Docs/README_fr.md)
-- [German](Docs/README_de.md)
-- [Korean](Docs/README_ko.md)
-- [Portuguese](Docs/README_pt-BR.md)
-- [Italian](Docs/README_it.md)
+- [Japanese](READMEs/README_ja.md)
+- [Simplified Chinese](READMEs/README_zh-CN.md)
+- [Traditional Chinese](READMEs/README_zh-TW.md)
+- [Spanish](READMEs/README_es.md)
+- [French](READMEs/README_fr.md)
+- [German](READMEs/README_de.md)
+- [Korean](READMEs/README_ko.md)
+- [Portuguese](READMEs/README_pt-BR.md)
+- [Italian](READMEs/README_it.md)
 
 ## Community
 

--- a/READMEs/README_de.md
+++ b/READMEs/README_de.md
@@ -5,53 +5,53 @@
 [![Platforms](https://img.shields.io/badge/Platforms-iOS%20%7C%20macOS%20%7C%20tvOS%20%7C%20watchOS%20%7C%20Mac%20Catalyst-333333.svg?style=flat)](https://developer.apple.com/)
 
 
-Lockman은 The Composable Architecture (TCA) 애플리케이션에서 동시 액션 제어 문제를 해결하는 Swift 라이브러리로, 반응성, 투명성, 선언적 설계에 중점을 둡니다.
+Lockman ist eine Swift-Bibliothek, die Probleme bei der Kontrolle konkurrierender Aktionen in The Composable Architecture (TCA) Anwendungen löst, mit Fokus auf Reaktionsfähigkeit, Transparenz und deklaratives Design.
 
-* [설계 철학](#설계-철학)
-* [개요](#개요)
-* [기본 예제](#기본-예제)
-* [설치](#설치)
-* [커뮤니티](#커뮤니티)
+* [Design-Philosophie](#design-philosophie)
+* [Überblick](#überblick)
+* [Grundlegendes Beispiel](#grundlegendes-beispiel)
+* [Installation](#installation)
+* [Community](#community)
 
-## 설계 철학
+## Design-Philosophie
 
-### Designing Fluid Interfaces 원칙
+### Designing Fluid Interfaces Prinzipien
 
-WWDC18의 "Designing Fluid Interfaces" 프레젠테이션은 뛰어난 인터페이스를 위한 원칙을 제시했습니다:
+Die Präsentation "Designing Fluid Interfaces" der WWDC18 stellte Prinzipien für außergewöhnliche Schnittstellen vor:
 
-* **즉각적인 응답과 지속적인 리디렉션** - 10ms의 지연도 허용하지 않는 반응성
-* **터치와 콘텐츠 간의 일대일 움직임** - 드래그 작업 중 콘텐츠가 손가락을 따라감
-* **지속적인 피드백** - 모든 상호작용에 대한 즉각적인 반응
-* **병렬 제스처 감지** - 여러 제스처를 동시에 인식
-* **공간적 일관성** - 애니메이션 중 위치 일관성 유지
-* **가벼운 상호작용, 증폭된 출력** - 작은 입력에서 큰 효과
+* **Sofortige Reaktion und kontinuierliche Umleitung** - Reaktionsfähigkeit, die nicht einmal 10ms Verzögerung toleriert
+* **Eins-zu-Eins-Bewegung zwischen Berührung und Inhalt** - Inhalt folgt dem Finger während Ziehvorgängen
+* **Kontinuierliches Feedback** - Sofortige Reaktion auf alle Interaktionen
+* **Parallele Gestenerkennung** - Gleichzeitige Erkennung mehrerer Gesten
+* **Räumliche Konsistenz** - Beibehaltung der Positionskonsistenz während Animationen
+* **Leichte Interaktionen, verstärkte Ausgabe** - Große Effekte aus kleinen Eingaben
 
-### 기존의 과제
+### Traditionelle Herausforderungen
 
-기존 UI 개발은 단순히 동시 버튼 누름과 중복 실행을 금지하여 문제를 해결했습니다. 이러한 접근 방식은 현대적인 유동적 인터페이스 설계에서 사용자 경험을 저해하는 요인이 되었습니다.
+Die traditionelle UI-Entwicklung löste Probleme, indem sie gleichzeitige Tasteneingaben und doppelte Ausführungen einfach verbot. Diese Ansätze wurden zu Faktoren, die die Benutzererfahrung im modernen flüssigen Interface-Design behindern.
 
-사용자는 동시에 버튼을 누르더라도 어떤 형태의 피드백을 기대합니다. UI 레이어에서의 즉각적인 응답과 비즈니스 로직 레이어에서의 적절한 상호 배제 제어를 명확히 분리하는 것이 중요합니다.
+Benutzer erwarten eine Form von Feedback, auch wenn sie gleichzeitig Tasten drücken. Es ist entscheidend, die sofortige Reaktion auf UI-Ebene klar von der angemessenen gegenseitigen Ausschlusskontrolle auf Geschäftslogikebene zu trennen.
 
-## 개요
+## Überblick
 
-Lockman은 애플리케이션 개발의 일반적인 문제를 해결하기 위해 다음과 같은 제어 전략을 제공합니다:
+Lockman bietet die folgenden Kontrollstrategien zur Lösung häufiger Probleme in der Anwendungsentwicklung:
 
-* **Single Execution**: 동일한 액션의 중복 실행 방지
-* **Priority Based**: 우선순위 기반 액션 제어 및 취소
-* **Group Coordination**: 리더/멤버 역할을 통한 그룹 제어
-* **Dynamic Condition**: 실행 조건에 기반한 동적 제어
-* **Concurrency Limited**: 그룹당 동시 실행 수 제한
-* **Composite Strategy**: 여러 전략 조합
+* **Single Execution**: Verhindert doppelte Ausführung derselben Aktion
+* **Priority Based**: Prioritätsbasierte Aktionskontrolle und -stornierung
+* **Group Coordination**: Gruppenkontrolle über Leader/Member-Rollen
+* **Dynamic Condition**: Dynamische Kontrolle basierend auf Ausführungsbedingungen
+* **Concurrency Limited**: Begrenzt die Anzahl gleichzeitiger Ausführungen pro Gruppe
+* **Composite Strategy**: Kombination mehrerer Strategien
 
-## 예제
+## Beispiele
 
 | Single Execution Strategy | Priority Based Strategy | Concurrency Limited Strategy |
 |--------------------------|------------------------|------------------------------|
 | ![Single Execution Strategy](../Sources/Lockman/Documentation.docc/images/01-SingleExecutionStrategy.gif) | ![Priority Based Strategy](../Sources/Lockman/Documentation.docc/images/02-PriorityBasedStrategy.gif) | ![Concurrency Limited Strategy](../Sources/Lockman/Documentation.docc/images/03-ConcurrencyLimitedStrategy.gif) |
 
-## 코드 예제
+## Code-Beispiel
 
-`@LockmanSingleExecution` 매크로를 사용하여 프로세스의 중복 실행을 방지하는 기능을 구현하는 방법입니다:
+So implementieren Sie eine Funktion, die doppelte Prozessausführung mit dem `@LockmanSingleExecution` Makro verhindert:
 
 ```swift
 import CasePaths
@@ -99,7 +99,7 @@ struct ProcessFeature {
                 case .startProcessButtonTapped:
                     return .run { send in
                         await send(.internal(.processStart))
-                        // 무거운 처리 시뮬레이션
+                        // Schwere Verarbeitung simulieren
                         try await Task.sleep(nanoseconds: 3_000_000_000)
                         await send(.internal(.processCompleted))
                     }
@@ -109,12 +109,12 @@ struct ProcessFeature {
                 switch internalAction {
                 case .processStart:
                     state.isProcessing = true
-                    state.message = "처리 시작됨..."
+                    state.message = "Verarbeitung gestartet..."
                     return .none
                     
                 case .processCompleted:
                     state.isProcessing = false
-                    state.message = "처리 완료됨"
+                    state.message = "Verarbeitung abgeschlossen"
                     return .none
                     
                 case .updateMessage(let message):
@@ -126,10 +126,10 @@ struct ProcessFeature {
         .lock(
             boundaryId: CancelID.userAction,
             lockFailure: { error, send in
-                // 이미 처리가 진행 중일 때
+                // Wenn die Verarbeitung bereits läuft
                 if error is LockmanSingleExecutionError {
-                    // 직접적인 상태 변경 대신 액션을 통해 메시지 업데이트
-                    await send(.internal(.updateMessage("이미 처리가 진행 중입니다")))
+                    // Nachricht über eine Aktion aktualisieren anstatt direkte Zustandsmutation
+                    await send(.internal(.updateMessage("Verarbeitung läuft bereits")))
                 }
             },
             for: \.view
@@ -138,9 +138,9 @@ struct ProcessFeature {
 }
 ```
 
-`Reducer.lock` 수정자는 `LockmanAction`을 준수하는 액션에 대해 자동으로 잠금 관리를 적용합니다. `ViewAction` 열거형이 `@LockmanSingleExecution`으로 표시되어 있으므로, 처리가 진행 중일 때 `startProcessButtonTapped` 액션이 실행되지 않습니다. `for: \.view` 매개변수는 Lockman에게 `view` 케이스에 중첩된 액션에 대해 `LockmanAction` 준수를 확인하도록 지시합니다.
+Der `Reducer.lock` Modifikator wendet automatisch Lock-Management auf Aktionen an, die dem `LockmanAction` Protokoll entsprechen. Da die `ViewAction` Enumeration mit `@LockmanSingleExecution` markiert ist, wird die `startProcessButtonTapped` Aktion nicht erneut ausgeführt, während die Verarbeitung läuft. Der Parameter `for: \.view` weist Lockman an, Aktionen, die im `view` Fall verschachtelt sind, auf `LockmanAction` Konformität zu prüfen.
 
-### 디버그 출력 예제
+### Debug-Ausgabe Beispiel
 
 ```
 ✅ [Lockman] canLock succeeded - Strategy: SingleExecution, BoundaryId: process, Info: LockmanSingleExecutionInfo(actionId: 'startProcessButtonTapped', uniqueId: 7BFC785A-3D25-4722-B9BC-A3A63A7F49FC, mode: boundary)
@@ -161,19 +161,19 @@ struct ProcessFeature {
 └─────────────────┴──────────────────┴──────────────────────────────────────┴─────────────────┘
 ```
 
-## 문서
+## Dokumentation
 
-출시된 버전과 `main`에 대한 문서는 여기에서 사용할 수 있습니다:
+Die Dokumentation für veröffentlichte Versionen und `main` ist hier verfügbar:
 
 * [`main`](https://takeshishimada.github.io/Lockman/main/documentation/lockman/)
-* [1.3.0](https://takeshishimada.github.io/Lockman/1.3.0/documentation/lockman/) ([마이그레이션 가이드](https://takeshishimada.github.io/Lockman/1.3.0/documentation/lockman/migratingto1.3))
-* [1.2.0](https://takeshishimada.github.io/Lockman/1.2.0/documentation/lockman/) ([마이그레이션 가이드](https://takeshishimada.github.io/Lockman/1.2.0/documentation/lockman/migratingto1.2))
-* [1.1.0](https://takeshishimada.github.io/Lockman/1.1.0/documentation/lockman/) ([마이그레이션 가이드](https://takeshishimada.github.io/Lockman/1.1.0/documentation/lockman/migratingto1.1))
+* [1.3.0](https://takeshishimada.github.io/Lockman/1.3.0/documentation/lockman/) ([Migrationsleitfaden](https://takeshishimada.github.io/Lockman/1.3.0/documentation/lockman/migratingto1.3))
+* [1.2.0](https://takeshishimada.github.io/Lockman/1.2.0/documentation/lockman/) ([Migrationsanleitung](https://takeshishimada.github.io/Lockman/1.2.0/documentation/lockman/migratingto1.2))
+* [1.1.0](https://takeshishimada.github.io/Lockman/1.1.0/documentation/lockman/) ([Migrationsanleitung](https://takeshishimada.github.io/Lockman/1.1.0/documentation/lockman/migratingto1.1))
 
 <details>
-<summary>다른 버전</summary>
+<summary>Weitere Versionen</summary>
 
-* [1.0.0](https://takeshishimada.github.io/Lockman/1.0.0/documentation/lockman/) ([마이그레이션 가이드](https://takeshishimada.github.io/Lockman/1.0.0/documentation/lockman/migratingto1.0))
+* [1.0.0](https://takeshishimada.github.io/Lockman/1.0.0/documentation/lockman/) ([Migrationsleitfaden](https://takeshishimada.github.io/Lockman/1.0.0/documentation/lockman/migratingto1.0))
 * [0.13.0](https://takeshishimada.github.io/Lockman/0.13.0/documentation/lockman/)
 * [0.12.0](https://takeshishimada.github.io/Lockman/0.12.0/documentation/lockman/)
 * [0.11.0](https://takeshishimada.github.io/Lockman/0.11.0/documentation/lockman/)
@@ -188,35 +188,35 @@ struct ProcessFeature {
 
 </details>
 
-라이브러리에 익숙해지는 데 도움이 될 수 있는 여러 문서가 있습니다:
+Es gibt mehrere Artikel in der Dokumentation, die Ihnen beim Einstieg in die Bibliothek helfen können:
 
-### 필수 사항
-* [시작하기](https://takeshishimada.github.io/Lockman/main/documentation/lockman/gettingstarted) - TCA 애플리케이션에 Lockman을 통합하는 방법 알아보기
-* [Boundary 개요](https://takeshishimada.github.io/Lockman/main/documentation/lockman/boundaryoverview) - Lockman의 boundary 개념 이해하기
-* [잠금](https://takeshishimada.github.io/Lockman/main/documentation/lockman/lock) - 잠금 메커니즘 이해하기
-* [잠금 해제](https://takeshishimada.github.io/Lockman/main/documentation/lockman/unlock) - 잠금 해제 메커니즘 이해하기
-* [전략 선택](https://takeshishimada.github.io/Lockman/main/documentation/lockman/choosingstrategy) - 사용 사례에 맞는 전략 선택하기
-* [구성](https://takeshishimada.github.io/Lockman/main/documentation/lockman/configuration) - 애플리케이션 요구 사항에 맞게 Lockman 구성하기
-* [오류 처리](https://takeshishimada.github.io/Lockman/main/documentation/lockman/errorhandling) - 일반적인 오류 처리 패턴 알아보기
-* [디버깅 가이드](https://takeshishimada.github.io/Lockman/main/documentation/lockman/debuggingguide) - 애플리케이션에서 Lockman 관련 문제 디버깅하기
+### Grundlagen
+* [Erste Schritte](https://takeshishimada.github.io/Lockman/main/documentation/lockman/gettingstarted) - Lernen Sie, wie Sie Lockman in Ihre TCA-Anwendung integrieren
+* [Boundary-Überblick](https://takeshishimada.github.io/Lockman/main/documentation/lockman/boundaryoverview) - Verstehen Sie das Boundary-Konzept in Lockman
+* [Sperren](https://takeshishimada.github.io/Lockman/main/documentation/lockman/lock) - Verstehen Sie den Sperrmechanismus
+* [Entsperren](https://takeshishimada.github.io/Lockman/main/documentation/lockman/unlock) - Verstehen Sie den Entsperrmechanismus
+* [Eine Strategie wählen](https://takeshishimada.github.io/Lockman/main/documentation/lockman/choosingstrategy) - Wählen Sie die richtige Strategie für Ihren Anwendungsfall
+* [Konfiguration](https://takeshishimada.github.io/Lockman/main/documentation/lockman/configuration) - Konfigurieren Sie Lockman für Ihre Anwendungsanforderungen
+* [Fehlerbehandlung](https://takeshishimada.github.io/Lockman/main/documentation/lockman/errorhandling) - Lernen Sie gängige Fehlerbehandlungsmuster
+* [Debugging-Leitfaden](https://takeshishimada.github.io/Lockman/main/documentation/lockman/debuggingguide) - Debuggen Sie Lockman-bezogene Probleme in Ihrer Anwendung
 
-### 전략
-* [Single Execution Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/singleexecutionstrategy) - 중복 실행 방지
-* [Priority Based Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/prioritybasedstrategy) - 우선순위 기반 제어
-* [Concurrency Limited Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/concurrencylimitedstrategy) - 동시 실행 제한
-* [Group Coordination Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/groupcoordinationstrategy) - 관련 액션 조정
-* [Dynamic Condition Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/dynamicconditionstrategy) - 동적 런타임 제어
-* [Composite Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/compositestrategy) - 여러 전략 결합
+### Strategien
+* [Single Execution Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/singleexecutionstrategy) - Doppelte Ausführung verhindern
+* [Priority Based Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/prioritybasedstrategy) - Prioritätsbasierte Kontrolle
+* [Concurrency Limited Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/concurrencylimitedstrategy) - Gleichzeitige Ausführungen begrenzen
+* [Group Coordination Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/groupcoordinationstrategy) - Verwandte Aktionen koordinieren
+* [Dynamic Condition Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/dynamicconditionstrategy) - Dynamische Laufzeitkontrolle
+* [Composite Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/compositestrategy) - Mehrere Strategien kombinieren
 
-참고: 문서는 영어로만 제공됩니다.
+Hinweis: Die Dokumentation ist nur auf Englisch verfügbar.
 
-## 설치
+## Installation
 
-Lockman은 [Swift Package Manager](https://swift.org/package-manager/)를 사용하여 설치할 수 있습니다.
+Lockman kann über den [Swift Package Manager](https://swift.org/package-manager/) installiert werden.
 
 ### Xcode
 
-Xcode에서 File → Add Package Dependencies를 선택하고 다음 URL을 입력하세요:
+Wählen Sie in Xcode File → Add Package Dependencies und geben Sie die folgende URL ein:
 
 ```
 https://github.com/takeshishimada/Lockman
@@ -224,7 +224,7 @@ https://github.com/takeshishimada/Lockman
 
 ### Package.swift
 
-Package.swift 파일에 종속성을 추가하세요:
+Fügen Sie die Abhängigkeit zu Ihrer Package.swift-Datei hinzu:
 
 ```swift
 dependencies: [
@@ -232,7 +232,7 @@ dependencies: [
 ]
 ```
 
-타겟에 종속성을 추가하세요:
+Fügen Sie die Abhängigkeit zu Ihrem Target hinzu:
 
 ```swift
 .target(
@@ -243,20 +243,26 @@ dependencies: [
 )
 ```
 
-### 요구 사항
+### Anforderungen
 
-| 플랫폼  | 최소 버전 |
-|---------|-----------|
-| iOS     | 13.0      |
-| macOS   | 10.15     |
-| tvOS    | 13.0      |
-| watchOS | 6.0       |
+| Plattform | Mindestversion |
+|-----------|----------------|
+| iOS       | 13.0           |
+| macOS     | 10.15          |
+| tvOS      | 13.0           |
+| watchOS   | 6.0            |
 
-### 버전 호환성
+### Versionskompatibilität
 
 | Lockman | The Composable Architecture |
 |---------|----------------------------|
 | 1.3.0   | 1.20.2                     |
+
+<details>
+<summary>Weitere Versionen</summary>
+
+| Lockman | The Composable Architecture |
+|---------|----------------------------|
 | 1.2.0   | 1.20.2                     |
 | 1.1.0   | 1.20.2                     |
 | 1.0.0   | 1.20.2                     |
@@ -270,12 +276,6 @@ dependencies: [
 | 0.10.0  | 1.19.0                     |
 | 0.9.0   | 1.18.0                     |
 | 0.8.0   | 1.17.1                     |
-
-<details>
-<summary>다른 버전</summary>
-
-| Lockman | The Composable Architecture |
-|---------|----------------------------|
 | 0.7.0   | 1.17.1                     |
 | 0.6.0   | 1.17.1                     |
 | 0.5.0   | 1.17.1                     |
@@ -302,20 +302,20 @@ This documentation is also available in other languages:
 - [Português (Portuguese)](README_pt-BR.md)
 - [Italiano (Italian)](README_it.md)
 
-## 커뮤니티
+## Community
 
-### 토론 및 도움말
+### Diskussion und Hilfe
 
-질문과 토론은 [GitHub Discussions](https://github.com/takeshishimada/Lockman/discussions)에서 진행할 수 있습니다.
+Fragen und Diskussionen können in [GitHub Discussions](https://github.com/takeshishimada/Lockman/discussions) geführt werden.
 
-### 버그 보고
+### Fehlerberichte
 
-버그를 발견하면 [Issues](https://github.com/takeshishimada/Lockman/issues)에 보고해 주세요.
+Wenn Sie einen Fehler finden, melden Sie ihn bitte unter [Issues](https://github.com/takeshishimada/Lockman/issues).
 
-### 기여
+### Beitragen
 
-라이브러리에 기여하고 싶으시면 링크와 함께 PR을 열어주세요!
+Wenn Sie zur Bibliothek beitragen möchten, öffnen Sie bitte eine PR mit einem Link dazu!
 
-## 라이선스
+## Lizenz
 
-이 라이브러리는 MIT 라이선스로 출시되었습니다. 자세한 내용은 [LICENSE](./LICENSE) 파일을 참조하세요.
+Diese Bibliothek wird unter der MIT-Lizenz veröffentlicht. Siehe [LICENSE](./LICENSE) Datei für Details.

--- a/READMEs/README_es.md
+++ b/READMEs/README_es.md
@@ -257,6 +257,12 @@ Agrega la dependencia a tu objetivo:
 | Lockman | The Composable Architecture |
 |---------|----------------------------|
 | 1.3.0   | 1.20.2                     |
+
+<details>
+<summary>Otras versiones</summary>
+
+| Lockman | The Composable Architecture |
+|---------|----------------------------|
 | 1.2.0   | 1.20.2                     |
 | 1.1.0   | 1.20.2                     |
 | 1.0.0   | 1.20.2                     |
@@ -270,12 +276,6 @@ Agrega la dependencia a tu objetivo:
 | 0.10.0  | 1.19.0                     |
 | 0.9.0   | 1.18.0                     |
 | 0.8.0   | 1.17.1                     |
-
-<details>
-<summary>Otras versiones</summary>
-
-| Lockman | The Composable Architecture |
-|---------|----------------------------|
 | 0.7.0   | 1.17.1                     |
 | 0.6.0   | 1.17.1                     |
 | 0.5.0   | 1.17.1                     |

--- a/READMEs/README_fr.md
+++ b/READMEs/README_fr.md
@@ -4,53 +4,54 @@
 [![Swift](https://img.shields.io/badge/Swift-5.9%20%7C%205.10%20%7C%206.0-ED523F.svg?style=flat)](https://swift.org/download/)
 [![Platforms](https://img.shields.io/badge/Platforms-iOS%20%7C%20macOS%20%7C%20tvOS%20%7C%20watchOS%20%7C%20Mac%20Catalyst-333333.svg?style=flat)](https://developer.apple.com/)
 
-LockmanはThe Composable Architecture（TCA）アプリケーションにおける排他アクションの制御問題を解決するSwiftライブラリです。応答性、透明性、宣言的設計を重視しています。
 
-* [設計思想](#設計思想)
-* [概要](#概要)
-* [基本例](#基本例)
-* [インストール](#インストール)
-* [コミュニティ](#コミュニティ)
+Lockman est une bibliothèque Swift qui résout les problèmes de contrôle des actions concurrentes dans les applications The Composable Architecture (TCA), en mettant l'accent sur la réactivité, la transparence et la conception déclarative.
 
-## 設計思想
+* [Philosophie de Conception](#philosophie-de-conception)
+* [Vue d'Ensemble](#vue-densemble)
+* [Exemple de Base](#exemple-de-base)
+* [Installation](#installation)
+* [Communauté](#communauté)
 
-### Designing Fluid Interfacesの原則
+## Philosophie de Conception
 
-WWDC18「Designing Fluid Interfaces」では、優れたインターフェースの原則が示されました：
+### Principes de Designing Fluid Interfaces
 
-* **即座の応答と継続的なリダイレクション** - 10msの遅延も感じさせない応答性
-* **タッチとコンテンツの1対1の動き** - ドラッグ時にコンテンツが指に追従
-* **継続的なフィードバック** - すべてのインタラクションに対する即座の反応
-* **複数ジェスチャーの並列検出** - 同時に複数のジェスチャーを認識
-* **空間的な一貫性の維持** - アニメーション中の位置の一貫性
-* **軽量なインタラクション、増幅された出力** - 小さな入力から大きな効果
+La présentation "Designing Fluid Interfaces" de WWDC18 a présenté des principes pour des interfaces exceptionnelles :
 
-### 従来の課題
+* **Réponse Immédiate et Redirection Continue** - Une réactivité qui ne tolère pas même 10ms de délai
+* **Mouvement Un-à-Un entre le Toucher et le Contenu** - Le contenu suit le doigt pendant les opérations de glissement
+* **Retour d'Information Continu** - Réaction immédiate à toutes les interactions
+* **Détection de Gestes en Parallèle** - Reconnaissance de plusieurs gestes simultanément
+* **Cohérence Spatiale** - Maintien de la cohérence de position pendant les animations
+* **Interactions Légères, Sortie Amplifiée** - Grands effets à partir de petites entrées
 
-従来のUI開発では、ボタンの同時押しや重複実行を単純に禁止することで問題を解決してきました。これらのアプローチは現代の流動的なインターフェース設計において、ユーザー体験を阻害する要因となっています。
+### Défis Traditionnels
 
-ユーザーは押下可能なボタンに対して、同時押しの場合でも何らかのフィードバックを期待します。UI層での即座の応答と、ビジネスロジック層での適切な排他制御を明確に分離することが重要です。
+Le développement d'interface utilisateur traditionnel a résolu les problèmes en interdisant simplement les pressions simultanées de boutons et les exécutions en double. Ces approches sont devenues des facteurs qui entravent l'expérience utilisateur dans la conception moderne d'interfaces fluides.
 
-## 概要
+Les utilisateurs attendent une forme de retour d'information même lorsqu'ils appuient simultanément sur des boutons. Il est crucial de séparer clairement la réponse immédiate au niveau de la couche UI du contrôle d'exclusion mutuelle approprié au niveau de la couche de logique métier.
 
-Lockmanは以下の制御戦略を提供し、実際のアプリ開発で頻繁に発生する問題に対処します：
+## Vue d'Ensemble
 
-* **Single Execution**: 同じアクションの重複実行を防止
-* **Priority Based**: 優先度に基づくアクションの制御とキャンセル
-* **Group Coordination**: リーダー/メンバーの役割によるグループ制御
-* **Dynamic Condition**: 実行時条件による動的制御
-* **Concurrency Limited**: グループごとの同時実行数を制限
-* **Composite Strategy**: 複数戦略の組み合わせ
+Lockman fournit les stratégies de contrôle suivantes pour résoudre les problèmes courants dans le développement d'applications :
 
-## 例
+* **Single Execution** : Empêche l'exécution en double de la même action
+* **Priority Based** : Contrôle et annulation d'actions basés sur la priorité
+* **Group Coordination** : Contrôle de groupe via les rôles leader/membre
+* **Dynamic Condition** : Contrôle dynamique basé sur les conditions d'exécution
+* **Concurrency Limited** : Limite le nombre d'exécutions concurrentes par groupe
+* **Composite Strategy** : Combinaison de plusieurs stratégies
+
+## Exemples
 
 | Single Execution Strategy | Priority Based Strategy | Concurrency Limited Strategy |
 |--------------------------|------------------------|------------------------------|
 | ![Single Execution Strategy](../Sources/Lockman/Documentation.docc/images/01-SingleExecutionStrategy.gif) | ![Priority Based Strategy](../Sources/Lockman/Documentation.docc/images/02-PriorityBasedStrategy.gif) | ![Concurrency Limited Strategy](../Sources/Lockman/Documentation.docc/images/03-ConcurrencyLimitedStrategy.gif) |
 
-## コード例
+## Exemple de Code
 
-`@LockmanSingleExecution`マクロを使用して、処理の重複実行を防ぐ機能を実装する方法：
+Voici comment implémenter une fonctionnalité qui empêche l'exécution en double de processus en utilisant la macro `@LockmanSingleExecution` :
 
 ```swift
 import CasePaths
@@ -98,7 +99,7 @@ struct ProcessFeature {
                 case .startProcessButtonTapped:
                     return .run { send in
                         await send(.internal(.processStart))
-                        // 重い処理をシミュレート
+                        // Simuler un traitement lourd
                         try await Task.sleep(nanoseconds: 3_000_000_000)
                         await send(.internal(.processCompleted))
                     }
@@ -108,12 +109,12 @@ struct ProcessFeature {
                 switch internalAction {
                 case .processStart:
                     state.isProcessing = true
-                    state.message = "処理を開始しました..."
+                    state.message = "Traitement démarré..."
                     return .none
                     
                 case .processCompleted:
                     state.isProcessing = false
-                    state.message = "処理が完了しました"
+                    state.message = "Traitement terminé"
                     return .none
                     
                 case .updateMessage(let message):
@@ -125,10 +126,10 @@ struct ProcessFeature {
         .lock(
             boundaryId: CancelID.userAction,
             lockFailure: { error, send in
-                // すでに処理が実行中の場合
+                // Lorsque le traitement est déjà en cours
                 if error is LockmanSingleExecutionError {
-                    // アクションを通じてメッセージを更新
-                    await send(.internal(.updateMessage("処理は既に実行中です")))
+                    // Mettre à jour le message via une action au lieu d'une mutation directe de l'état
+                    await send(.internal(.updateMessage("Le traitement est déjà en cours")))
                 }
             },
             for: \.view
@@ -137,9 +138,9 @@ struct ProcessFeature {
 }
 ```
 
-`Reducer.lock`モディファイアは`LockmanAction`に準拠するアクションに対して自動的にロック管理を適用します。`ViewAction`列挙型が`@LockmanSingleExecution`でマークされているため、`startProcessButtonTapped`アクションは処理中に再実行されません。`for: \.view`パラメータはLockmanに`view`ケースにネストされたアクションの`LockmanAction`準拠性をチェックするよう指示します。
+Le modificateur `Reducer.lock` applique automatiquement la gestion des verrous aux actions qui se conforment à `LockmanAction`. Puisque l'énumération `ViewAction` est marquée avec `@LockmanSingleExecution`, l'action `startProcessButtonTapped` ne s'exécutera pas pendant que le traitement est en cours. Le paramètre `for: \.view` indique à Lockman de vérifier la conformité à `LockmanAction` pour les actions imbriquées dans le cas `view`.
 
-### デバッグ出力例
+### Exemple de Sortie de Débogage
 
 ```
 ✅ [Lockman] canLock succeeded - Strategy: SingleExecution, BoundaryId: process, Info: LockmanSingleExecutionInfo(actionId: 'startProcessButtonTapped', uniqueId: 7BFC785A-3D25-4722-B9BC-A3A63A7F49FC, mode: boundary)
@@ -160,19 +161,19 @@ struct ProcessFeature {
 └─────────────────┴──────────────────┴──────────────────────────────────────┴─────────────────┘
 ```
 
-## ドキュメント
+## Documentation
 
-リリース版とmainのドキュメントはこちらで利用できます：
+La documentation pour les versions publiées et `main` est disponible ici :
 
 * [`main`](https://takeshishimada.github.io/Lockman/main/documentation/lockman/)
-* [1.3.0](https://takeshishimada.github.io/Lockman/1.3.0/documentation/lockman/) ([マイグレーションガイド](https://takeshishimada.github.io/Lockman/1.3.0/documentation/lockman/migratingto1.3))
-* [1.2.0](https://takeshishimada.github.io/Lockman/1.2.0/documentation/lockman/) ([マイグレーションガイド](https://takeshishimada.github.io/Lockman/1.2.0/documentation/lockman/migratingto1.2))
-* [1.1.0](https://takeshishimada.github.io/Lockman/1.1.0/documentation/lockman/) ([マイグレーションガイド](https://takeshishimada.github.io/Lockman/1.1.0/documentation/lockman/migratingto1.1))
+* [1.3.0](https://takeshishimada.github.io/Lockman/1.3.0/documentation/lockman/) ([guide de migration](https://takeshishimada.github.io/Lockman/1.3.0/documentation/lockman/migratingto1.3))
+* [1.2.0](https://takeshishimada.github.io/Lockman/1.2.0/documentation/lockman/) ([guide de migration](https://takeshishimada.github.io/Lockman/1.2.0/documentation/lockman/migratingto1.2))
+* [1.1.0](https://takeshishimada.github.io/Lockman/1.1.0/documentation/lockman/) ([guide de migration](https://takeshishimada.github.io/Lockman/1.1.0/documentation/lockman/migratingto1.1))
 
 <details>
-<summary>その他のバージョン</summary>
+<summary>Autres versions</summary>
 
-* [1.0.0](https://takeshishimada.github.io/Lockman/1.0.0/documentation/lockman/) ([マイグレーションガイド](https://takeshishimada.github.io/Lockman/1.0.0/documentation/lockman/migratingto1.0))
+* [1.0.0](https://takeshishimada.github.io/Lockman/1.0.0/documentation/lockman/) ([guide de migration](https://takeshishimada.github.io/Lockman/1.0.0/documentation/lockman/migratingto1.0))
 * [0.13.0](https://takeshishimada.github.io/Lockman/0.13.0/documentation/lockman/)
 * [0.12.0](https://takeshishimada.github.io/Lockman/0.12.0/documentation/lockman/)
 * [0.11.0](https://takeshishimada.github.io/Lockman/0.11.0/documentation/lockman/)
@@ -187,33 +188,35 @@ struct ProcessFeature {
 
 </details>
 
-ライブラリをより深く理解するために、以下のドキュメントが役立つでしょう：
+Il existe plusieurs articles dans la documentation qui peuvent vous être utiles pour vous familiariser avec la bibliothèque :
 
-### Essentials
-* [Getting Started](https://takeshishimada.github.io/Lockman/main/documentation/lockman/gettingstarted) - LockmanをTCAアプリケーションに統合する方法
-* [Boundary Overview](https://takeshishimada.github.io/Lockman/main/documentation/lockman/boundaryoverview) - Lockmanにおける境界の概念を理解する
-* [Lock](https://takeshishimada.github.io/Lockman/main/documentation/lockman/lock) - ロック機構の理解
-* [Unlock](https://takeshishimada.github.io/Lockman/main/documentation/lockman/unlock) - アンロック機構の理解
-* [Choosing a Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/choosingstrategy) - ユースケースに適した戦略を選択する
-* [Configuration](https://takeshishimada.github.io/Lockman/main/documentation/lockman/configuration) - アプリケーションのニーズに合わせてLockmanを設定する
-* [Error Handling](https://takeshishimada.github.io/Lockman/main/documentation/lockman/errorhandling) - 一般的なエラーハンドリングパターンを学ぶ
-* [Debugging Guide](https://takeshishimada.github.io/Lockman/main/documentation/lockman/debuggingguide) - アプリケーションのLockman関連の問題をデバッグする
+### Essentiels
+* [Démarrage](https://takeshishimada.github.io/Lockman/main/documentation/lockman/gettingstarted) - Apprenez à intégrer Lockman dans votre application TCA
+* [Vue d'Ensemble des Limites](https://takeshishimada.github.io/Lockman/main/documentation/lockman/boundaryoverview) - Comprendre le concept de limites dans Lockman
+* [Verrouillage](https://takeshishimada.github.io/Lockman/main/documentation/lockman/lock) - Comprendre le mécanisme de verrouillage
+* [Déverrouillage](https://takeshishimada.github.io/Lockman/main/documentation/lockman/unlock) - Comprendre le mécanisme de déverrouillage
+* [Choisir une Stratégie](https://takeshishimada.github.io/Lockman/main/documentation/lockman/choosingstrategy) - Sélectionnez la bonne stratégie pour votre cas d'utilisation
+* [Configuration](https://takeshishimada.github.io/Lockman/main/documentation/lockman/configuration) - Configurez Lockman pour les besoins de votre application
+* [Gestion des Erreurs](https://takeshishimada.github.io/Lockman/main/documentation/lockman/errorhandling) - Apprenez les modèles courants de gestion des erreurs
+* [Guide de Débogage](https://takeshishimada.github.io/Lockman/main/documentation/lockman/debuggingguide) - Déboguez les problèmes liés à Lockman dans votre application
 
-### 戦略
-* [Single Execution Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/singleexecutionstrategy) - 重複実行を防止
-* [Priority Based Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/prioritybasedstrategy) - 優先度に基づく制御
-* [Concurrency Limited Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/concurrencylimitedstrategy) - 同時実行数を制限
-* [Group Coordination Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/groupcoordinationstrategy) - 関連するアクションを協調
-* [Dynamic Condition Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/dynamicconditionstrategy) - 動的なランタイム制御
-* [Composite Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/compositestrategy) - 複数の戦略を組み合わせる
+### Stratégies
+* [Single Execution Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/singleexecutionstrategy) - Empêcher l'exécution en double
+* [Priority Based Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/prioritybasedstrategy) - Contrôle basé sur la priorité
+* [Concurrency Limited Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/concurrencylimitedstrategy) - Limiter les exécutions concurrentes
+* [Group Coordination Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/groupcoordinationstrategy) - Coordonner les actions liées
+* [Dynamic Condition Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/dynamicconditionstrategy) - Contrôle dynamique à l'exécution
+* [Composite Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/compositestrategy) - Combiner plusieurs stratégies
 
-## インストール
+Note : La documentation est disponible uniquement en anglais.
 
-Lockmanは[Swift Package Manager](https://swift.org/package-manager/)でインストールできます。
+## Installation
+
+Lockman peut être installé en utilisant [Swift Package Manager](https://swift.org/package-manager/).
 
 ### Xcode
 
-Xcodeで File → Add Package Dependencies を選択し、以下のURLを入力：
+Dans Xcode, sélectionnez File → Add Package Dependencies et entrez l'URL suivante :
 
 ```
 https://github.com/takeshishimada/Lockman
@@ -221,7 +224,7 @@ https://github.com/takeshishimada/Lockman
 
 ### Package.swift
 
-Package.swiftファイルに依存関係を追加：
+Ajoutez la dépendance à votre fichier Package.swift :
 
 ```swift
 dependencies: [
@@ -229,7 +232,7 @@ dependencies: [
 ]
 ```
 
-ターゲットに依存関係を追加：
+Ajoutez la dépendance à votre cible :
 
 ```swift
 .target(
@@ -240,20 +243,26 @@ dependencies: [
 )
 ```
 
-### 動作要件
+### Configuration Requise
 
-| Platform | Minimum Version |
-|----------|----------------|
-| iOS      | 13.0           |
-| macOS    | 10.15          |
-| tvOS     | 13.0           |
-| watchOS  | 6.0            |
+| Plateforme | Version Minimale |
+|------------|------------------|
+| iOS        | 13.0             |
+| macOS      | 10.15            |
+| tvOS       | 13.0             |
+| watchOS    | 6.0              |
 
-### バージョン互換性
+### Compatibilité des Versions
 
 | Lockman | The Composable Architecture |
 |---------|----------------------------|
 | 1.3.0   | 1.20.2                     |
+
+<details>
+<summary>Autres versions</summary>
+
+| Lockman | The Composable Architecture |
+|---------|----------------------------|
 | 1.2.0   | 1.20.2                     |
 | 1.1.0   | 1.20.2                     |
 | 1.0.0   | 1.20.2                     |
@@ -267,12 +276,6 @@ dependencies: [
 | 0.10.0  | 1.19.0                     |
 | 0.9.0   | 1.18.0                     |
 | 0.8.0   | 1.17.1                     |
-
-<details>
-<summary>その他のバージョン</summary>
-
-| Lockman | The Composable Architecture |
-|---------|----------------------------|
 | 0.7.0   | 1.17.1                     |
 | 0.6.0   | 1.17.1                     |
 | 0.5.0   | 1.17.1                     |
@@ -284,35 +287,35 @@ dependencies: [
 
 </details>
 
-### 翻訳
+## Translations
 
-The following translations of this README have been contributed by members of the community:
+This documentation is also available in other languages:
 
 - [English](../README.md)
-- [Japanese](README_ja.md)
-- [Simplified Chinese](README_zh-CN.md)
-- [Traditional Chinese](README_zh-TW.md)
-- [Spanish](README_es.md)
-- [French](README_fr.md)
-- [German](README_de.md)
-- [Korean](README_ko.md)
-- [Portuguese](README_pt-BR.md)
-- [Italian](README_it.md)
+- [日本語 (Japanese)](README_ja.md)
+- [简体中文 (Simplified Chinese)](README_zh-CN.md)
+- [繁體中文 (Traditional Chinese)](README_zh-TW.md)
+- [Español (Spanish)](README_es.md)
+- [Français (French)](README_fr.md)
+- [Deutsch (German)](README_de.md)
+- [한국어 (Korean)](README_ko.md)
+- [Português (Portuguese)](README_pt-BR.md)
+- [Italiano (Italian)](README_it.md)
 
-## コミュニティ
+## Communauté
 
-### 議論とヘルプ
+### Discussion et Aide
 
-質問や議論は[GitHub Discussions](https://github.com/takeshishimada/Lockman/discussions)で行えます。
+Les questions et discussions peuvent être tenues sur [GitHub Discussions](https://github.com/takeshishimada/Lockman/discussions).
 
-### バグ報告
+### Rapports de Bogues
 
-バグを発見した場合は[Issues](https://github.com/takeshishimada/Lockman/issues)で報告してください。
+Si vous trouvez un bogue, veuillez le signaler sur [Issues](https://github.com/takeshishimada/Lockman/issues).
 
-### コントリビューション
+### Contribution
 
-ライブラリにコントリビュートしたい場合は、リンク付きのPRを開いてください！
+Si vous souhaitez contribuer à la bibliothèque, veuillez ouvrir une PR avec un lien vers celle-ci !
 
-## ライセンス
+## Licence
 
-このライブラリはMITライセンスの下でリリースされています。詳細は[LICENSE](./LICENSE)ファイルをご確認ください。
+Cette bibliothèque est publiée sous la licence MIT. Consultez le fichier [LICENSE](./LICENSE) pour plus de détails.

--- a/READMEs/README_it.md
+++ b/READMEs/README_it.md
@@ -5,53 +5,53 @@
 [![Platforms](https://img.shields.io/badge/Platforms-iOS%20%7C%20macOS%20%7C%20tvOS%20%7C%20watchOS%20%7C%20Mac%20Catalyst-333333.svg?style=flat)](https://developer.apple.com/)
 
 
-Lockman 是一個 Swift 函式庫，旨在解決 The Composable Architecture (TCA) 應用程式中的並行動作控制問題，著重於回應性、透明性和宣告式設計。
+Lockman è una libreria Swift che risolve i problemi di controllo esclusivo delle azioni nelle applicazioni The Composable Architecture (TCA), con reattività, trasparenza e design dichiarativo in mente.
 
-* [設計理念](#設計理念)
-* [概述](#概述)
-* [基本範例](#基本範例)
-* [安裝](#安裝)
-* [社群](#社群)
+* [Filosofia di Design](#filosofia-di-design)
+* [Panoramica](#panoramica)
+* [Esempio Base](#esempio-base)
+* [Installazione](#installazione)
+* [Comunità](#comunità)
 
-## 設計理念
+## Filosofia di Design
 
-### Designing Fluid Interfaces 原則
+### Principi di Designing Fluid Interfaces
 
-WWDC18 的「Designing Fluid Interfaces」提出了卓越介面的原則：
+"Designing Fluid Interfaces" della WWDC18 ha presentato principi per interfacce eccezionali:
 
-* **即時回應和持續重新導向** - 不允許有 10 毫秒延遲的回應性
-* **一對一的觸控和內容移動** - 拖曳操作時內容跟隨手指
-* **持續回饋** - 對所有互動的即時反應
-* **平行手勢偵測** - 同時識別多個手勢
-* **空間一致性** - 動畫期間保持位置一致性
-* **輕量級互動，放大輸出** - 小輸入產生大效果
+* **Risposta Immediata e Reindirizzamento Continuo** - Reattività che non permette nemmeno 10ms di ritardo
+* **Movimento di Tocco e Contenuto Uno-a-Uno** - Il contenuto segue il dito durante le operazioni di trascinamento
+* **Feedback Continuo** - Reazione immediata a tutte le interazioni
+* **Rilevamento di Gesti Paralleli** - Riconoscimento di più gesti simultaneamente
+* **Coerenza Spaziale** - Mantenimento della coerenza di posizione durante le animazioni
+* **Interazioni Leggere, Output Amplificato** - Grandi effetti da piccoli input
 
-### 傳統挑戰
+### Sfide Tradizionali
 
-傳統 UI 開發透過簡單地禁止同時按下按鈕和重複執行來解決問題。這些方法已成為現代流暢介面設計中阻礙使用者體驗的因素。
+Lo sviluppo tradizionale dell'UI ha risolto i problemi semplicemente proibendo pressioni simultanee di pulsanti ed esecuzioni duplicate. Questi approcci sono diventati fattori che ostacolano l'esperienza utente nel moderno design di interfacce fluide.
 
-使用者期望即使同時按下按鈕也能獲得某種形式的回饋。在 UI 層的即時回應與業務邏輯層的適當互斥控制之間進行清晰分離至關重要。
+Gli utenti si aspettano qualche forma di feedback anche quando premono i pulsanti simultaneamente. È cruciale separare chiaramente la risposta immediata al livello UI dal controllo appropriato di esclusione reciproca al livello della logica di business.
 
-## 概述
+## Panoramica
 
-Lockman 提供以下控制策略來解決應用程式開發中的常見問題：
+Lockman fornisce le seguenti strategie di controllo per affrontare problemi comuni nello sviluppo di app:
 
-* **Single Execution**：防止相同動作的重複執行
-* **Priority Based**：基於優先順序的動作控制和取消
-* **Group Coordination**：透過領導者/成員角色進行群組控制
-* **Dynamic Condition**：基於執行時條件的動態控制
-* **Concurrency Limited**：限制每組的並行執行數量
-* **Composite Strategy**：多種策略的組合
+* **Esecuzione Singola**: Previene l'esecuzione duplicata della stessa azione
+* **Basata su Priorità**: Controllo e cancellazione delle azioni basata su priorità
+* **Coordinamento di Gruppo**: Controllo di gruppo attraverso ruoli leader/membro
+* **Condizione Dinamica**: Controllo dinamico basato su condizioni runtime
+* **Concorrenza Limitata**: Limita il numero di esecuzioni concorrenti per gruppo
+* **Strategia Composita**: Combinazione di più strategie
 
-## 範例
+## Esempi
 
-| Single Execution Strategy | Priority Based Strategy | Concurrency Limited Strategy |
-|--------------------------|------------------------|------------------------------|
-| ![Single Execution Strategy](../Sources/Lockman/Documentation.docc/images/01-SingleExecutionStrategy.gif) | ![Priority Based Strategy](../Sources/Lockman/Documentation.docc/images/02-PriorityBasedStrategy.gif) | ![Concurrency Limited Strategy](../Sources/Lockman/Documentation.docc/images/03-ConcurrencyLimitedStrategy.gif) |
+| Strategia di Esecuzione Singola | Strategia Basata su Priorità | Strategia di Concorrenza Limitata |
+|----------------------------------|------------------------------|-----------------------------------|
+| ![Strategia di Esecuzione Singola](../Sources/Lockman/Documentation.docc/images/01-SingleExecutionStrategy.gif) | ![Strategia Basata su Priorità](../Sources/Lockman/Documentation.docc/images/02-PriorityBasedStrategy.gif) | ![Strategia di Concorrenza Limitata](../Sources/Lockman/Documentation.docc/images/03-ConcurrencyLimitedStrategy.gif) |
 
-## 程式碼範例
+## Esempio di Codice
 
-以下是如何使用 `@LockmanSingleExecution` 巨集實作防止程序重複執行的功能：
+Ecco come implementare una funzionalità che previene l'esecuzione duplicata di processi usando il macro `@LockmanSingleExecution`:
 
 ```swift
 import CasePaths
@@ -99,7 +99,7 @@ struct ProcessFeature {
                 case .startProcessButtonTapped:
                     return .run { send in
                         await send(.internal(.processStart))
-                        // 模擬重處理
+                        // Simula elaborazione pesante
                         try await Task.sleep(nanoseconds: 3_000_000_000)
                         await send(.internal(.processCompleted))
                     }
@@ -109,12 +109,12 @@ struct ProcessFeature {
                 switch internalAction {
                 case .processStart:
                     state.isProcessing = true
-                    state.message = "處理已開始..."
+                    state.message = "Elaborazione avviata..."
                     return .none
                     
                 case .processCompleted:
                     state.isProcessing = false
-                    state.message = "處理已完成"
+                    state.message = "Elaborazione completata"
                     return .none
                     
                 case .updateMessage(let message):
@@ -126,10 +126,10 @@ struct ProcessFeature {
         .lock(
             boundaryId: CancelID.userAction,
             lockFailure: { error, send in
-                // 當處理已經在進行中時
+                // Quando l'elaborazione è già in corso
                 if error is LockmanSingleExecutionError {
-                    // 透過動作更新訊息而不是直接修改狀態
-                    await send(.internal(.updateMessage("處理已經在進行中")))
+                    // Aggiorna il messaggio tramite un'azione invece di mutazione diretta dello stato
+                    await send(.internal(.updateMessage("L'elaborazione è già in corso")))
                 }
             },
             for: \.view
@@ -138,9 +138,9 @@ struct ProcessFeature {
 }
 ```
 
-`Reducer.lock` 修飾符自動對符合 `LockmanAction` 的動作應用鎖管理。由於 `ViewAction` 枚舉被標記為 `@LockmanSingleExecution`，`startProcessButtonTapped` 動作在處理進行中時不會被執行。`for: \.view` 參數告訴 Lockman 檢查嵌套在 `view` 情況中的動作的 `LockmanAction` 一致性。
+Il modificatore `Reducer.lock` applica automaticamente la gestione dei lock alle azioni che si conformano a `LockmanAction`. Poiché l'enumerazione `ViewAction` è contrassegnata con `@LockmanSingleExecution`, l'azione `startProcessButtonTapped` non verrà eseguita mentre l'elaborazione è in corso. Il parametro `for: \.view` indica a Lockman di controllare la conformità a `LockmanAction` per le azioni annidate nel caso `view`.
 
-### 除錯輸出範例
+### Esempio di Output di Debug
 
 ```
 ✅ [Lockman] canLock succeeded - Strategy: SingleExecution, BoundaryId: process, Info: LockmanSingleExecutionInfo(actionId: 'startProcessButtonTapped', uniqueId: 7BFC785A-3D25-4722-B9BC-A3A63A7F49FC, mode: boundary)
@@ -161,19 +161,19 @@ struct ProcessFeature {
 └─────────────────┴──────────────────┴──────────────────────────────────────┴─────────────────┘
 ```
 
-## 文件
+## Documentazione
 
-發布版本和 `main` 分支的文件可在此處取得：
+La documentazione per le release e `main` è disponibile qui:
 
 * [`main`](https://takeshishimada.github.io/Lockman/main/documentation/lockman/)
-* [1.3.0](https://takeshishimada.github.io/Lockman/1.3.0/documentation/lockman/) ([移轉指南](https://takeshishimada.github.io/Lockman/1.3.0/documentation/lockman/migratingto1.3))
-* [1.2.0](https://takeshishimada.github.io/Lockman/1.2.0/documentation/lockman/) ([遷移指南](https://takeshishimada.github.io/Lockman/1.2.0/documentation/lockman/migratingto1.2))
-* [1.1.0](https://takeshishimada.github.io/Lockman/1.1.0/documentation/lockman/) ([遷移指南](https://takeshishimada.github.io/Lockman/1.1.0/documentation/lockman/migratingto1.1))
+* [1.3.0](https://takeshishimada.github.io/Lockman/1.3.0/documentation/lockman/) ([guida alla migrazione](https://takeshishimada.github.io/Lockman/1.3.0/documentation/lockman/migratingto1.3))
+* [1.2.0](https://takeshishimada.github.io/Lockman/1.2.0/documentation/lockman/) ([guida alla migrazione](https://takeshishimada.github.io/Lockman/1.2.0/documentation/lockman/migratingto1.2))
+* [1.1.0](https://takeshishimada.github.io/Lockman/1.1.0/documentation/lockman/) ([guida alla migrazione](https://takeshishimada.github.io/Lockman/1.1.0/documentation/lockman/migratingto1.1))
 
 <details>
-<summary>其他版本</summary>
+<summary>Altre versioni</summary>
 
-* [1.0.0](https://takeshishimada.github.io/Lockman/1.0.0/documentation/lockman/) ([移轉指南](https://takeshishimada.github.io/Lockman/1.0.0/documentation/lockman/migratingto1.0))
+* [1.0.0](https://takeshishimada.github.io/Lockman/1.0.0/documentation/lockman/) ([guida alla migrazione](https://takeshishimada.github.io/Lockman/1.0.0/documentation/lockman/migratingto1.0))
 * [0.13.0](https://takeshishimada.github.io/Lockman/0.13.0/documentation/lockman/)
 * [0.12.0](https://takeshishimada.github.io/Lockman/0.12.0/documentation/lockman/)
 * [0.11.0](https://takeshishimada.github.io/Lockman/0.11.0/documentation/lockman/)
@@ -188,35 +188,35 @@ struct ProcessFeature {
 
 </details>
 
-文件中有許多文章可以幫助您更好地使用該函式庫：
+Ci sono numerosi articoli nella documentazione che potresti trovare utili mentre prendi confidenza con la libreria:
 
-### 基礎知識
-* [入門指南](https://takeshishimada.github.io/Lockman/main/documentation/lockman/gettingstarted) - 了解如何將 Lockman 整合到您的 TCA 應用程式中
-* [邊界概述](https://takeshishimada.github.io/Lockman/main/documentation/lockman/boundaryoverview) - 理解 Lockman 中的邊界概念
-* [鎖定](https://takeshishimada.github.io/Lockman/main/documentation/lockman/lock) - 理解鎖定機制
-* [解鎖](https://takeshishimada.github.io/Lockman/main/documentation/lockman/unlock) - 理解解鎖機制
-* [選擇策略](https://takeshishimada.github.io/Lockman/main/documentation/lockman/choosingstrategy) - 為您的使用案例選擇合適的策略
-* [設定](https://takeshishimada.github.io/Lockman/main/documentation/lockman/configuration) - 根據應用程式需求設定 Lockman
-* [錯誤處理](https://takeshishimada.github.io/Lockman/main/documentation/lockman/errorhandling) - 了解常見的錯誤處理模式
-* [除錯指南](https://takeshishimada.github.io/Lockman/main/documentation/lockman/debuggingguide) - 除錯應用程式中與 Lockman 相關的問題
+### Essenziali
+* [Iniziare](https://takeshishimada.github.io/Lockman/main/documentation/lockman/gettingstarted) - Impara come integrare Lockman nella tua applicazione TCA
+* [Panoramica dei Confini](https://takeshishimada.github.io/Lockman/main/documentation/lockman/boundaryoverview) - Comprendi il concetto di confini in Lockman
+* [Lock](https://takeshishimada.github.io/Lockman/main/documentation/lockman/lock) - Comprendere il meccanismo di blocco
+* [Unlock](https://takeshishimada.github.io/Lockman/main/documentation/lockman/unlock) - Comprendere il meccanismo di sblocco
+* [Scegliere una Strategia](https://takeshishimada.github.io/Lockman/main/documentation/lockman/choosingstrategy) - Seleziona la strategia giusta per il tuo caso d'uso
+* [Configurazione](https://takeshishimada.github.io/Lockman/main/documentation/lockman/configuration) - Configura Lockman per le esigenze della tua applicazione
+* [Gestione degli Errori](https://takeshishimada.github.io/Lockman/main/documentation/lockman/errorhandling) - Impara i pattern comuni di gestione degli errori
+* [Guida al Debug](https://takeshishimada.github.io/Lockman/main/documentation/lockman/debuggingguide) - Esegui il debug dei problemi relativi a Lockman nella tua applicazione
 
-### 策略
-* [Single Execution Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/singleexecutionstrategy) - 防止重複執行
-* [Priority Based Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/prioritybasedstrategy) - 基於優先順序的控制
-* [Concurrency Limited Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/concurrencylimitedstrategy) - 限制並行執行
-* [Group Coordination Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/groupcoordinationstrategy) - 協調相關動作
-* [Dynamic Condition Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/dynamicconditionstrategy) - 動態執行時控制
-* [Composite Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/compositestrategy) - 組合多種策略
+### Strategie
+* [Strategia di Esecuzione Singola](https://takeshishimada.github.io/Lockman/main/documentation/lockman/singleexecutionstrategy) - Previene l'esecuzione duplicata
+* [Strategia Basata su Priorità](https://takeshishimada.github.io/Lockman/main/documentation/lockman/prioritybasedstrategy) - Controllo basato su priorità
+* [Strategia di Concorrenza Limitata](https://takeshishimada.github.io/Lockman/main/documentation/lockman/concurrencylimitedstrategy) - Limita le esecuzioni concorrenti
+* [Strategia di Coordinamento di Gruppo](https://takeshishimada.github.io/Lockman/main/documentation/lockman/groupcoordinationstrategy) - Coordina le azioni correlate
+* [Strategia di Condizione Dinamica](https://takeshishimada.github.io/Lockman/main/documentation/lockman/dynamicconditionstrategy) - Controllo dinamico runtime
+* [Strategia Composita](https://takeshishimada.github.io/Lockman/main/documentation/lockman/compositestrategy) - Combina più strategie
 
-註：文件僅提供英文版本。
+Nota: La documentazione è disponibile solo in inglese.
 
-## 安裝
+## Installazione
 
-Lockman 可以使用 [Swift Package Manager](https://swift.org/package-manager/) 進行安裝。
+Lockman può essere installato usando [Swift Package Manager](https://swift.org/package-manager/).
 
 ### Xcode
 
-在 Xcode 中，選擇 File → Add Package Dependencies 並輸入以下 URL：
+In Xcode, seleziona File → Add Package Dependencies e inserisci il seguente URL:
 
 ```
 https://github.com/takeshishimada/Lockman
@@ -224,7 +224,7 @@ https://github.com/takeshishimada/Lockman
 
 ### Package.swift
 
-將相依性新增到您的 Package.swift 檔案中：
+Aggiungi la dipendenza al tuo file Package.swift:
 
 ```swift
 dependencies: [
@@ -232,7 +232,7 @@ dependencies: [
 ]
 ```
 
-將相依性新增到您的目標中：
+Aggiungi la dipendenza al tuo target:
 
 ```swift
 .target(
@@ -243,20 +243,26 @@ dependencies: [
 )
 ```
 
-### 系統需求
+### Requisiti
 
-| 平台      | 最低版本 |
-|----------|---------|
-| iOS      | 13.0    |
-| macOS    | 10.15   |
-| tvOS     | 13.0    |
-| watchOS  | 6.0     |
+| Piattaforma | Versione Minima |
+|-------------|-----------------|
+| iOS         | 13.0            |
+| macOS       | 10.15           |
+| tvOS        | 13.0            |
+| watchOS     | 6.0             |
 
-### 版本相容性
+### Compatibilità delle Versioni
 
 | Lockman | The Composable Architecture |
 |---------|----------------------------|
 | 1.3.0   | 1.20.2                     |
+
+<details>
+<summary>Altre versioni</summary>
+
+| Lockman | The Composable Architecture |
+|---------|----------------------------|
 | 1.2.0   | 1.20.2                     |
 | 1.1.0   | 1.20.2                     |
 | 1.0.0   | 1.20.2                     |
@@ -270,12 +276,6 @@ dependencies: [
 | 0.10.0  | 1.19.0                     |
 | 0.9.0   | 1.18.0                     |
 | 0.8.0   | 1.17.1                     |
-
-<details>
-<summary>其他版本</summary>
-
-| Lockman | The Composable Architecture |
-|---------|----------------------------|
 | 0.7.0   | 1.17.1                     |
 | 0.6.0   | 1.17.1                     |
 | 0.5.0   | 1.17.1                     |
@@ -302,20 +302,20 @@ This documentation is also available in other languages:
 - [Português (Portuguese)](README_pt-BR.md)
 - [Italiano (Italian)](README_it.md)
 
-## 社群
+## Comunità
 
-### 討論和協助
+### Discussione e Aiuto
 
-可以在 [GitHub Discussions](https://github.com/takeshishimada/Lockman/discussions) 上進行問題討論。
+Domande e discussioni possono essere tenute su [GitHub Discussions](https://github.com/takeshishimada/Lockman/discussions).
 
-### 錯誤回報
+### Segnalazioni di Bug
 
-如果發現錯誤，請在 [Issues](https://github.com/takeshishimada/Lockman/issues) 上回報。
+Se trovi un bug, per favore segnalalo su [Issues](https://github.com/takeshishimada/Lockman/issues).
 
-### 貢獻
+### Contribuire
 
-如果您想為該函式庫做出貢獻，請建立一個 PR 並附上相關連結！
+Se desideri contribuire alla libreria, per favore apri una PR con un link ad essa!
 
-## 授權條款
+## Licenza
 
-本函式庫基於 MIT 授權條款發布。詳情請參閱 [LICENSE](./LICENSE) 檔案。
+Questa libreria è rilasciata sotto licenza MIT. Vedi il file [LICENSE](./LICENSE) per i dettagli.

--- a/READMEs/README_ja.md
+++ b/READMEs/README_ja.md
@@ -4,54 +4,53 @@
 [![Swift](https://img.shields.io/badge/Swift-5.9%20%7C%205.10%20%7C%206.0-ED523F.svg?style=flat)](https://swift.org/download/)
 [![Platforms](https://img.shields.io/badge/Platforms-iOS%20%7C%20macOS%20%7C%20tvOS%20%7C%20watchOS%20%7C%20Mac%20Catalyst-333333.svg?style=flat)](https://developer.apple.com/)
 
+LockmanはThe Composable Architecture（TCA）アプリケーションにおける排他アクションの制御問題を解決するSwiftライブラリです。応答性、透明性、宣言的設計を重視しています。
 
-Lockman est une bibliothèque Swift qui résout les problèmes de contrôle des actions concurrentes dans les applications The Composable Architecture (TCA), en mettant l'accent sur la réactivité, la transparence et la conception déclarative.
+* [設計思想](#設計思想)
+* [概要](#概要)
+* [基本例](#基本例)
+* [インストール](#インストール)
+* [コミュニティ](#コミュニティ)
 
-* [Philosophie de Conception](#philosophie-de-conception)
-* [Vue d'Ensemble](#vue-densemble)
-* [Exemple de Base](#exemple-de-base)
-* [Installation](#installation)
-* [Communauté](#communauté)
+## 設計思想
 
-## Philosophie de Conception
+### Designing Fluid Interfacesの原則
 
-### Principes de Designing Fluid Interfaces
+WWDC18「Designing Fluid Interfaces」では、優れたインターフェースの原則が示されました：
 
-La présentation "Designing Fluid Interfaces" de WWDC18 a présenté des principes pour des interfaces exceptionnelles :
+* **即座の応答と継続的なリダイレクション** - 10msの遅延も感じさせない応答性
+* **タッチとコンテンツの1対1の動き** - ドラッグ時にコンテンツが指に追従
+* **継続的なフィードバック** - すべてのインタラクションに対する即座の反応
+* **複数ジェスチャーの並列検出** - 同時に複数のジェスチャーを認識
+* **空間的な一貫性の維持** - アニメーション中の位置の一貫性
+* **軽量なインタラクション、増幅された出力** - 小さな入力から大きな効果
 
-* **Réponse Immédiate et Redirection Continue** - Une réactivité qui ne tolère pas même 10ms de délai
-* **Mouvement Un-à-Un entre le Toucher et le Contenu** - Le contenu suit le doigt pendant les opérations de glissement
-* **Retour d'Information Continu** - Réaction immédiate à toutes les interactions
-* **Détection de Gestes en Parallèle** - Reconnaissance de plusieurs gestes simultanément
-* **Cohérence Spatiale** - Maintien de la cohérence de position pendant les animations
-* **Interactions Légères, Sortie Amplifiée** - Grands effets à partir de petites entrées
+### 従来の課題
 
-### Défis Traditionnels
+従来のUI開発では、ボタンの同時押しや重複実行を単純に禁止することで問題を解決してきました。これらのアプローチは現代の流動的なインターフェース設計において、ユーザー体験を阻害する要因となっています。
 
-Le développement d'interface utilisateur traditionnel a résolu les problèmes en interdisant simplement les pressions simultanées de boutons et les exécutions en double. Ces approches sont devenues des facteurs qui entravent l'expérience utilisateur dans la conception moderne d'interfaces fluides.
+ユーザーは押下可能なボタンに対して、同時押しの場合でも何らかのフィードバックを期待します。UI層での即座の応答と、ビジネスロジック層での適切な排他制御を明確に分離することが重要です。
 
-Les utilisateurs attendent une forme de retour d'information même lorsqu'ils appuient simultanément sur des boutons. Il est crucial de séparer clairement la réponse immédiate au niveau de la couche UI du contrôle d'exclusion mutuelle approprié au niveau de la couche de logique métier.
+## 概要
 
-## Vue d'Ensemble
+Lockmanは以下の制御戦略を提供し、実際のアプリ開発で頻繁に発生する問題に対処します：
 
-Lockman fournit les stratégies de contrôle suivantes pour résoudre les problèmes courants dans le développement d'applications :
+* **Single Execution**: 同じアクションの重複実行を防止
+* **Priority Based**: 優先度に基づくアクションの制御とキャンセル
+* **Group Coordination**: リーダー/メンバーの役割によるグループ制御
+* **Dynamic Condition**: 実行時条件による動的制御
+* **Concurrency Limited**: グループごとの同時実行数を制限
+* **Composite Strategy**: 複数戦略の組み合わせ
 
-* **Single Execution** : Empêche l'exécution en double de la même action
-* **Priority Based** : Contrôle et annulation d'actions basés sur la priorité
-* **Group Coordination** : Contrôle de groupe via les rôles leader/membre
-* **Dynamic Condition** : Contrôle dynamique basé sur les conditions d'exécution
-* **Concurrency Limited** : Limite le nombre d'exécutions concurrentes par groupe
-* **Composite Strategy** : Combinaison de plusieurs stratégies
-
-## Exemples
+## 例
 
 | Single Execution Strategy | Priority Based Strategy | Concurrency Limited Strategy |
 |--------------------------|------------------------|------------------------------|
 | ![Single Execution Strategy](../Sources/Lockman/Documentation.docc/images/01-SingleExecutionStrategy.gif) | ![Priority Based Strategy](../Sources/Lockman/Documentation.docc/images/02-PriorityBasedStrategy.gif) | ![Concurrency Limited Strategy](../Sources/Lockman/Documentation.docc/images/03-ConcurrencyLimitedStrategy.gif) |
 
-## Exemple de Code
+## コード例
 
-Voici comment implémenter une fonctionnalité qui empêche l'exécution en double de processus en utilisant la macro `@LockmanSingleExecution` :
+`@LockmanSingleExecution`マクロを使用して、処理の重複実行を防ぐ機能を実装する方法：
 
 ```swift
 import CasePaths
@@ -99,7 +98,7 @@ struct ProcessFeature {
                 case .startProcessButtonTapped:
                     return .run { send in
                         await send(.internal(.processStart))
-                        // Simuler un traitement lourd
+                        // 重い処理をシミュレート
                         try await Task.sleep(nanoseconds: 3_000_000_000)
                         await send(.internal(.processCompleted))
                     }
@@ -109,12 +108,12 @@ struct ProcessFeature {
                 switch internalAction {
                 case .processStart:
                     state.isProcessing = true
-                    state.message = "Traitement démarré..."
+                    state.message = "処理を開始しました..."
                     return .none
                     
                 case .processCompleted:
                     state.isProcessing = false
-                    state.message = "Traitement terminé"
+                    state.message = "処理が完了しました"
                     return .none
                     
                 case .updateMessage(let message):
@@ -126,10 +125,10 @@ struct ProcessFeature {
         .lock(
             boundaryId: CancelID.userAction,
             lockFailure: { error, send in
-                // Lorsque le traitement est déjà en cours
+                // すでに処理が実行中の場合
                 if error is LockmanSingleExecutionError {
-                    // Mettre à jour le message via une action au lieu d'une mutation directe de l'état
-                    await send(.internal(.updateMessage("Le traitement est déjà en cours")))
+                    // アクションを通じてメッセージを更新
+                    await send(.internal(.updateMessage("処理は既に実行中です")))
                 }
             },
             for: \.view
@@ -138,9 +137,9 @@ struct ProcessFeature {
 }
 ```
 
-Le modificateur `Reducer.lock` applique automatiquement la gestion des verrous aux actions qui se conforment à `LockmanAction`. Puisque l'énumération `ViewAction` est marquée avec `@LockmanSingleExecution`, l'action `startProcessButtonTapped` ne s'exécutera pas pendant que le traitement est en cours. Le paramètre `for: \.view` indique à Lockman de vérifier la conformité à `LockmanAction` pour les actions imbriquées dans le cas `view`.
+`Reducer.lock`モディファイアは`LockmanAction`に準拠するアクションに対して自動的にロック管理を適用します。`ViewAction`列挙型が`@LockmanSingleExecution`でマークされているため、`startProcessButtonTapped`アクションは処理中に再実行されません。`for: \.view`パラメータはLockmanに`view`ケースにネストされたアクションの`LockmanAction`準拠性をチェックするよう指示します。
 
-### Exemple de Sortie de Débogage
+### デバッグ出力例
 
 ```
 ✅ [Lockman] canLock succeeded - Strategy: SingleExecution, BoundaryId: process, Info: LockmanSingleExecutionInfo(actionId: 'startProcessButtonTapped', uniqueId: 7BFC785A-3D25-4722-B9BC-A3A63A7F49FC, mode: boundary)
@@ -161,19 +160,19 @@ Le modificateur `Reducer.lock` applique automatiquement la gestion des verrous a
 └─────────────────┴──────────────────┴──────────────────────────────────────┴─────────────────┘
 ```
 
-## Documentation
+## ドキュメント
 
-La documentation pour les versions publiées et `main` est disponible ici :
+リリース版とmainのドキュメントはこちらで利用できます：
 
 * [`main`](https://takeshishimada.github.io/Lockman/main/documentation/lockman/)
-* [1.3.0](https://takeshishimada.github.io/Lockman/1.3.0/documentation/lockman/) ([guide de migration](https://takeshishimada.github.io/Lockman/1.3.0/documentation/lockman/migratingto1.3))
-* [1.2.0](https://takeshishimada.github.io/Lockman/1.2.0/documentation/lockman/) ([guide de migration](https://takeshishimada.github.io/Lockman/1.2.0/documentation/lockman/migratingto1.2))
-* [1.1.0](https://takeshishimada.github.io/Lockman/1.1.0/documentation/lockman/) ([guide de migration](https://takeshishimada.github.io/Lockman/1.1.0/documentation/lockman/migratingto1.1))
+* [1.3.0](https://takeshishimada.github.io/Lockman/1.3.0/documentation/lockman/) ([マイグレーションガイド](https://takeshishimada.github.io/Lockman/1.3.0/documentation/lockman/migratingto1.3))
+* [1.2.0](https://takeshishimada.github.io/Lockman/1.2.0/documentation/lockman/) ([マイグレーションガイド](https://takeshishimada.github.io/Lockman/1.2.0/documentation/lockman/migratingto1.2))
+* [1.1.0](https://takeshishimada.github.io/Lockman/1.1.0/documentation/lockman/) ([マイグレーションガイド](https://takeshishimada.github.io/Lockman/1.1.0/documentation/lockman/migratingto1.1))
 
 <details>
-<summary>Autres versions</summary>
+<summary>その他のバージョン</summary>
 
-* [1.0.0](https://takeshishimada.github.io/Lockman/1.0.0/documentation/lockman/) ([guide de migration](https://takeshishimada.github.io/Lockman/1.0.0/documentation/lockman/migratingto1.0))
+* [1.0.0](https://takeshishimada.github.io/Lockman/1.0.0/documentation/lockman/) ([マイグレーションガイド](https://takeshishimada.github.io/Lockman/1.0.0/documentation/lockman/migratingto1.0))
 * [0.13.0](https://takeshishimada.github.io/Lockman/0.13.0/documentation/lockman/)
 * [0.12.0](https://takeshishimada.github.io/Lockman/0.12.0/documentation/lockman/)
 * [0.11.0](https://takeshishimada.github.io/Lockman/0.11.0/documentation/lockman/)
@@ -188,35 +187,33 @@ La documentation pour les versions publiées et `main` est disponible ici :
 
 </details>
 
-Il existe plusieurs articles dans la documentation qui peuvent vous être utiles pour vous familiariser avec la bibliothèque :
+ライブラリをより深く理解するために、以下のドキュメントが役立つでしょう：
 
-### Essentiels
-* [Démarrage](https://takeshishimada.github.io/Lockman/main/documentation/lockman/gettingstarted) - Apprenez à intégrer Lockman dans votre application TCA
-* [Vue d'Ensemble des Limites](https://takeshishimada.github.io/Lockman/main/documentation/lockman/boundaryoverview) - Comprendre le concept de limites dans Lockman
-* [Verrouillage](https://takeshishimada.github.io/Lockman/main/documentation/lockman/lock) - Comprendre le mécanisme de verrouillage
-* [Déverrouillage](https://takeshishimada.github.io/Lockman/main/documentation/lockman/unlock) - Comprendre le mécanisme de déverrouillage
-* [Choisir une Stratégie](https://takeshishimada.github.io/Lockman/main/documentation/lockman/choosingstrategy) - Sélectionnez la bonne stratégie pour votre cas d'utilisation
-* [Configuration](https://takeshishimada.github.io/Lockman/main/documentation/lockman/configuration) - Configurez Lockman pour les besoins de votre application
-* [Gestion des Erreurs](https://takeshishimada.github.io/Lockman/main/documentation/lockman/errorhandling) - Apprenez les modèles courants de gestion des erreurs
-* [Guide de Débogage](https://takeshishimada.github.io/Lockman/main/documentation/lockman/debuggingguide) - Déboguez les problèmes liés à Lockman dans votre application
+### Essentials
+* [Getting Started](https://takeshishimada.github.io/Lockman/main/documentation/lockman/gettingstarted) - LockmanをTCAアプリケーションに統合する方法
+* [Boundary Overview](https://takeshishimada.github.io/Lockman/main/documentation/lockman/boundaryoverview) - Lockmanにおける境界の概念を理解する
+* [Lock](https://takeshishimada.github.io/Lockman/main/documentation/lockman/lock) - ロック機構の理解
+* [Unlock](https://takeshishimada.github.io/Lockman/main/documentation/lockman/unlock) - アンロック機構の理解
+* [Choosing a Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/choosingstrategy) - ユースケースに適した戦略を選択する
+* [Configuration](https://takeshishimada.github.io/Lockman/main/documentation/lockman/configuration) - アプリケーションのニーズに合わせてLockmanを設定する
+* [Error Handling](https://takeshishimada.github.io/Lockman/main/documentation/lockman/errorhandling) - 一般的なエラーハンドリングパターンを学ぶ
+* [Debugging Guide](https://takeshishimada.github.io/Lockman/main/documentation/lockman/debuggingguide) - アプリケーションのLockman関連の問題をデバッグする
 
-### Stratégies
-* [Single Execution Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/singleexecutionstrategy) - Empêcher l'exécution en double
-* [Priority Based Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/prioritybasedstrategy) - Contrôle basé sur la priorité
-* [Concurrency Limited Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/concurrencylimitedstrategy) - Limiter les exécutions concurrentes
-* [Group Coordination Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/groupcoordinationstrategy) - Coordonner les actions liées
-* [Dynamic Condition Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/dynamicconditionstrategy) - Contrôle dynamique à l'exécution
-* [Composite Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/compositestrategy) - Combiner plusieurs stratégies
+### 戦略
+* [Single Execution Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/singleexecutionstrategy) - 重複実行を防止
+* [Priority Based Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/prioritybasedstrategy) - 優先度に基づく制御
+* [Concurrency Limited Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/concurrencylimitedstrategy) - 同時実行数を制限
+* [Group Coordination Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/groupcoordinationstrategy) - 関連するアクションを協調
+* [Dynamic Condition Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/dynamicconditionstrategy) - 動的なランタイム制御
+* [Composite Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/compositestrategy) - 複数の戦略を組み合わせる
 
-Note : La documentation est disponible uniquement en anglais.
+## インストール
 
-## Installation
-
-Lockman peut être installé en utilisant [Swift Package Manager](https://swift.org/package-manager/).
+Lockmanは[Swift Package Manager](https://swift.org/package-manager/)でインストールできます。
 
 ### Xcode
 
-Dans Xcode, sélectionnez File → Add Package Dependencies et entrez l'URL suivante :
+Xcodeで File → Add Package Dependencies を選択し、以下のURLを入力：
 
 ```
 https://github.com/takeshishimada/Lockman
@@ -224,7 +221,7 @@ https://github.com/takeshishimada/Lockman
 
 ### Package.swift
 
-Ajoutez la dépendance à votre fichier Package.swift :
+Package.swiftファイルに依存関係を追加：
 
 ```swift
 dependencies: [
@@ -232,7 +229,7 @@ dependencies: [
 ]
 ```
 
-Ajoutez la dépendance à votre cible :
+ターゲットに依存関係を追加：
 
 ```swift
 .target(
@@ -243,20 +240,26 @@ Ajoutez la dépendance à votre cible :
 )
 ```
 
-### Configuration Requise
+### 動作要件
 
-| Plateforme | Version Minimale |
-|------------|------------------|
-| iOS        | 13.0             |
-| macOS      | 10.15            |
-| tvOS       | 13.0             |
-| watchOS    | 6.0              |
+| Platform | Minimum Version |
+|----------|----------------|
+| iOS      | 13.0           |
+| macOS    | 10.15          |
+| tvOS     | 13.0           |
+| watchOS  | 6.0            |
 
-### Compatibilité des Versions
+### バージョン互換性
 
 | Lockman | The Composable Architecture |
 |---------|----------------------------|
 | 1.3.0   | 1.20.2                     |
+
+<details>
+<summary>その他のバージョン</summary>
+
+| Lockman | The Composable Architecture |
+|---------|----------------------------|
 | 1.2.0   | 1.20.2                     |
 | 1.1.0   | 1.20.2                     |
 | 1.0.0   | 1.20.2                     |
@@ -270,12 +273,6 @@ Ajoutez la dépendance à votre cible :
 | 0.10.0  | 1.19.0                     |
 | 0.9.0   | 1.18.0                     |
 | 0.8.0   | 1.17.1                     |
-
-<details>
-<summary>Autres versions</summary>
-
-| Lockman | The Composable Architecture |
-|---------|----------------------------|
 | 0.7.0   | 1.17.1                     |
 | 0.6.0   | 1.17.1                     |
 | 0.5.0   | 1.17.1                     |
@@ -287,35 +284,35 @@ Ajoutez la dépendance à votre cible :
 
 </details>
 
-## Translations
+### 翻訳
 
-This documentation is also available in other languages:
+The following translations of this README have been contributed by members of the community:
 
 - [English](../README.md)
-- [日本語 (Japanese)](README_ja.md)
-- [简体中文 (Simplified Chinese)](README_zh-CN.md)
-- [繁體中文 (Traditional Chinese)](README_zh-TW.md)
-- [Español (Spanish)](README_es.md)
-- [Français (French)](README_fr.md)
-- [Deutsch (German)](README_de.md)
-- [한국어 (Korean)](README_ko.md)
-- [Português (Portuguese)](README_pt-BR.md)
-- [Italiano (Italian)](README_it.md)
+- [Japanese](README_ja.md)
+- [Simplified Chinese](README_zh-CN.md)
+- [Traditional Chinese](README_zh-TW.md)
+- [Spanish](README_es.md)
+- [French](README_fr.md)
+- [German](README_de.md)
+- [Korean](README_ko.md)
+- [Portuguese](README_pt-BR.md)
+- [Italian](README_it.md)
 
-## Communauté
+## コミュニティ
 
-### Discussion et Aide
+### 議論とヘルプ
 
-Les questions et discussions peuvent être tenues sur [GitHub Discussions](https://github.com/takeshishimada/Lockman/discussions).
+質問や議論は[GitHub Discussions](https://github.com/takeshishimada/Lockman/discussions)で行えます。
 
-### Rapports de Bogues
+### バグ報告
 
-Si vous trouvez un bogue, veuillez le signaler sur [Issues](https://github.com/takeshishimada/Lockman/issues).
+バグを発見した場合は[Issues](https://github.com/takeshishimada/Lockman/issues)で報告してください。
 
-### Contribution
+### コントリビューション
 
-Si vous souhaitez contribuer à la bibliothèque, veuillez ouvrir une PR avec un lien vers celle-ci !
+ライブラリにコントリビュートしたい場合は、リンク付きのPRを開いてください！
 
-## Licence
+## ライセンス
 
-Cette bibliothèque est publiée sous la licence MIT. Consultez le fichier [LICENSE](./LICENSE) pour plus de détails.
+このライブラリはMITライセンスの下でリリースされています。詳細は[LICENSE](./LICENSE)ファイルをご確認ください。

--- a/READMEs/README_ko.md
+++ b/READMEs/README_ko.md
@@ -5,53 +5,53 @@
 [![Platforms](https://img.shields.io/badge/Platforms-iOS%20%7C%20macOS%20%7C%20tvOS%20%7C%20watchOS%20%7C%20Mac%20Catalyst-333333.svg?style=flat)](https://developer.apple.com/)
 
 
-Lockman ist eine Swift-Bibliothek, die Probleme bei der Kontrolle konkurrierender Aktionen in The Composable Architecture (TCA) Anwendungen löst, mit Fokus auf Reaktionsfähigkeit, Transparenz und deklaratives Design.
+Lockman은 The Composable Architecture (TCA) 애플리케이션에서 동시 액션 제어 문제를 해결하는 Swift 라이브러리로, 반응성, 투명성, 선언적 설계에 중점을 둡니다.
 
-* [Design-Philosophie](#design-philosophie)
-* [Überblick](#überblick)
-* [Grundlegendes Beispiel](#grundlegendes-beispiel)
-* [Installation](#installation)
-* [Community](#community)
+* [설계 철학](#설계-철학)
+* [개요](#개요)
+* [기본 예제](#기본-예제)
+* [설치](#설치)
+* [커뮤니티](#커뮤니티)
 
-## Design-Philosophie
+## 설계 철학
 
-### Designing Fluid Interfaces Prinzipien
+### Designing Fluid Interfaces 원칙
 
-Die Präsentation "Designing Fluid Interfaces" der WWDC18 stellte Prinzipien für außergewöhnliche Schnittstellen vor:
+WWDC18의 "Designing Fluid Interfaces" 프레젠테이션은 뛰어난 인터페이스를 위한 원칙을 제시했습니다:
 
-* **Sofortige Reaktion und kontinuierliche Umleitung** - Reaktionsfähigkeit, die nicht einmal 10ms Verzögerung toleriert
-* **Eins-zu-Eins-Bewegung zwischen Berührung und Inhalt** - Inhalt folgt dem Finger während Ziehvorgängen
-* **Kontinuierliches Feedback** - Sofortige Reaktion auf alle Interaktionen
-* **Parallele Gestenerkennung** - Gleichzeitige Erkennung mehrerer Gesten
-* **Räumliche Konsistenz** - Beibehaltung der Positionskonsistenz während Animationen
-* **Leichte Interaktionen, verstärkte Ausgabe** - Große Effekte aus kleinen Eingaben
+* **즉각적인 응답과 지속적인 리디렉션** - 10ms의 지연도 허용하지 않는 반응성
+* **터치와 콘텐츠 간의 일대일 움직임** - 드래그 작업 중 콘텐츠가 손가락을 따라감
+* **지속적인 피드백** - 모든 상호작용에 대한 즉각적인 반응
+* **병렬 제스처 감지** - 여러 제스처를 동시에 인식
+* **공간적 일관성** - 애니메이션 중 위치 일관성 유지
+* **가벼운 상호작용, 증폭된 출력** - 작은 입력에서 큰 효과
 
-### Traditionelle Herausforderungen
+### 기존의 과제
 
-Die traditionelle UI-Entwicklung löste Probleme, indem sie gleichzeitige Tasteneingaben und doppelte Ausführungen einfach verbot. Diese Ansätze wurden zu Faktoren, die die Benutzererfahrung im modernen flüssigen Interface-Design behindern.
+기존 UI 개발은 단순히 동시 버튼 누름과 중복 실행을 금지하여 문제를 해결했습니다. 이러한 접근 방식은 현대적인 유동적 인터페이스 설계에서 사용자 경험을 저해하는 요인이 되었습니다.
 
-Benutzer erwarten eine Form von Feedback, auch wenn sie gleichzeitig Tasten drücken. Es ist entscheidend, die sofortige Reaktion auf UI-Ebene klar von der angemessenen gegenseitigen Ausschlusskontrolle auf Geschäftslogikebene zu trennen.
+사용자는 동시에 버튼을 누르더라도 어떤 형태의 피드백을 기대합니다. UI 레이어에서의 즉각적인 응답과 비즈니스 로직 레이어에서의 적절한 상호 배제 제어를 명확히 분리하는 것이 중요합니다.
 
-## Überblick
+## 개요
 
-Lockman bietet die folgenden Kontrollstrategien zur Lösung häufiger Probleme in der Anwendungsentwicklung:
+Lockman은 애플리케이션 개발의 일반적인 문제를 해결하기 위해 다음과 같은 제어 전략을 제공합니다:
 
-* **Single Execution**: Verhindert doppelte Ausführung derselben Aktion
-* **Priority Based**: Prioritätsbasierte Aktionskontrolle und -stornierung
-* **Group Coordination**: Gruppenkontrolle über Leader/Member-Rollen
-* **Dynamic Condition**: Dynamische Kontrolle basierend auf Ausführungsbedingungen
-* **Concurrency Limited**: Begrenzt die Anzahl gleichzeitiger Ausführungen pro Gruppe
-* **Composite Strategy**: Kombination mehrerer Strategien
+* **Single Execution**: 동일한 액션의 중복 실행 방지
+* **Priority Based**: 우선순위 기반 액션 제어 및 취소
+* **Group Coordination**: 리더/멤버 역할을 통한 그룹 제어
+* **Dynamic Condition**: 실행 조건에 기반한 동적 제어
+* **Concurrency Limited**: 그룹당 동시 실행 수 제한
+* **Composite Strategy**: 여러 전략 조합
 
-## Beispiele
+## 예제
 
 | Single Execution Strategy | Priority Based Strategy | Concurrency Limited Strategy |
 |--------------------------|------------------------|------------------------------|
 | ![Single Execution Strategy](../Sources/Lockman/Documentation.docc/images/01-SingleExecutionStrategy.gif) | ![Priority Based Strategy](../Sources/Lockman/Documentation.docc/images/02-PriorityBasedStrategy.gif) | ![Concurrency Limited Strategy](../Sources/Lockman/Documentation.docc/images/03-ConcurrencyLimitedStrategy.gif) |
 
-## Code-Beispiel
+## 코드 예제
 
-So implementieren Sie eine Funktion, die doppelte Prozessausführung mit dem `@LockmanSingleExecution` Makro verhindert:
+`@LockmanSingleExecution` 매크로를 사용하여 프로세스의 중복 실행을 방지하는 기능을 구현하는 방법입니다:
 
 ```swift
 import CasePaths
@@ -99,7 +99,7 @@ struct ProcessFeature {
                 case .startProcessButtonTapped:
                     return .run { send in
                         await send(.internal(.processStart))
-                        // Schwere Verarbeitung simulieren
+                        // 무거운 처리 시뮬레이션
                         try await Task.sleep(nanoseconds: 3_000_000_000)
                         await send(.internal(.processCompleted))
                     }
@@ -109,12 +109,12 @@ struct ProcessFeature {
                 switch internalAction {
                 case .processStart:
                     state.isProcessing = true
-                    state.message = "Verarbeitung gestartet..."
+                    state.message = "처리 시작됨..."
                     return .none
                     
                 case .processCompleted:
                     state.isProcessing = false
-                    state.message = "Verarbeitung abgeschlossen"
+                    state.message = "처리 완료됨"
                     return .none
                     
                 case .updateMessage(let message):
@@ -126,10 +126,10 @@ struct ProcessFeature {
         .lock(
             boundaryId: CancelID.userAction,
             lockFailure: { error, send in
-                // Wenn die Verarbeitung bereits läuft
+                // 이미 처리가 진행 중일 때
                 if error is LockmanSingleExecutionError {
-                    // Nachricht über eine Aktion aktualisieren anstatt direkte Zustandsmutation
-                    await send(.internal(.updateMessage("Verarbeitung läuft bereits")))
+                    // 직접적인 상태 변경 대신 액션을 통해 메시지 업데이트
+                    await send(.internal(.updateMessage("이미 처리가 진행 중입니다")))
                 }
             },
             for: \.view
@@ -138,9 +138,9 @@ struct ProcessFeature {
 }
 ```
 
-Der `Reducer.lock` Modifikator wendet automatisch Lock-Management auf Aktionen an, die dem `LockmanAction` Protokoll entsprechen. Da die `ViewAction` Enumeration mit `@LockmanSingleExecution` markiert ist, wird die `startProcessButtonTapped` Aktion nicht erneut ausgeführt, während die Verarbeitung läuft. Der Parameter `for: \.view` weist Lockman an, Aktionen, die im `view` Fall verschachtelt sind, auf `LockmanAction` Konformität zu prüfen.
+`Reducer.lock` 수정자는 `LockmanAction`을 준수하는 액션에 대해 자동으로 잠금 관리를 적용합니다. `ViewAction` 열거형이 `@LockmanSingleExecution`으로 표시되어 있으므로, 처리가 진행 중일 때 `startProcessButtonTapped` 액션이 실행되지 않습니다. `for: \.view` 매개변수는 Lockman에게 `view` 케이스에 중첩된 액션에 대해 `LockmanAction` 준수를 확인하도록 지시합니다.
 
-### Debug-Ausgabe Beispiel
+### 디버그 출력 예제
 
 ```
 ✅ [Lockman] canLock succeeded - Strategy: SingleExecution, BoundaryId: process, Info: LockmanSingleExecutionInfo(actionId: 'startProcessButtonTapped', uniqueId: 7BFC785A-3D25-4722-B9BC-A3A63A7F49FC, mode: boundary)
@@ -161,19 +161,19 @@ Der `Reducer.lock` Modifikator wendet automatisch Lock-Management auf Aktionen a
 └─────────────────┴──────────────────┴──────────────────────────────────────┴─────────────────┘
 ```
 
-## Dokumentation
+## 문서
 
-Die Dokumentation für veröffentlichte Versionen und `main` ist hier verfügbar:
+출시된 버전과 `main`에 대한 문서는 여기에서 사용할 수 있습니다:
 
 * [`main`](https://takeshishimada.github.io/Lockman/main/documentation/lockman/)
-* [1.3.0](https://takeshishimada.github.io/Lockman/1.3.0/documentation/lockman/) ([Migrationsleitfaden](https://takeshishimada.github.io/Lockman/1.3.0/documentation/lockman/migratingto1.3))
-* [1.2.0](https://takeshishimada.github.io/Lockman/1.2.0/documentation/lockman/) ([Migrationsanleitung](https://takeshishimada.github.io/Lockman/1.2.0/documentation/lockman/migratingto1.2))
-* [1.1.0](https://takeshishimada.github.io/Lockman/1.1.0/documentation/lockman/) ([Migrationsanleitung](https://takeshishimada.github.io/Lockman/1.1.0/documentation/lockman/migratingto1.1))
+* [1.3.0](https://takeshishimada.github.io/Lockman/1.3.0/documentation/lockman/) ([마이그레이션 가이드](https://takeshishimada.github.io/Lockman/1.3.0/documentation/lockman/migratingto1.3))
+* [1.2.0](https://takeshishimada.github.io/Lockman/1.2.0/documentation/lockman/) ([마이그레이션 가이드](https://takeshishimada.github.io/Lockman/1.2.0/documentation/lockman/migratingto1.2))
+* [1.1.0](https://takeshishimada.github.io/Lockman/1.1.0/documentation/lockman/) ([마이그레이션 가이드](https://takeshishimada.github.io/Lockman/1.1.0/documentation/lockman/migratingto1.1))
 
 <details>
-<summary>Weitere Versionen</summary>
+<summary>다른 버전</summary>
 
-* [1.0.0](https://takeshishimada.github.io/Lockman/1.0.0/documentation/lockman/) ([Migrationsleitfaden](https://takeshishimada.github.io/Lockman/1.0.0/documentation/lockman/migratingto1.0))
+* [1.0.0](https://takeshishimada.github.io/Lockman/1.0.0/documentation/lockman/) ([마이그레이션 가이드](https://takeshishimada.github.io/Lockman/1.0.0/documentation/lockman/migratingto1.0))
 * [0.13.0](https://takeshishimada.github.io/Lockman/0.13.0/documentation/lockman/)
 * [0.12.0](https://takeshishimada.github.io/Lockman/0.12.0/documentation/lockman/)
 * [0.11.0](https://takeshishimada.github.io/Lockman/0.11.0/documentation/lockman/)
@@ -188,35 +188,35 @@ Die Dokumentation für veröffentlichte Versionen und `main` ist hier verfügbar
 
 </details>
 
-Es gibt mehrere Artikel in der Dokumentation, die Ihnen beim Einstieg in die Bibliothek helfen können:
+라이브러리에 익숙해지는 데 도움이 될 수 있는 여러 문서가 있습니다:
 
-### Grundlagen
-* [Erste Schritte](https://takeshishimada.github.io/Lockman/main/documentation/lockman/gettingstarted) - Lernen Sie, wie Sie Lockman in Ihre TCA-Anwendung integrieren
-* [Boundary-Überblick](https://takeshishimada.github.io/Lockman/main/documentation/lockman/boundaryoverview) - Verstehen Sie das Boundary-Konzept in Lockman
-* [Sperren](https://takeshishimada.github.io/Lockman/main/documentation/lockman/lock) - Verstehen Sie den Sperrmechanismus
-* [Entsperren](https://takeshishimada.github.io/Lockman/main/documentation/lockman/unlock) - Verstehen Sie den Entsperrmechanismus
-* [Eine Strategie wählen](https://takeshishimada.github.io/Lockman/main/documentation/lockman/choosingstrategy) - Wählen Sie die richtige Strategie für Ihren Anwendungsfall
-* [Konfiguration](https://takeshishimada.github.io/Lockman/main/documentation/lockman/configuration) - Konfigurieren Sie Lockman für Ihre Anwendungsanforderungen
-* [Fehlerbehandlung](https://takeshishimada.github.io/Lockman/main/documentation/lockman/errorhandling) - Lernen Sie gängige Fehlerbehandlungsmuster
-* [Debugging-Leitfaden](https://takeshishimada.github.io/Lockman/main/documentation/lockman/debuggingguide) - Debuggen Sie Lockman-bezogene Probleme in Ihrer Anwendung
+### 필수 사항
+* [시작하기](https://takeshishimada.github.io/Lockman/main/documentation/lockman/gettingstarted) - TCA 애플리케이션에 Lockman을 통합하는 방법 알아보기
+* [Boundary 개요](https://takeshishimada.github.io/Lockman/main/documentation/lockman/boundaryoverview) - Lockman의 boundary 개념 이해하기
+* [잠금](https://takeshishimada.github.io/Lockman/main/documentation/lockman/lock) - 잠금 메커니즘 이해하기
+* [잠금 해제](https://takeshishimada.github.io/Lockman/main/documentation/lockman/unlock) - 잠금 해제 메커니즘 이해하기
+* [전략 선택](https://takeshishimada.github.io/Lockman/main/documentation/lockman/choosingstrategy) - 사용 사례에 맞는 전략 선택하기
+* [구성](https://takeshishimada.github.io/Lockman/main/documentation/lockman/configuration) - 애플리케이션 요구 사항에 맞게 Lockman 구성하기
+* [오류 처리](https://takeshishimada.github.io/Lockman/main/documentation/lockman/errorhandling) - 일반적인 오류 처리 패턴 알아보기
+* [디버깅 가이드](https://takeshishimada.github.io/Lockman/main/documentation/lockman/debuggingguide) - 애플리케이션에서 Lockman 관련 문제 디버깅하기
 
-### Strategien
-* [Single Execution Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/singleexecutionstrategy) - Doppelte Ausführung verhindern
-* [Priority Based Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/prioritybasedstrategy) - Prioritätsbasierte Kontrolle
-* [Concurrency Limited Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/concurrencylimitedstrategy) - Gleichzeitige Ausführungen begrenzen
-* [Group Coordination Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/groupcoordinationstrategy) - Verwandte Aktionen koordinieren
-* [Dynamic Condition Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/dynamicconditionstrategy) - Dynamische Laufzeitkontrolle
-* [Composite Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/compositestrategy) - Mehrere Strategien kombinieren
+### 전략
+* [Single Execution Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/singleexecutionstrategy) - 중복 실행 방지
+* [Priority Based Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/prioritybasedstrategy) - 우선순위 기반 제어
+* [Concurrency Limited Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/concurrencylimitedstrategy) - 동시 실행 제한
+* [Group Coordination Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/groupcoordinationstrategy) - 관련 액션 조정
+* [Dynamic Condition Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/dynamicconditionstrategy) - 동적 런타임 제어
+* [Composite Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/compositestrategy) - 여러 전략 결합
 
-Hinweis: Die Dokumentation ist nur auf Englisch verfügbar.
+참고: 문서는 영어로만 제공됩니다.
 
-## Installation
+## 설치
 
-Lockman kann über den [Swift Package Manager](https://swift.org/package-manager/) installiert werden.
+Lockman은 [Swift Package Manager](https://swift.org/package-manager/)를 사용하여 설치할 수 있습니다.
 
 ### Xcode
 
-Wählen Sie in Xcode File → Add Package Dependencies und geben Sie die folgende URL ein:
+Xcode에서 File → Add Package Dependencies를 선택하고 다음 URL을 입력하세요:
 
 ```
 https://github.com/takeshishimada/Lockman
@@ -224,7 +224,7 @@ https://github.com/takeshishimada/Lockman
 
 ### Package.swift
 
-Fügen Sie die Abhängigkeit zu Ihrer Package.swift-Datei hinzu:
+Package.swift 파일에 종속성을 추가하세요:
 
 ```swift
 dependencies: [
@@ -232,7 +232,7 @@ dependencies: [
 ]
 ```
 
-Fügen Sie die Abhängigkeit zu Ihrem Target hinzu:
+타겟에 종속성을 추가하세요:
 
 ```swift
 .target(
@@ -243,20 +243,26 @@ Fügen Sie die Abhängigkeit zu Ihrem Target hinzu:
 )
 ```
 
-### Anforderungen
+### 요구 사항
 
-| Plattform | Mindestversion |
-|-----------|----------------|
-| iOS       | 13.0           |
-| macOS     | 10.15          |
-| tvOS      | 13.0           |
-| watchOS   | 6.0            |
+| 플랫폼  | 최소 버전 |
+|---------|-----------|
+| iOS     | 13.0      |
+| macOS   | 10.15     |
+| tvOS    | 13.0      |
+| watchOS | 6.0       |
 
-### Versionskompatibilität
+### 버전 호환성
 
 | Lockman | The Composable Architecture |
 |---------|----------------------------|
 | 1.3.0   | 1.20.2                     |
+
+<details>
+<summary>다른 버전</summary>
+
+| Lockman | The Composable Architecture |
+|---------|----------------------------|
 | 1.2.0   | 1.20.2                     |
 | 1.1.0   | 1.20.2                     |
 | 1.0.0   | 1.20.2                     |
@@ -270,12 +276,6 @@ Fügen Sie die Abhängigkeit zu Ihrem Target hinzu:
 | 0.10.0  | 1.19.0                     |
 | 0.9.0   | 1.18.0                     |
 | 0.8.0   | 1.17.1                     |
-
-<details>
-<summary>Weitere Versionen</summary>
-
-| Lockman | The Composable Architecture |
-|---------|----------------------------|
 | 0.7.0   | 1.17.1                     |
 | 0.6.0   | 1.17.1                     |
 | 0.5.0   | 1.17.1                     |
@@ -302,20 +302,20 @@ This documentation is also available in other languages:
 - [Português (Portuguese)](README_pt-BR.md)
 - [Italiano (Italian)](README_it.md)
 
-## Community
+## 커뮤니티
 
-### Diskussion und Hilfe
+### 토론 및 도움말
 
-Fragen und Diskussionen können in [GitHub Discussions](https://github.com/takeshishimada/Lockman/discussions) geführt werden.
+질문과 토론은 [GitHub Discussions](https://github.com/takeshishimada/Lockman/discussions)에서 진행할 수 있습니다.
 
-### Fehlerberichte
+### 버그 보고
 
-Wenn Sie einen Fehler finden, melden Sie ihn bitte unter [Issues](https://github.com/takeshishimada/Lockman/issues).
+버그를 발견하면 [Issues](https://github.com/takeshishimada/Lockman/issues)에 보고해 주세요.
 
-### Beitragen
+### 기여
 
-Wenn Sie zur Bibliothek beitragen möchten, öffnen Sie bitte eine PR mit einem Link dazu!
+라이브러리에 기여하고 싶으시면 링크와 함께 PR을 열어주세요!
 
-## Lizenz
+## 라이선스
 
-Diese Bibliothek wird unter der MIT-Lizenz veröffentlicht. Siehe [LICENSE](./LICENSE) Datei für Details.
+이 라이브러리는 MIT 라이선스로 출시되었습니다. 자세한 내용은 [LICENSE](./LICENSE) 파일을 참조하세요.

--- a/READMEs/README_pt-BR.md
+++ b/READMEs/README_pt-BR.md
@@ -5,53 +5,53 @@
 [![Platforms](https://img.shields.io/badge/Platforms-iOS%20%7C%20macOS%20%7C%20tvOS%20%7C%20watchOS%20%7C%20Mac%20Catalyst-333333.svg?style=flat)](https://developer.apple.com/)
 
 
-Lockman è una libreria Swift che risolve i problemi di controllo esclusivo delle azioni nelle applicazioni The Composable Architecture (TCA), con reattività, trasparenza e design dichiarativo in mente.
+Lockman é uma biblioteca Swift que resolve problemas de controle exclusivo de ações em aplicações The Composable Architecture (TCA), com responsividade, transparência e design declarativo em mente.
 
-* [Filosofia di Design](#filosofia-di-design)
-* [Panoramica](#panoramica)
-* [Esempio Base](#esempio-base)
-* [Installazione](#installazione)
-* [Comunità](#comunità)
+* [Filosofia de Design](#filosofia-de-design)
+* [Visão Geral](#visão-geral)
+* [Exemplo Básico](#exemplo-básico)
+* [Instalação](#instalação)
+* [Comunidade](#comunidade)
 
-## Filosofia di Design
+## Filosofia de Design
 
-### Principi di Designing Fluid Interfaces
+### Princípios de Designing Fluid Interfaces
 
-"Designing Fluid Interfaces" della WWDC18 ha presentato principi per interfacce eccezionali:
+O "Designing Fluid Interfaces" da WWDC18 apresentou princípios para interfaces excepcionais:
 
-* **Risposta Immediata e Reindirizzamento Continuo** - Reattività che non permette nemmeno 10ms di ritardo
-* **Movimento di Tocco e Contenuto Uno-a-Uno** - Il contenuto segue il dito durante le operazioni di trascinamento
-* **Feedback Continuo** - Reazione immediata a tutte le interazioni
-* **Rilevamento di Gesti Paralleli** - Riconoscimento di più gesti simultaneamente
-* **Coerenza Spaziale** - Mantenimento della coerenza di posizione durante le animazioni
-* **Interazioni Leggere, Output Amplificato** - Grandi effetti da piccoli input
+* **Resposta Imediata e Redirecionamento Contínuo** - Responsividade que não permite nem 10ms de atraso
+* **Movimento de Toque e Conteúdo Um-para-Um** - O conteúdo segue o dedo durante operações de arraste
+* **Feedback Contínuo** - Reação imediata a todas as interações
+* **Detecção de Gestos Paralelos** - Reconhecendo múltiplos gestos simultaneamente
+* **Consistência Espacial** - Mantendo consistência de posição durante animações
+* **Interações Leves, Saída Amplificada** - Grandes efeitos a partir de pequenas entradas
 
-### Sfide Tradizionali
+### Desafios Tradicionais
 
-Lo sviluppo tradizionale dell'UI ha risolto i problemi semplicemente proibendo pressioni simultanee di pulsanti ed esecuzioni duplicate. Questi approcci sono diventati fattori che ostacolano l'esperienza utente nel moderno design di interfacce fluide.
+O desenvolvimento tradicional de UI resolveu problemas simplesmente proibindo pressionamentos simultâneos de botões e execuções duplicadas. Essas abordagens se tornaram fatores que prejudicam a experiência do usuário no design moderno de interfaces fluidas.
 
-Gli utenti si aspettano qualche forma di feedback anche quando premono i pulsanti simultaneamente. È cruciale separare chiaramente la risposta immediata al livello UI dal controllo appropriato di esclusione reciproca al livello della logica di business.
+Os usuários esperam algum tipo de feedback mesmo ao pressionar botões simultaneamente. É crucial separar claramente a resposta imediata na camada de UI do controle apropriado de exclusão mútua na camada de lógica de negócios.
 
-## Panoramica
+## Visão Geral
 
-Lockman fornisce le seguenti strategie di controllo per affrontare problemi comuni nello sviluppo di app:
+Lockman fornece as seguintes estratégias de controle para abordar problemas comuns no desenvolvimento de aplicativos:
 
-* **Esecuzione Singola**: Previene l'esecuzione duplicata della stessa azione
-* **Basata su Priorità**: Controllo e cancellazione delle azioni basata su priorità
-* **Coordinamento di Gruppo**: Controllo di gruppo attraverso ruoli leader/membro
-* **Condizione Dinamica**: Controllo dinamico basato su condizioni runtime
-* **Concorrenza Limitata**: Limita il numero di esecuzioni concorrenti per gruppo
-* **Strategia Composita**: Combinazione di più strategie
+* **Execução Única**: Previne execução duplicada da mesma ação
+* **Baseado em Prioridade**: Controle e cancelamento de ação baseado em prioridade
+* **Coordenação de Grupo**: Controle de grupo através de papéis líder/membro
+* **Condição Dinâmica**: Controle dinâmico baseado em condições de tempo de execução
+* **Concorrência Limitada**: Limita o número de execuções concorrentes por grupo
+* **Estratégia Composta**: Combinação de múltiplas estratégias
 
-## Esempi
+## Exemplos
 
-| Strategia di Esecuzione Singola | Strategia Basata su Priorità | Strategia di Concorrenza Limitata |
-|----------------------------------|------------------------------|-----------------------------------|
-| ![Strategia di Esecuzione Singola](../Sources/Lockman/Documentation.docc/images/01-SingleExecutionStrategy.gif) | ![Strategia Basata su Priorità](../Sources/Lockman/Documentation.docc/images/02-PriorityBasedStrategy.gif) | ![Strategia di Concorrenza Limitata](../Sources/Lockman/Documentation.docc/images/03-ConcurrencyLimitedStrategy.gif) |
+| Estratégia de Execução Única | Estratégia Baseada em Prioridade | Estratégia de Concorrência Limitada |
+|------------------------------|----------------------------------|-------------------------------------|
+| ![Estratégia de Execução Única](../Sources/Lockman/Documentation.docc/images/01-SingleExecutionStrategy.gif) | ![Estratégia Baseada em Prioridade](../Sources/Lockman/Documentation.docc/images/02-PriorityBasedStrategy.gif) | ![Estratégia de Concorrência Limitada](../Sources/Lockman/Documentation.docc/images/03-ConcurrencyLimitedStrategy.gif) |
 
-## Esempio di Codice
+## Exemplo de Código
 
-Ecco come implementare una funzionalità che previene l'esecuzione duplicata di processi usando il macro `@LockmanSingleExecution`:
+Veja como implementar um recurso que previne execução duplicada de processos usando o macro `@LockmanSingleExecution`:
 
 ```swift
 import CasePaths
@@ -99,7 +99,7 @@ struct ProcessFeature {
                 case .startProcessButtonTapped:
                     return .run { send in
                         await send(.internal(.processStart))
-                        // Simula elaborazione pesante
+                        // Simular processamento pesado
                         try await Task.sleep(nanoseconds: 3_000_000_000)
                         await send(.internal(.processCompleted))
                     }
@@ -109,12 +109,12 @@ struct ProcessFeature {
                 switch internalAction {
                 case .processStart:
                     state.isProcessing = true
-                    state.message = "Elaborazione avviata..."
+                    state.message = "Processamento iniciado..."
                     return .none
                     
                 case .processCompleted:
                     state.isProcessing = false
-                    state.message = "Elaborazione completata"
+                    state.message = "Processamento concluído"
                     return .none
                     
                 case .updateMessage(let message):
@@ -126,10 +126,10 @@ struct ProcessFeature {
         .lock(
             boundaryId: CancelID.userAction,
             lockFailure: { error, send in
-                // Quando l'elaborazione è già in corso
+                // Quando o processamento já está em andamento
                 if error is LockmanSingleExecutionError {
-                    // Aggiorna il messaggio tramite un'azione invece di mutazione diretta dello stato
-                    await send(.internal(.updateMessage("L'elaborazione è già in corso")))
+                    // Atualizar mensagem através de uma ação em vez de mutação direta do estado
+                    await send(.internal(.updateMessage("O processamento já está em andamento")))
                 }
             },
             for: \.view
@@ -138,9 +138,9 @@ struct ProcessFeature {
 }
 ```
 
-Il modificatore `Reducer.lock` applica automaticamente la gestione dei lock alle azioni che si conformano a `LockmanAction`. Poiché l'enumerazione `ViewAction` è contrassegnata con `@LockmanSingleExecution`, l'azione `startProcessButtonTapped` non verrà eseguita mentre l'elaborazione è in corso. Il parametro `for: \.view` indica a Lockman di controllare la conformità a `LockmanAction` per le azioni annidate nel caso `view`.
+O modificador `Reducer.lock` aplica automaticamente o gerenciamento de bloqueio às ações que estão em conformidade com `LockmanAction`. Como a enumeração `ViewAction` está marcada com `@LockmanSingleExecution`, a ação `startProcessButtonTapped` não será executada enquanto o processamento estiver em andamento. O parâmetro `for: \.view` instrui o Lockman a verificar a conformidade com `LockmanAction` para ações aninhadas no caso `view`.
 
-### Esempio di Output di Debug
+### Exemplo de Saída de Debug
 
 ```
 ✅ [Lockman] canLock succeeded - Strategy: SingleExecution, BoundaryId: process, Info: LockmanSingleExecutionInfo(actionId: 'startProcessButtonTapped', uniqueId: 7BFC785A-3D25-4722-B9BC-A3A63A7F49FC, mode: boundary)
@@ -161,19 +161,19 @@ Il modificatore `Reducer.lock` applica automaticamente la gestione dei lock alle
 └─────────────────┴──────────────────┴──────────────────────────────────────┴─────────────────┘
 ```
 
-## Documentazione
+## Documentação
 
-La documentazione per le release e `main` è disponibile qui:
+A documentação para lançamentos e `main` estão disponíveis aqui:
 
 * [`main`](https://takeshishimada.github.io/Lockman/main/documentation/lockman/)
-* [1.3.0](https://takeshishimada.github.io/Lockman/1.3.0/documentation/lockman/) ([guida alla migrazione](https://takeshishimada.github.io/Lockman/1.3.0/documentation/lockman/migratingto1.3))
-* [1.2.0](https://takeshishimada.github.io/Lockman/1.2.0/documentation/lockman/) ([guida alla migrazione](https://takeshishimada.github.io/Lockman/1.2.0/documentation/lockman/migratingto1.2))
-* [1.1.0](https://takeshishimada.github.io/Lockman/1.1.0/documentation/lockman/) ([guida alla migrazione](https://takeshishimada.github.io/Lockman/1.1.0/documentation/lockman/migratingto1.1))
+* [1.3.0](https://takeshishimada.github.io/Lockman/1.3.0/documentation/lockman/) ([guia de migração](https://takeshishimada.github.io/Lockman/1.3.0/documentation/lockman/migratingto1.3))
+* [1.2.0](https://takeshishimada.github.io/Lockman/1.2.0/documentation/lockman/) ([guia de migração](https://takeshishimada.github.io/Lockman/1.2.0/documentation/lockman/migratingto1.2))
+* [1.1.0](https://takeshishimada.github.io/Lockman/1.1.0/documentation/lockman/) ([guia de migração](https://takeshishimada.github.io/Lockman/1.1.0/documentation/lockman/migratingto1.1))
 
 <details>
-<summary>Altre versioni</summary>
+<summary>Outras versões</summary>
 
-* [1.0.0](https://takeshishimada.github.io/Lockman/1.0.0/documentation/lockman/) ([guida alla migrazione](https://takeshishimada.github.io/Lockman/1.0.0/documentation/lockman/migratingto1.0))
+* [1.0.0](https://takeshishimada.github.io/Lockman/1.0.0/documentation/lockman/) ([guia de migração](https://takeshishimada.github.io/Lockman/1.0.0/documentation/lockman/migratingto1.0))
 * [0.13.0](https://takeshishimada.github.io/Lockman/0.13.0/documentation/lockman/)
 * [0.12.0](https://takeshishimada.github.io/Lockman/0.12.0/documentation/lockman/)
 * [0.11.0](https://takeshishimada.github.io/Lockman/0.11.0/documentation/lockman/)
@@ -188,35 +188,35 @@ La documentazione per le release e `main` è disponibile qui:
 
 </details>
 
-Ci sono numerosi articoli nella documentazione che potresti trovare utili mentre prendi confidenza con la libreria:
+Existem vários artigos na documentação que você pode achar úteis à medida que se familiariza com a biblioteca:
 
-### Essenziali
-* [Iniziare](https://takeshishimada.github.io/Lockman/main/documentation/lockman/gettingstarted) - Impara come integrare Lockman nella tua applicazione TCA
-* [Panoramica dei Confini](https://takeshishimada.github.io/Lockman/main/documentation/lockman/boundaryoverview) - Comprendi il concetto di confini in Lockman
-* [Lock](https://takeshishimada.github.io/Lockman/main/documentation/lockman/lock) - Comprendere il meccanismo di blocco
-* [Unlock](https://takeshishimada.github.io/Lockman/main/documentation/lockman/unlock) - Comprendere il meccanismo di sblocco
-* [Scegliere una Strategia](https://takeshishimada.github.io/Lockman/main/documentation/lockman/choosingstrategy) - Seleziona la strategia giusta per il tuo caso d'uso
-* [Configurazione](https://takeshishimada.github.io/Lockman/main/documentation/lockman/configuration) - Configura Lockman per le esigenze della tua applicazione
-* [Gestione degli Errori](https://takeshishimada.github.io/Lockman/main/documentation/lockman/errorhandling) - Impara i pattern comuni di gestione degli errori
-* [Guida al Debug](https://takeshishimada.github.io/Lockman/main/documentation/lockman/debuggingguide) - Esegui il debug dei problemi relativi a Lockman nella tua applicazione
+### Essenciais
+* [Começando](https://takeshishimada.github.io/Lockman/main/documentation/lockman/gettingstarted) - Aprenda como integrar Lockman em sua aplicação TCA
+* [Visão Geral de Limites](https://takeshishimada.github.io/Lockman/main/documentation/lockman/boundaryoverview) - Entenda o conceito de limites em Lockman
+* [Bloquear](https://takeshishimada.github.io/Lockman/main/documentation/lockman/lock) - Entendendo o mecanismo de bloqueio
+* [Desbloquear](https://takeshishimada.github.io/Lockman/main/documentation/lockman/unlock) - Entendendo o mecanismo de desbloqueio
+* [Escolhendo uma Estratégia](https://takeshishimada.github.io/Lockman/main/documentation/lockman/choosingstrategy) - Selecione a estratégia certa para seu caso de uso
+* [Configuração](https://takeshishimada.github.io/Lockman/main/documentation/lockman/configuration) - Configure Lockman para as necessidades de sua aplicação
+* [Tratamento de Erros](https://takeshishimada.github.io/Lockman/main/documentation/lockman/errorhandling) - Aprenda sobre padrões comuns de tratamento de erros
+* [Guia de Depuração](https://takeshishimada.github.io/Lockman/main/documentation/lockman/debuggingguide) - Depure problemas relacionados ao Lockman em sua aplicação
 
-### Strategie
-* [Strategia di Esecuzione Singola](https://takeshishimada.github.io/Lockman/main/documentation/lockman/singleexecutionstrategy) - Previene l'esecuzione duplicata
-* [Strategia Basata su Priorità](https://takeshishimada.github.io/Lockman/main/documentation/lockman/prioritybasedstrategy) - Controllo basato su priorità
-* [Strategia di Concorrenza Limitata](https://takeshishimada.github.io/Lockman/main/documentation/lockman/concurrencylimitedstrategy) - Limita le esecuzioni concorrenti
-* [Strategia di Coordinamento di Gruppo](https://takeshishimada.github.io/Lockman/main/documentation/lockman/groupcoordinationstrategy) - Coordina le azioni correlate
-* [Strategia di Condizione Dinamica](https://takeshishimada.github.io/Lockman/main/documentation/lockman/dynamicconditionstrategy) - Controllo dinamico runtime
-* [Strategia Composita](https://takeshishimada.github.io/Lockman/main/documentation/lockman/compositestrategy) - Combina più strategie
+### Estratégias
+* [Estratégia de Execução Única](https://takeshishimada.github.io/Lockman/main/documentation/lockman/singleexecutionstrategy) - Previne execução duplicada
+* [Estratégia Baseada em Prioridade](https://takeshishimada.github.io/Lockman/main/documentation/lockman/prioritybasedstrategy) - Controle baseado em prioridade
+* [Estratégia de Concorrência Limitada](https://takeshishimada.github.io/Lockman/main/documentation/lockman/concurrencylimitedstrategy) - Limita execuções concorrentes
+* [Estratégia de Coordenação de Grupo](https://takeshishimada.github.io/Lockman/main/documentation/lockman/groupcoordinationstrategy) - Coordena ações relacionadas
+* [Estratégia de Condição Dinâmica](https://takeshishimada.github.io/Lockman/main/documentation/lockman/dynamicconditionstrategy) - Controle dinâmico em tempo de execução
+* [Estratégia Composta](https://takeshishimada.github.io/Lockman/main/documentation/lockman/compositestrategy) - Combina múltiplas estratégias
 
-Nota: La documentazione è disponibile solo in inglese.
+Nota: A documentação está disponível apenas em inglês.
 
-## Installazione
+## Instalação
 
-Lockman può essere installato usando [Swift Package Manager](https://swift.org/package-manager/).
+Lockman pode ser instalado usando [Swift Package Manager](https://swift.org/package-manager/).
 
 ### Xcode
 
-In Xcode, seleziona File → Add Package Dependencies e inserisci il seguente URL:
+No Xcode, selecione File → Add Package Dependencies e insira a seguinte URL:
 
 ```
 https://github.com/takeshishimada/Lockman
@@ -224,7 +224,7 @@ https://github.com/takeshishimada/Lockman
 
 ### Package.swift
 
-Aggiungi la dipendenza al tuo file Package.swift:
+Adicione a dependência ao seu arquivo Package.swift:
 
 ```swift
 dependencies: [
@@ -232,7 +232,7 @@ dependencies: [
 ]
 ```
 
-Aggiungi la dipendenza al tuo target:
+Adicione a dependência ao seu alvo:
 
 ```swift
 .target(
@@ -243,20 +243,26 @@ Aggiungi la dipendenza al tuo target:
 )
 ```
 
-### Requisiti
+### Requisitos
 
-| Piattaforma | Versione Minima |
-|-------------|-----------------|
-| iOS         | 13.0            |
-| macOS       | 10.15           |
-| tvOS        | 13.0            |
-| watchOS     | 6.0             |
+| Plataforma | Versão Mínima |
+|------------|---------------|
+| iOS        | 13.0          |
+| macOS      | 10.15         |
+| tvOS       | 13.0          |
+| watchOS    | 6.0           |
 
-### Compatibilità delle Versioni
+### Compatibilidade de Versão
 
 | Lockman | The Composable Architecture |
 |---------|----------------------------|
 | 1.3.0   | 1.20.2                     |
+
+<details>
+<summary>Outras versões</summary>
+
+| Lockman | The Composable Architecture |
+|---------|----------------------------|
 | 1.2.0   | 1.20.2                     |
 | 1.1.0   | 1.20.2                     |
 | 1.0.0   | 1.20.2                     |
@@ -270,12 +276,6 @@ Aggiungi la dipendenza al tuo target:
 | 0.10.0  | 1.19.0                     |
 | 0.9.0   | 1.18.0                     |
 | 0.8.0   | 1.17.1                     |
-
-<details>
-<summary>Altre versioni</summary>
-
-| Lockman | The Composable Architecture |
-|---------|----------------------------|
 | 0.7.0   | 1.17.1                     |
 | 0.6.0   | 1.17.1                     |
 | 0.5.0   | 1.17.1                     |
@@ -302,20 +302,20 @@ This documentation is also available in other languages:
 - [Português (Portuguese)](README_pt-BR.md)
 - [Italiano (Italian)](README_it.md)
 
-## Comunità
+## Comunidade
 
-### Discussione e Aiuto
+### Discussão e Ajuda
 
-Domande e discussioni possono essere tenute su [GitHub Discussions](https://github.com/takeshishimada/Lockman/discussions).
+Perguntas e discussões podem ser realizadas no [GitHub Discussions](https://github.com/takeshishimada/Lockman/discussions).
 
-### Segnalazioni di Bug
+### Relatórios de Bugs
 
-Se trovi un bug, per favore segnalalo su [Issues](https://github.com/takeshishimada/Lockman/issues).
+Se você encontrar um bug, por favor reporte em [Issues](https://github.com/takeshishimada/Lockman/issues).
 
-### Contribuire
+### Contribuindo
 
-Se desideri contribuire alla libreria, per favore apri una PR con un link ad essa!
+Se você gostaria de contribuir para a biblioteca, por favor abra um PR com um link para ele!
 
-## Licenza
+## Licença
 
-Questa libreria è rilasciata sotto licenza MIT. Vedi il file [LICENSE](./LICENSE) per i dettagli.
+Esta biblioteca é lançada sob a Licença MIT. Veja o arquivo [LICENSE](./LICENSE) para detalhes.

--- a/READMEs/README_zh-CN.md
+++ b/READMEs/README_zh-CN.md
@@ -5,53 +5,53 @@
 [![Platforms](https://img.shields.io/badge/Platforms-iOS%20%7C%20macOS%20%7C%20tvOS%20%7C%20watchOS%20%7C%20Mac%20Catalyst-333333.svg?style=flat)](https://developer.apple.com/)
 
 
-Lockman é uma biblioteca Swift que resolve problemas de controle exclusivo de ações em aplicações The Composable Architecture (TCA), com responsividade, transparência e design declarativo em mente.
+Lockman 是一个 Swift 库，旨在解决 The Composable Architecture (TCA) 应用程序中的并发动作控制问题，注重响应性、透明性和声明式设计。
 
-* [Filosofia de Design](#filosofia-de-design)
-* [Visão Geral](#visão-geral)
-* [Exemplo Básico](#exemplo-básico)
-* [Instalação](#instalação)
-* [Comunidade](#comunidade)
+* [设计理念](#设计理念)
+* [概述](#概述)
+* [基本示例](#基本示例)
+* [安装](#安装)
+* [社区](#社区)
 
-## Filosofia de Design
+## 设计理念
 
-### Princípios de Designing Fluid Interfaces
+### Designing Fluid Interfaces 原则
 
-O "Designing Fluid Interfaces" da WWDC18 apresentou princípios para interfaces excepcionais:
+WWDC18 的"Designing Fluid Interfaces"提出了卓越界面的原则：
 
-* **Resposta Imediata e Redirecionamento Contínuo** - Responsividade que não permite nem 10ms de atraso
-* **Movimento de Toque e Conteúdo Um-para-Um** - O conteúdo segue o dedo durante operações de arraste
-* **Feedback Contínuo** - Reação imediata a todas as interações
-* **Detecção de Gestos Paralelos** - Reconhecendo múltiplos gestos simultaneamente
-* **Consistência Espacial** - Mantendo consistência de posição durante animações
-* **Interações Leves, Saída Amplificada** - Grandes efeitos a partir de pequenas entradas
+* **即时响应和持续重定向** - 不允许有 10 毫秒延迟的响应性
+* **一对一的触摸和内容移动** - 拖动操作时内容跟随手指
+* **持续反馈** - 对所有交互的即时反应
+* **并行手势检测** - 同时识别多个手势
+* **空间一致性** - 动画期间保持位置一致性
+* **轻量级交互，放大输出** - 小输入产生大效果
 
-### Desafios Tradicionais
+### 传统挑战
 
-O desenvolvimento tradicional de UI resolveu problemas simplesmente proibindo pressionamentos simultâneos de botões e execuções duplicadas. Essas abordagens se tornaram fatores que prejudicam a experiência do usuário no design moderno de interfaces fluidas.
+传统 UI 开发通过简单地禁止同时按下按钮和重复执行来解决问题。这些方法已成为现代流畅界面设计中阻碍用户体验的因素。
 
-Os usuários esperam algum tipo de feedback mesmo ao pressionar botões simultaneamente. É crucial separar claramente a resposta imediata na camada de UI do controle apropriado de exclusão mútua na camada de lógica de negócios.
+用户期望即使同时按下按钮也能获得某种形式的反馈。在 UI 层的即时响应与业务逻辑层的适当互斥控制之间进行清晰分离至关重要。
 
-## Visão Geral
+## 概述
 
-Lockman fornece as seguintes estratégias de controle para abordar problemas comuns no desenvolvimento de aplicativos:
+Lockman 提供以下控制策略来解决应用开发中的常见问题：
 
-* **Execução Única**: Previne execução duplicada da mesma ação
-* **Baseado em Prioridade**: Controle e cancelamento de ação baseado em prioridade
-* **Coordenação de Grupo**: Controle de grupo através de papéis líder/membro
-* **Condição Dinâmica**: Controle dinâmico baseado em condições de tempo de execução
-* **Concorrência Limitada**: Limita o número de execuções concorrentes por grupo
-* **Estratégia Composta**: Combinação de múltiplas estratégias
+* **Single Execution**：防止相同动作的重复执行
+* **Priority Based**：基于优先级的动作控制和取消
+* **Group Coordination**：通过领导者/成员角色进行组控制
+* **Dynamic Condition**：基于运行时条件的动态控制
+* **Concurrency Limited**：限制每组的并发执行数量
+* **Composite Strategy**：多种策略的组合
 
-## Exemplos
+## 示例
 
-| Estratégia de Execução Única | Estratégia Baseada em Prioridade | Estratégia de Concorrência Limitada |
-|------------------------------|----------------------------------|-------------------------------------|
-| ![Estratégia de Execução Única](../Sources/Lockman/Documentation.docc/images/01-SingleExecutionStrategy.gif) | ![Estratégia Baseada em Prioridade](../Sources/Lockman/Documentation.docc/images/02-PriorityBasedStrategy.gif) | ![Estratégia de Concorrência Limitada](../Sources/Lockman/Documentation.docc/images/03-ConcurrencyLimitedStrategy.gif) |
+| Single Execution Strategy | Priority Based Strategy | Concurrency Limited Strategy |
+|--------------------------|------------------------|------------------------------|
+| ![Single Execution Strategy](../Sources/Lockman/Documentation.docc/images/01-SingleExecutionStrategy.gif) | ![Priority Based Strategy](../Sources/Lockman/Documentation.docc/images/02-PriorityBasedStrategy.gif) | ![Concurrency Limited Strategy](../Sources/Lockman/Documentation.docc/images/03-ConcurrencyLimitedStrategy.gif) |
 
-## Exemplo de Código
+## 代码示例
 
-Veja como implementar um recurso que previne execução duplicada de processos usando o macro `@LockmanSingleExecution`:
+以下是如何使用 `@LockmanSingleExecution` 宏实现防止进程重复执行的功能：
 
 ```swift
 import CasePaths
@@ -99,7 +99,7 @@ struct ProcessFeature {
                 case .startProcessButtonTapped:
                     return .run { send in
                         await send(.internal(.processStart))
-                        // Simular processamento pesado
+                        // 模拟重处理
                         try await Task.sleep(nanoseconds: 3_000_000_000)
                         await send(.internal(.processCompleted))
                     }
@@ -109,12 +109,12 @@ struct ProcessFeature {
                 switch internalAction {
                 case .processStart:
                     state.isProcessing = true
-                    state.message = "Processamento iniciado..."
+                    state.message = "处理已开始..."
                     return .none
                     
                 case .processCompleted:
                     state.isProcessing = false
-                    state.message = "Processamento concluído"
+                    state.message = "处理已完成"
                     return .none
                     
                 case .updateMessage(let message):
@@ -126,10 +126,10 @@ struct ProcessFeature {
         .lock(
             boundaryId: CancelID.userAction,
             lockFailure: { error, send in
-                // Quando o processamento já está em andamento
+                // 当处理已经在进行中时
                 if error is LockmanSingleExecutionError {
-                    // Atualizar mensagem através de uma ação em vez de mutação direta do estado
-                    await send(.internal(.updateMessage("O processamento já está em andamento")))
+                    // 通过动作更新消息而不是直接修改状态
+                    await send(.internal(.updateMessage("处理已经在进行中")))
                 }
             },
             for: \.view
@@ -138,9 +138,9 @@ struct ProcessFeature {
 }
 ```
 
-O modificador `Reducer.lock` aplica automaticamente o gerenciamento de bloqueio às ações que estão em conformidade com `LockmanAction`. Como a enumeração `ViewAction` está marcada com `@LockmanSingleExecution`, a ação `startProcessButtonTapped` não será executada enquanto o processamento estiver em andamento. O parâmetro `for: \.view` instrui o Lockman a verificar a conformidade com `LockmanAction` para ações aninhadas no caso `view`.
+`Reducer.lock` 修饰符自动对符合 `LockmanAction` 的动作应用锁管理。由于 `ViewAction` 枚举被标记为 `@LockmanSingleExecution`，`startProcessButtonTapped` 动作在处理进行中时不会被执行。`for: \.view` 参数告诉 Lockman 检查嵌套在 `view` 情况中的动作的 `LockmanAction` 一致性。
 
-### Exemplo de Saída de Debug
+### 调试输出示例
 
 ```
 ✅ [Lockman] canLock succeeded - Strategy: SingleExecution, BoundaryId: process, Info: LockmanSingleExecutionInfo(actionId: 'startProcessButtonTapped', uniqueId: 7BFC785A-3D25-4722-B9BC-A3A63A7F49FC, mode: boundary)
@@ -161,19 +161,19 @@ O modificador `Reducer.lock` aplica automaticamente o gerenciamento de bloqueio 
 └─────────────────┴──────────────────┴──────────────────────────────────────┴─────────────────┘
 ```
 
-## Documentação
+## 文档
 
-A documentação para lançamentos e `main` estão disponíveis aqui:
+发布版本和 `main` 分支的文档可在此处获取：
 
 * [`main`](https://takeshishimada.github.io/Lockman/main/documentation/lockman/)
-* [1.3.0](https://takeshishimada.github.io/Lockman/1.3.0/documentation/lockman/) ([guia de migração](https://takeshishimada.github.io/Lockman/1.3.0/documentation/lockman/migratingto1.3))
-* [1.2.0](https://takeshishimada.github.io/Lockman/1.2.0/documentation/lockman/) ([guia de migração](https://takeshishimada.github.io/Lockman/1.2.0/documentation/lockman/migratingto1.2))
-* [1.1.0](https://takeshishimada.github.io/Lockman/1.1.0/documentation/lockman/) ([guia de migração](https://takeshishimada.github.io/Lockman/1.1.0/documentation/lockman/migratingto1.1))
+* [1.3.0](https://takeshishimada.github.io/Lockman/1.3.0/documentation/lockman/) ([迁移指南](https://takeshishimada.github.io/Lockman/1.3.0/documentation/lockman/migratingto1.3))
+* [1.2.0](https://takeshishimada.github.io/Lockman/1.2.0/documentation/lockman/) ([迁移指南](https://takeshishimada.github.io/Lockman/1.2.0/documentation/lockman/migratingto1.2))
+* [1.1.0](https://takeshishimada.github.io/Lockman/1.1.0/documentation/lockman/) ([迁移指南](https://takeshishimada.github.io/Lockman/1.1.0/documentation/lockman/migratingto1.1))
 
 <details>
-<summary>Outras versões</summary>
+<summary>其他版本</summary>
 
-* [1.0.0](https://takeshishimada.github.io/Lockman/1.0.0/documentation/lockman/) ([guia de migração](https://takeshishimada.github.io/Lockman/1.0.0/documentation/lockman/migratingto1.0))
+* [1.0.0](https://takeshishimada.github.io/Lockman/1.0.0/documentation/lockman/) ([迁移指南](https://takeshishimada.github.io/Lockman/1.0.0/documentation/lockman/migratingto1.0))
 * [0.13.0](https://takeshishimada.github.io/Lockman/0.13.0/documentation/lockman/)
 * [0.12.0](https://takeshishimada.github.io/Lockman/0.12.0/documentation/lockman/)
 * [0.11.0](https://takeshishimada.github.io/Lockman/0.11.0/documentation/lockman/)
@@ -188,35 +188,35 @@ A documentação para lançamentos e `main` estão disponíveis aqui:
 
 </details>
 
-Existem vários artigos na documentação que você pode achar úteis à medida que se familiariza com a biblioteca:
+文档中有许多文章可以帮助您更好地使用该库：
 
-### Essenciais
-* [Começando](https://takeshishimada.github.io/Lockman/main/documentation/lockman/gettingstarted) - Aprenda como integrar Lockman em sua aplicação TCA
-* [Visão Geral de Limites](https://takeshishimada.github.io/Lockman/main/documentation/lockman/boundaryoverview) - Entenda o conceito de limites em Lockman
-* [Bloquear](https://takeshishimada.github.io/Lockman/main/documentation/lockman/lock) - Entendendo o mecanismo de bloqueio
-* [Desbloquear](https://takeshishimada.github.io/Lockman/main/documentation/lockman/unlock) - Entendendo o mecanismo de desbloqueio
-* [Escolhendo uma Estratégia](https://takeshishimada.github.io/Lockman/main/documentation/lockman/choosingstrategy) - Selecione a estratégia certa para seu caso de uso
-* [Configuração](https://takeshishimada.github.io/Lockman/main/documentation/lockman/configuration) - Configure Lockman para as necessidades de sua aplicação
-* [Tratamento de Erros](https://takeshishimada.github.io/Lockman/main/documentation/lockman/errorhandling) - Aprenda sobre padrões comuns de tratamento de erros
-* [Guia de Depuração](https://takeshishimada.github.io/Lockman/main/documentation/lockman/debuggingguide) - Depure problemas relacionados ao Lockman em sua aplicação
+### 基础知识
+* [入门指南](https://takeshishimada.github.io/Lockman/main/documentation/lockman/gettingstarted) - 了解如何将 Lockman 集成到您的 TCA 应用程序中
+* [边界概述](https://takeshishimada.github.io/Lockman/main/documentation/lockman/boundaryoverview) - 理解 Lockman 中的边界概念
+* [锁定](https://takeshishimada.github.io/Lockman/main/documentation/lockman/lock) - 理解锁定机制
+* [解锁](https://takeshishimada.github.io/Lockman/main/documentation/lockman/unlock) - 理解解锁机制
+* [选择策略](https://takeshishimada.github.io/Lockman/main/documentation/lockman/choosingstrategy) - 为您的用例选择合适的策略
+* [配置](https://takeshishimada.github.io/Lockman/main/documentation/lockman/configuration) - 根据应用程序需求配置 Lockman
+* [错误处理](https://takeshishimada.github.io/Lockman/main/documentation/lockman/errorhandling) - 了解常见的错误处理模式
+* [调试指南](https://takeshishimada.github.io/Lockman/main/documentation/lockman/debuggingguide) - 调试应用程序中与 Lockman 相关的问题
 
-### Estratégias
-* [Estratégia de Execução Única](https://takeshishimada.github.io/Lockman/main/documentation/lockman/singleexecutionstrategy) - Previne execução duplicada
-* [Estratégia Baseada em Prioridade](https://takeshishimada.github.io/Lockman/main/documentation/lockman/prioritybasedstrategy) - Controle baseado em prioridade
-* [Estratégia de Concorrência Limitada](https://takeshishimada.github.io/Lockman/main/documentation/lockman/concurrencylimitedstrategy) - Limita execuções concorrentes
-* [Estratégia de Coordenação de Grupo](https://takeshishimada.github.io/Lockman/main/documentation/lockman/groupcoordinationstrategy) - Coordena ações relacionadas
-* [Estratégia de Condição Dinâmica](https://takeshishimada.github.io/Lockman/main/documentation/lockman/dynamicconditionstrategy) - Controle dinâmico em tempo de execução
-* [Estratégia Composta](https://takeshishimada.github.io/Lockman/main/documentation/lockman/compositestrategy) - Combina múltiplas estratégias
+### 策略
+* [Single Execution Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/singleexecutionstrategy) - 防止重复执行
+* [Priority Based Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/prioritybasedstrategy) - 基于优先级的控制
+* [Concurrency Limited Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/concurrencylimitedstrategy) - 限制并发执行
+* [Group Coordination Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/groupcoordinationstrategy) - 协调相关动作
+* [Dynamic Condition Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/dynamicconditionstrategy) - 动态运行时控制
+* [Composite Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/compositestrategy) - 组合多种策略
 
-Nota: A documentação está disponível apenas em inglês.
+注：文档仅提供英文版本。
 
-## Instalação
+## 安装
 
-Lockman pode ser instalado usando [Swift Package Manager](https://swift.org/package-manager/).
+Lockman 可以使用 [Swift Package Manager](https://swift.org/package-manager/) 进行安装。
 
 ### Xcode
 
-No Xcode, selecione File → Add Package Dependencies e insira a seguinte URL:
+在 Xcode 中，选择 File → Add Package Dependencies 并输入以下 URL：
 
 ```
 https://github.com/takeshishimada/Lockman
@@ -224,7 +224,7 @@ https://github.com/takeshishimada/Lockman
 
 ### Package.swift
 
-Adicione a dependência ao seu arquivo Package.swift:
+将依赖项添加到您的 Package.swift 文件中：
 
 ```swift
 dependencies: [
@@ -232,7 +232,7 @@ dependencies: [
 ]
 ```
 
-Adicione a dependência ao seu alvo:
+将依赖项添加到您的目标中：
 
 ```swift
 .target(
@@ -243,20 +243,26 @@ Adicione a dependência ao seu alvo:
 )
 ```
 
-### Requisitos
+### 系统要求
 
-| Plataforma | Versão Mínima |
-|------------|---------------|
-| iOS        | 13.0          |
-| macOS      | 10.15         |
-| tvOS       | 13.0          |
-| watchOS    | 6.0           |
+| 平台      | 最低版本 |
+|----------|---------|
+| iOS      | 13.0    |
+| macOS    | 10.15   |
+| tvOS     | 13.0    |
+| watchOS  | 6.0     |
 
-### Compatibilidade de Versão
+### 版本兼容性
 
 | Lockman | The Composable Architecture |
 |---------|----------------------------|
 | 1.3.0   | 1.20.2                     |
+
+<details>
+<summary>其他版本</summary>
+
+| Lockman | The Composable Architecture |
+|---------|----------------------------|
 | 1.2.0   | 1.20.2                     |
 | 1.1.0   | 1.20.2                     |
 | 1.0.0   | 1.20.2                     |
@@ -270,12 +276,6 @@ Adicione a dependência ao seu alvo:
 | 0.10.0  | 1.19.0                     |
 | 0.9.0   | 1.18.0                     |
 | 0.8.0   | 1.17.1                     |
-
-<details>
-<summary>Outras versões</summary>
-
-| Lockman | The Composable Architecture |
-|---------|----------------------------|
 | 0.7.0   | 1.17.1                     |
 | 0.6.0   | 1.17.1                     |
 | 0.5.0   | 1.17.1                     |
@@ -302,20 +302,20 @@ This documentation is also available in other languages:
 - [Português (Portuguese)](README_pt-BR.md)
 - [Italiano (Italian)](README_it.md)
 
-## Comunidade
+## 社区
 
-### Discussão e Ajuda
+### 讨论和帮助
 
-Perguntas e discussões podem ser realizadas no [GitHub Discussions](https://github.com/takeshishimada/Lockman/discussions).
+可以在 [GitHub Discussions](https://github.com/takeshishimada/Lockman/discussions) 上进行问题讨论。
 
-### Relatórios de Bugs
+### 错误报告
 
-Se você encontrar um bug, por favor reporte em [Issues](https://github.com/takeshishimada/Lockman/issues).
+如果发现错误，请在 [Issues](https://github.com/takeshishimada/Lockman/issues) 上报告。
 
-### Contribuindo
+### 贡献
 
-Se você gostaria de contribuir para a biblioteca, por favor abra um PR com um link para ele!
+如果您想为该库做出贡献，请创建一个 PR 并附上相关链接！
 
-## Licença
+## 许可证
 
-Esta biblioteca é lançada sob a Licença MIT. Veja o arquivo [LICENSE](./LICENSE) para detalhes.
+本库基于 MIT 许可证发布。详情请参阅 [LICENSE](./LICENSE) 文件。

--- a/READMEs/README_zh-TW.md
+++ b/READMEs/README_zh-TW.md
@@ -5,53 +5,53 @@
 [![Platforms](https://img.shields.io/badge/Platforms-iOS%20%7C%20macOS%20%7C%20tvOS%20%7C%20watchOS%20%7C%20Mac%20Catalyst-333333.svg?style=flat)](https://developer.apple.com/)
 
 
-Lockman 是一个 Swift 库，旨在解决 The Composable Architecture (TCA) 应用程序中的并发动作控制问题，注重响应性、透明性和声明式设计。
+Lockman 是一個 Swift 函式庫，旨在解決 The Composable Architecture (TCA) 應用程式中的並行動作控制問題，著重於回應性、透明性和宣告式設計。
 
-* [设计理念](#设计理念)
+* [設計理念](#設計理念)
 * [概述](#概述)
-* [基本示例](#基本示例)
-* [安装](#安装)
-* [社区](#社区)
+* [基本範例](#基本範例)
+* [安裝](#安裝)
+* [社群](#社群)
 
-## 设计理念
+## 設計理念
 
-### Designing Fluid Interfaces 原则
+### Designing Fluid Interfaces 原則
 
-WWDC18 的"Designing Fluid Interfaces"提出了卓越界面的原则：
+WWDC18 的「Designing Fluid Interfaces」提出了卓越介面的原則：
 
-* **即时响应和持续重定向** - 不允许有 10 毫秒延迟的响应性
-* **一对一的触摸和内容移动** - 拖动操作时内容跟随手指
-* **持续反馈** - 对所有交互的即时反应
-* **并行手势检测** - 同时识别多个手势
-* **空间一致性** - 动画期间保持位置一致性
-* **轻量级交互，放大输出** - 小输入产生大效果
+* **即時回應和持續重新導向** - 不允許有 10 毫秒延遲的回應性
+* **一對一的觸控和內容移動** - 拖曳操作時內容跟隨手指
+* **持續回饋** - 對所有互動的即時反應
+* **平行手勢偵測** - 同時識別多個手勢
+* **空間一致性** - 動畫期間保持位置一致性
+* **輕量級互動，放大輸出** - 小輸入產生大效果
 
-### 传统挑战
+### 傳統挑戰
 
-传统 UI 开发通过简单地禁止同时按下按钮和重复执行来解决问题。这些方法已成为现代流畅界面设计中阻碍用户体验的因素。
+傳統 UI 開發透過簡單地禁止同時按下按鈕和重複執行來解決問題。這些方法已成為現代流暢介面設計中阻礙使用者體驗的因素。
 
-用户期望即使同时按下按钮也能获得某种形式的反馈。在 UI 层的即时响应与业务逻辑层的适当互斥控制之间进行清晰分离至关重要。
+使用者期望即使同時按下按鈕也能獲得某種形式的回饋。在 UI 層的即時回應與業務邏輯層的適當互斥控制之間進行清晰分離至關重要。
 
 ## 概述
 
-Lockman 提供以下控制策略来解决应用开发中的常见问题：
+Lockman 提供以下控制策略來解決應用程式開發中的常見問題：
 
-* **Single Execution**：防止相同动作的重复执行
-* **Priority Based**：基于优先级的动作控制和取消
-* **Group Coordination**：通过领导者/成员角色进行组控制
-* **Dynamic Condition**：基于运行时条件的动态控制
-* **Concurrency Limited**：限制每组的并发执行数量
-* **Composite Strategy**：多种策略的组合
+* **Single Execution**：防止相同動作的重複執行
+* **Priority Based**：基於優先順序的動作控制和取消
+* **Group Coordination**：透過領導者/成員角色進行群組控制
+* **Dynamic Condition**：基於執行時條件的動態控制
+* **Concurrency Limited**：限制每組的並行執行數量
+* **Composite Strategy**：多種策略的組合
 
-## 示例
+## 範例
 
 | Single Execution Strategy | Priority Based Strategy | Concurrency Limited Strategy |
 |--------------------------|------------------------|------------------------------|
 | ![Single Execution Strategy](../Sources/Lockman/Documentation.docc/images/01-SingleExecutionStrategy.gif) | ![Priority Based Strategy](../Sources/Lockman/Documentation.docc/images/02-PriorityBasedStrategy.gif) | ![Concurrency Limited Strategy](../Sources/Lockman/Documentation.docc/images/03-ConcurrencyLimitedStrategy.gif) |
 
-## 代码示例
+## 程式碼範例
 
-以下是如何使用 `@LockmanSingleExecution` 宏实现防止进程重复执行的功能：
+以下是如何使用 `@LockmanSingleExecution` 巨集實作防止程序重複執行的功能：
 
 ```swift
 import CasePaths
@@ -99,7 +99,7 @@ struct ProcessFeature {
                 case .startProcessButtonTapped:
                     return .run { send in
                         await send(.internal(.processStart))
-                        // 模拟重处理
+                        // 模擬重處理
                         try await Task.sleep(nanoseconds: 3_000_000_000)
                         await send(.internal(.processCompleted))
                     }
@@ -109,12 +109,12 @@ struct ProcessFeature {
                 switch internalAction {
                 case .processStart:
                     state.isProcessing = true
-                    state.message = "处理已开始..."
+                    state.message = "處理已開始..."
                     return .none
                     
                 case .processCompleted:
                     state.isProcessing = false
-                    state.message = "处理已完成"
+                    state.message = "處理已完成"
                     return .none
                     
                 case .updateMessage(let message):
@@ -126,10 +126,10 @@ struct ProcessFeature {
         .lock(
             boundaryId: CancelID.userAction,
             lockFailure: { error, send in
-                // 当处理已经在进行中时
+                // 當處理已經在進行中時
                 if error is LockmanSingleExecutionError {
-                    // 通过动作更新消息而不是直接修改状态
-                    await send(.internal(.updateMessage("处理已经在进行中")))
+                    // 透過動作更新訊息而不是直接修改狀態
+                    await send(.internal(.updateMessage("處理已經在進行中")))
                 }
             },
             for: \.view
@@ -138,9 +138,9 @@ struct ProcessFeature {
 }
 ```
 
-`Reducer.lock` 修饰符自动对符合 `LockmanAction` 的动作应用锁管理。由于 `ViewAction` 枚举被标记为 `@LockmanSingleExecution`，`startProcessButtonTapped` 动作在处理进行中时不会被执行。`for: \.view` 参数告诉 Lockman 检查嵌套在 `view` 情况中的动作的 `LockmanAction` 一致性。
+`Reducer.lock` 修飾符自動對符合 `LockmanAction` 的動作應用鎖管理。由於 `ViewAction` 枚舉被標記為 `@LockmanSingleExecution`，`startProcessButtonTapped` 動作在處理進行中時不會被執行。`for: \.view` 參數告訴 Lockman 檢查嵌套在 `view` 情況中的動作的 `LockmanAction` 一致性。
 
-### 调试输出示例
+### 除錯輸出範例
 
 ```
 ✅ [Lockman] canLock succeeded - Strategy: SingleExecution, BoundaryId: process, Info: LockmanSingleExecutionInfo(actionId: 'startProcessButtonTapped', uniqueId: 7BFC785A-3D25-4722-B9BC-A3A63A7F49FC, mode: boundary)
@@ -161,19 +161,19 @@ struct ProcessFeature {
 └─────────────────┴──────────────────┴──────────────────────────────────────┴─────────────────┘
 ```
 
-## 文档
+## 文件
 
-发布版本和 `main` 分支的文档可在此处获取：
+發布版本和 `main` 分支的文件可在此處取得：
 
 * [`main`](https://takeshishimada.github.io/Lockman/main/documentation/lockman/)
-* [1.3.0](https://takeshishimada.github.io/Lockman/1.3.0/documentation/lockman/) ([迁移指南](https://takeshishimada.github.io/Lockman/1.3.0/documentation/lockman/migratingto1.3))
-* [1.2.0](https://takeshishimada.github.io/Lockman/1.2.0/documentation/lockman/) ([迁移指南](https://takeshishimada.github.io/Lockman/1.2.0/documentation/lockman/migratingto1.2))
-* [1.1.0](https://takeshishimada.github.io/Lockman/1.1.0/documentation/lockman/) ([迁移指南](https://takeshishimada.github.io/Lockman/1.1.0/documentation/lockman/migratingto1.1))
+* [1.3.0](https://takeshishimada.github.io/Lockman/1.3.0/documentation/lockman/) ([移轉指南](https://takeshishimada.github.io/Lockman/1.3.0/documentation/lockman/migratingto1.3))
+* [1.2.0](https://takeshishimada.github.io/Lockman/1.2.0/documentation/lockman/) ([遷移指南](https://takeshishimada.github.io/Lockman/1.2.0/documentation/lockman/migratingto1.2))
+* [1.1.0](https://takeshishimada.github.io/Lockman/1.1.0/documentation/lockman/) ([遷移指南](https://takeshishimada.github.io/Lockman/1.1.0/documentation/lockman/migratingto1.1))
 
 <details>
 <summary>其他版本</summary>
 
-* [1.0.0](https://takeshishimada.github.io/Lockman/1.0.0/documentation/lockman/) ([迁移指南](https://takeshishimada.github.io/Lockman/1.0.0/documentation/lockman/migratingto1.0))
+* [1.0.0](https://takeshishimada.github.io/Lockman/1.0.0/documentation/lockman/) ([移轉指南](https://takeshishimada.github.io/Lockman/1.0.0/documentation/lockman/migratingto1.0))
 * [0.13.0](https://takeshishimada.github.io/Lockman/0.13.0/documentation/lockman/)
 * [0.12.0](https://takeshishimada.github.io/Lockman/0.12.0/documentation/lockman/)
 * [0.11.0](https://takeshishimada.github.io/Lockman/0.11.0/documentation/lockman/)
@@ -188,35 +188,35 @@ struct ProcessFeature {
 
 </details>
 
-文档中有许多文章可以帮助您更好地使用该库：
+文件中有許多文章可以幫助您更好地使用該函式庫：
 
-### 基础知识
-* [入门指南](https://takeshishimada.github.io/Lockman/main/documentation/lockman/gettingstarted) - 了解如何将 Lockman 集成到您的 TCA 应用程序中
-* [边界概述](https://takeshishimada.github.io/Lockman/main/documentation/lockman/boundaryoverview) - 理解 Lockman 中的边界概念
-* [锁定](https://takeshishimada.github.io/Lockman/main/documentation/lockman/lock) - 理解锁定机制
-* [解锁](https://takeshishimada.github.io/Lockman/main/documentation/lockman/unlock) - 理解解锁机制
-* [选择策略](https://takeshishimada.github.io/Lockman/main/documentation/lockman/choosingstrategy) - 为您的用例选择合适的策略
-* [配置](https://takeshishimada.github.io/Lockman/main/documentation/lockman/configuration) - 根据应用程序需求配置 Lockman
-* [错误处理](https://takeshishimada.github.io/Lockman/main/documentation/lockman/errorhandling) - 了解常见的错误处理模式
-* [调试指南](https://takeshishimada.github.io/Lockman/main/documentation/lockman/debuggingguide) - 调试应用程序中与 Lockman 相关的问题
+### 基礎知識
+* [入門指南](https://takeshishimada.github.io/Lockman/main/documentation/lockman/gettingstarted) - 了解如何將 Lockman 整合到您的 TCA 應用程式中
+* [邊界概述](https://takeshishimada.github.io/Lockman/main/documentation/lockman/boundaryoverview) - 理解 Lockman 中的邊界概念
+* [鎖定](https://takeshishimada.github.io/Lockman/main/documentation/lockman/lock) - 理解鎖定機制
+* [解鎖](https://takeshishimada.github.io/Lockman/main/documentation/lockman/unlock) - 理解解鎖機制
+* [選擇策略](https://takeshishimada.github.io/Lockman/main/documentation/lockman/choosingstrategy) - 為您的使用案例選擇合適的策略
+* [設定](https://takeshishimada.github.io/Lockman/main/documentation/lockman/configuration) - 根據應用程式需求設定 Lockman
+* [錯誤處理](https://takeshishimada.github.io/Lockman/main/documentation/lockman/errorhandling) - 了解常見的錯誤處理模式
+* [除錯指南](https://takeshishimada.github.io/Lockman/main/documentation/lockman/debuggingguide) - 除錯應用程式中與 Lockman 相關的問題
 
 ### 策略
-* [Single Execution Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/singleexecutionstrategy) - 防止重复执行
-* [Priority Based Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/prioritybasedstrategy) - 基于优先级的控制
-* [Concurrency Limited Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/concurrencylimitedstrategy) - 限制并发执行
-* [Group Coordination Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/groupcoordinationstrategy) - 协调相关动作
-* [Dynamic Condition Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/dynamicconditionstrategy) - 动态运行时控制
-* [Composite Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/compositestrategy) - 组合多种策略
+* [Single Execution Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/singleexecutionstrategy) - 防止重複執行
+* [Priority Based Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/prioritybasedstrategy) - 基於優先順序的控制
+* [Concurrency Limited Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/concurrencylimitedstrategy) - 限制並行執行
+* [Group Coordination Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/groupcoordinationstrategy) - 協調相關動作
+* [Dynamic Condition Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/dynamicconditionstrategy) - 動態執行時控制
+* [Composite Strategy](https://takeshishimada.github.io/Lockman/main/documentation/lockman/compositestrategy) - 組合多種策略
 
-注：文档仅提供英文版本。
+註：文件僅提供英文版本。
 
-## 安装
+## 安裝
 
-Lockman 可以使用 [Swift Package Manager](https://swift.org/package-manager/) 进行安装。
+Lockman 可以使用 [Swift Package Manager](https://swift.org/package-manager/) 進行安裝。
 
 ### Xcode
 
-在 Xcode 中，选择 File → Add Package Dependencies 并输入以下 URL：
+在 Xcode 中，選擇 File → Add Package Dependencies 並輸入以下 URL：
 
 ```
 https://github.com/takeshishimada/Lockman
@@ -224,7 +224,7 @@ https://github.com/takeshishimada/Lockman
 
 ### Package.swift
 
-将依赖项添加到您的 Package.swift 文件中：
+將相依性新增到您的 Package.swift 檔案中：
 
 ```swift
 dependencies: [
@@ -232,7 +232,7 @@ dependencies: [
 ]
 ```
 
-将依赖项添加到您的目标中：
+將相依性新增到您的目標中：
 
 ```swift
 .target(
@@ -243,7 +243,7 @@ dependencies: [
 )
 ```
 
-### 系统要求
+### 系統需求
 
 | 平台      | 最低版本 |
 |----------|---------|
@@ -252,11 +252,17 @@ dependencies: [
 | tvOS     | 13.0    |
 | watchOS  | 6.0     |
 
-### 版本兼容性
+### 版本相容性
 
 | Lockman | The Composable Architecture |
 |---------|----------------------------|
 | 1.3.0   | 1.20.2                     |
+
+<details>
+<summary>其他版本</summary>
+
+| Lockman | The Composable Architecture |
+|---------|----------------------------|
 | 1.2.0   | 1.20.2                     |
 | 1.1.0   | 1.20.2                     |
 | 1.0.0   | 1.20.2                     |
@@ -270,12 +276,6 @@ dependencies: [
 | 0.10.0  | 1.19.0                     |
 | 0.9.0   | 1.18.0                     |
 | 0.8.0   | 1.17.1                     |
-
-<details>
-<summary>其他版本</summary>
-
-| Lockman | The Composable Architecture |
-|---------|----------------------------|
 | 0.7.0   | 1.17.1                     |
 | 0.6.0   | 1.17.1                     |
 | 0.5.0   | 1.17.1                     |
@@ -302,20 +302,20 @@ This documentation is also available in other languages:
 - [Português (Portuguese)](README_pt-BR.md)
 - [Italiano (Italian)](README_it.md)
 
-## 社区
+## 社群
 
-### 讨论和帮助
+### 討論和協助
 
-可以在 [GitHub Discussions](https://github.com/takeshishimada/Lockman/discussions) 上进行问题讨论。
+可以在 [GitHub Discussions](https://github.com/takeshishimada/Lockman/discussions) 上進行問題討論。
 
-### 错误报告
+### 錯誤回報
 
-如果发现错误，请在 [Issues](https://github.com/takeshishimada/Lockman/issues) 上报告。
+如果發現錯誤，請在 [Issues](https://github.com/takeshishimada/Lockman/issues) 上回報。
 
-### 贡献
+### 貢獻
 
-如果您想为该库做出贡献，请创建一个 PR 并附上相关链接！
+如果您想為該函式庫做出貢獻，請建立一個 PR 並附上相關連結！
 
-## 许可证
+## 授權條款
 
-本库基于 MIT 许可证发布。详情请参阅 [LICENSE](./LICENSE) 文件。
+本函式庫基於 MIT 授權條款發布。詳情請參閱 [LICENSE](./LICENSE) 檔案。


### PR DESCRIPTION
## Summary
- Rename `Docs/` directory to `READMEs/` for clearer purpose indication
- Update Version Compatibility sections to show only latest version (1.3.0) in main table
- Move all older versions to "Other versions" collapsible sections

## Changes
- **Directory Structure**: Renamed `./Docs/` → `./READMEs/` to better reflect the directory's purpose of containing translated README files
- **Version Compatibility**: Updated all README files (main + 9 translations) to show only the latest version (1.3.0) in the main compatibility table, with older versions moved to collapsible "Other versions" sections
- **Link Updates**: Updated all translation links in main README.md to point to the new `READMEs/` directory path
- **Consistency**: Applied changes uniformly across all translated README files (Japanese, Chinese Simplified/Traditional, Spanish, French, German, Korean, Portuguese, Italian)

This improves documentation organization and makes version compatibility information more focused on the current release while keeping historical information easily accessible.

🤖 Generated with [Claude Code](https://claude.ai/code)