### PR TITLE
chore: prepare for 1.3.1 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ Add the dependency to your Package.swift file:
 
 ```swift
 dependencies: [
-  .package(url: "https://github.com/takeshishimada/Lockman", from: "1.3.0")
+  .package(url: "https://github.com/takeshishimada/Lockman", from: "1.3.1")
 ]
 ```
 
@@ -253,13 +253,14 @@ Add the dependency to your target:
 
 | Lockman | The Composable Architecture |
 |---------|----------------------------|
-| 1.3.0   | 1.20.2                     |
+| 1.3.1   | 1.20.2                     |
 
 <details>
 <summary>Other versions</summary>
 
 | Lockman | The Composable Architecture |
 |---------|----------------------------|
+| 1.3.0   | 1.20.2                     |
 | 1.2.0   | 1.20.2                     |
 | 1.1.0   | 1.20.2                     |
 | 1.0.0   | 1.20.2                     |

--- a/READMEs/README_de.md
+++ b/READMEs/README_de.md
@@ -228,7 +228,7 @@ Fügen Sie die Abhängigkeit zu Ihrer Package.swift-Datei hinzu:
 
 ```swift
 dependencies: [
-  .package(url: "https://github.com/takeshishimada/Lockman", from: "1.3.0")
+  .package(url: "https://github.com/takeshishimada/Lockman", from: "1.3.1")
 ]
 ```
 
@@ -256,13 +256,14 @@ Fügen Sie die Abhängigkeit zu Ihrem Target hinzu:
 
 | Lockman | The Composable Architecture |
 |---------|----------------------------|
-| 1.3.0   | 1.20.2                     |
+| 1.3.1   | 1.20.2                     |
 
 <details>
 <summary>Weitere Versionen</summary>
 
 | Lockman | The Composable Architecture |
 |---------|----------------------------|
+| 1.3.0   | 1.20.2                     |
 | 1.2.0   | 1.20.2                     |
 | 1.1.0   | 1.20.2                     |
 | 1.0.0   | 1.20.2                     |

--- a/READMEs/README_es.md
+++ b/READMEs/README_es.md
@@ -228,7 +228,7 @@ Agrega la dependencia a tu archivo Package.swift:
 
 ```swift
 dependencies: [
-  .package(url: "https://github.com/takeshishimada/Lockman", from: "1.3.0")
+  .package(url: "https://github.com/takeshishimada/Lockman", from: "1.3.1")
 ]
 ```
 
@@ -256,13 +256,14 @@ Agrega la dependencia a tu objetivo:
 
 | Lockman | The Composable Architecture |
 |---------|----------------------------|
-| 1.3.0   | 1.20.2                     |
+| 1.3.1   | 1.20.2                     |
 
 <details>
 <summary>Otras versiones</summary>
 
 | Lockman | The Composable Architecture |
 |---------|----------------------------|
+| 1.3.0   | 1.20.2                     |
 | 1.2.0   | 1.20.2                     |
 | 1.1.0   | 1.20.2                     |
 | 1.0.0   | 1.20.2                     |

--- a/READMEs/README_fr.md
+++ b/READMEs/README_fr.md
@@ -228,7 +228,7 @@ Ajoutez la dépendance à votre fichier Package.swift :
 
 ```swift
 dependencies: [
-  .package(url: "https://github.com/takeshishimada/Lockman", from: "1.3.0")
+  .package(url: "https://github.com/takeshishimada/Lockman", from: "1.3.1")
 ]
 ```
 
@@ -256,13 +256,14 @@ Ajoutez la dépendance à votre cible :
 
 | Lockman | The Composable Architecture |
 |---------|----------------------------|
-| 1.3.0   | 1.20.2                     |
+| 1.3.1   | 1.20.2                     |
 
 <details>
 <summary>Autres versions</summary>
 
 | Lockman | The Composable Architecture |
 |---------|----------------------------|
+| 1.3.0   | 1.20.2                     |
 | 1.2.0   | 1.20.2                     |
 | 1.1.0   | 1.20.2                     |
 | 1.0.0   | 1.20.2                     |

--- a/READMEs/README_it.md
+++ b/READMEs/README_it.md
@@ -228,7 +228,7 @@ Aggiungi la dipendenza al tuo file Package.swift:
 
 ```swift
 dependencies: [
-  .package(url: "https://github.com/takeshishimada/Lockman", from: "1.3.0")
+  .package(url: "https://github.com/takeshishimada/Lockman", from: "1.3.1")
 ]
 ```
 
@@ -256,13 +256,14 @@ Aggiungi la dipendenza al tuo target:
 
 | Lockman | The Composable Architecture |
 |---------|----------------------------|
-| 1.3.0   | 1.20.2                     |
+| 1.3.1   | 1.20.2                     |
 
 <details>
 <summary>Altre versioni</summary>
 
 | Lockman | The Composable Architecture |
 |---------|----------------------------|
+| 1.3.0   | 1.20.2                     |
 | 1.2.0   | 1.20.2                     |
 | 1.1.0   | 1.20.2                     |
 | 1.0.0   | 1.20.2                     |

--- a/READMEs/README_ja.md
+++ b/READMEs/README_ja.md
@@ -225,7 +225,7 @@ Package.swiftファイルに依存関係を追加：
 
 ```swift
 dependencies: [
-  .package(url: "https://github.com/takeshishimada/Lockman", from: "1.3.0")
+  .package(url: "https://github.com/takeshishimada/Lockman", from: "1.3.1")
 ]
 ```
 
@@ -253,13 +253,14 @@ dependencies: [
 
 | Lockman | The Composable Architecture |
 |---------|----------------------------|
-| 1.3.0   | 1.20.2                     |
+| 1.3.1   | 1.20.2                     |
 
 <details>
 <summary>その他のバージョン</summary>
 
 | Lockman | The Composable Architecture |
 |---------|----------------------------|
+| 1.3.0   | 1.20.2                     |
 | 1.2.0   | 1.20.2                     |
 | 1.1.0   | 1.20.2                     |
 | 1.0.0   | 1.20.2                     |

--- a/READMEs/README_ko.md
+++ b/READMEs/README_ko.md
@@ -228,7 +228,7 @@ Package.swift 파일에 종속성을 추가하세요:
 
 ```swift
 dependencies: [
-  .package(url: "https://github.com/takeshishimada/Lockman", from: "1.3.0")
+  .package(url: "https://github.com/takeshishimada/Lockman", from: "1.3.1")
 ]
 ```
 
@@ -256,13 +256,14 @@ dependencies: [
 
 | Lockman | The Composable Architecture |
 |---------|----------------------------|
-| 1.3.0   | 1.20.2                     |
+| 1.3.1   | 1.20.2                     |
 
 <details>
 <summary>다른 버전</summary>
 
 | Lockman | The Composable Architecture |
 |---------|----------------------------|
+| 1.3.0   | 1.20.2                     |
 | 1.2.0   | 1.20.2                     |
 | 1.1.0   | 1.20.2                     |
 | 1.0.0   | 1.20.2                     |

--- a/READMEs/README_pt-BR.md
+++ b/READMEs/README_pt-BR.md
@@ -228,7 +228,7 @@ Adicione a dependência ao seu arquivo Package.swift:
 
 ```swift
 dependencies: [
-  .package(url: "https://github.com/takeshishimada/Lockman", from: "1.3.0")
+  .package(url: "https://github.com/takeshishimada/Lockman", from: "1.3.1")
 ]
 ```
 
@@ -256,13 +256,14 @@ Adicione a dependência ao seu alvo:
 
 | Lockman | The Composable Architecture |
 |---------|----------------------------|
-| 1.3.0   | 1.20.2                     |
+| 1.3.1   | 1.20.2                     |
 
 <details>
 <summary>Outras versões</summary>
 
 | Lockman | The Composable Architecture |
 |---------|----------------------------|
+| 1.3.0   | 1.20.2                     |
 | 1.2.0   | 1.20.2                     |
 | 1.1.0   | 1.20.2                     |
 | 1.0.0   | 1.20.2                     |

--- a/READMEs/README_zh-CN.md
+++ b/READMEs/README_zh-CN.md
@@ -228,7 +228,7 @@ https://github.com/takeshishimada/Lockman
 
 ```swift
 dependencies: [
-  .package(url: "https://github.com/takeshishimada/Lockman", from: "1.3.0")
+  .package(url: "https://github.com/takeshishimada/Lockman", from: "1.3.1")
 ]
 ```
 
@@ -256,13 +256,14 @@ dependencies: [
 
 | Lockman | The Composable Architecture |
 |---------|----------------------------|
-| 1.3.0   | 1.20.2                     |
+| 1.3.1   | 1.20.2                     |
 
 <details>
 <summary>其他版本</summary>
 
 | Lockman | The Composable Architecture |
 |---------|----------------------------|
+| 1.3.0   | 1.20.2                     |
 | 1.2.0   | 1.20.2                     |
 | 1.1.0   | 1.20.2                     |
 | 1.0.0   | 1.20.2                     |

--- a/READMEs/README_zh-TW.md
+++ b/READMEs/README_zh-TW.md
@@ -228,7 +228,7 @@ https://github.com/takeshishimada/Lockman
 
 ```swift
 dependencies: [
-  .package(url: "https://github.com/takeshishimada/Lockman", from: "1.3.0")
+  .package(url: "https://github.com/takeshishimada/Lockman", from: "1.3.1")
 ]
 ```
 
@@ -256,13 +256,14 @@ dependencies: [
 
 | Lockman | The Composable Architecture |
 |---------|----------------------------|
-| 1.3.0   | 1.20.2                     |
+| 1.3.1   | 1.20.2                     |
 
 <details>
 <summary>其他版本</summary>
 
 | Lockman | The Composable Architecture |
 |---------|----------------------------|
+| 1.3.0   | 1.20.2                     |
 | 1.2.0   | 1.20.2                     |
 | 1.1.0   | 1.20.2                     |
 | 1.0.0   | 1.20.2                     |


### PR DESCRIPTION
## Summary
Prepare for version 1.3.1 release

## Changes
- Updated installation section from 1.3.0 to 1.3.1
- Added 1.3.1 to Version Compatibility table 
- Moved 1.3.0 to Other versions section

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>