### PR TITLE
refactor: unify boundary ID parameter names for consistency

### DIFF
--- a/Sources/Lockman/Core/Strategies/ConcurrencyLimitedStrategy/LockmanConcurrencyLimitedStrategy.swift
+++ b/Sources/Lockman/Core/Strategies/ConcurrencyLimitedStrategy/LockmanConcurrencyLimitedStrategy.swift
@@ -38,7 +38,7 @@ public final class LockmanConcurrencyLimitedStrategy: LockmanStrategy, @unchecke
     info: LockmanConcurrencyLimitedInfo
   ) -> LockmanResult {
     // Use the key-based query for efficient lookup
-    let currentCount = state.count(id: boundaryId, key: info.concurrencyId)
+    let currentCount = state.count(boundaryId: boundaryId, key: info.concurrencyId)
 
     let result: LockmanResult
     var failureReason: String?
@@ -46,7 +46,7 @@ public final class LockmanConcurrencyLimitedStrategy: LockmanStrategy, @unchecke
     if info.limit.isExceeded(currentCount: currentCount) {
       if case .limited(let limit) = info.limit {
         // Get existing infos in the same concurrency group
-        let existingInfos = state.currents(id: boundaryId, key: info.concurrencyId)
+        let existingInfos = state.currents(boundaryId: boundaryId, key: info.concurrencyId)
 
         result = .cancel(
           LockmanConcurrencyLimitedError.concurrencyLimitReached(
@@ -88,7 +88,7 @@ public final class LockmanConcurrencyLimitedStrategy: LockmanStrategy, @unchecke
     boundaryId: B,
     info: LockmanConcurrencyLimitedInfo
   ) {
-    state.add(id: boundaryId, info: info)
+    state.add(boundaryId: boundaryId, info: info)
   }
 
   /// Releases a lock by removing it from the concurrency tracking state.
@@ -100,7 +100,7 @@ public final class LockmanConcurrencyLimitedStrategy: LockmanStrategy, @unchecke
     boundaryId: B,
     info: LockmanConcurrencyLimitedInfo
   ) {
-    state.remove(id: boundaryId, info: info)
+    state.remove(boundaryId: boundaryId, info: info)
   }
 
   /// Removes all locks for a specific boundary across all concurrency groups.
@@ -110,9 +110,9 @@ public final class LockmanConcurrencyLimitedStrategy: LockmanStrategy, @unchecke
     boundaryId: B
   ) {
     // Get all locks for this boundary and remove them one by one
-    let currentLocks = state.currents(id: boundaryId)
+    let currentLocks = state.currents(boundaryId: boundaryId)
     for info in currentLocks {
-      state.remove(id: boundaryId, info: info)
+      state.remove(boundaryId: boundaryId, info: info)
     }
   }
 

--- a/Sources/Lockman/Core/Strategies/Core/LockmanState.swift
+++ b/Sources/Lockman/Core/Strategies/Core/LockmanState.swift
@@ -69,13 +69,13 @@ final class LockmanState<I: LockmanInfo, K: Hashable & Sendable>: Sendable {
   /// for efficient key-based lookups.
   ///
   /// - Parameters:
-  ///   - id: The boundary identifier
+  ///   - boundaryId: The boundary identifier
   ///   - info: The lock info to add
   ///
   /// ## Complexity
   /// O(1) - Direct ordered dictionary insertion and dual index update
-  func add<B: LockmanBoundaryId>(id: B, info: I) {
-    let boundaryKey = AnyLockmanBoundaryId(id)
+  func add<B: LockmanBoundaryId>(boundaryId: B, info: I) {
+    let boundaryKey = AnyLockmanBoundaryId(boundaryId)
     let indexKey = keyExtractor(info)
 
     storage.withCriticalRegion { storage in
@@ -93,15 +93,15 @@ final class LockmanState<I: LockmanInfo, K: Hashable & Sendable>: Sendable {
   /// maintaining consistency between both the primary storage and key index.
   ///
   /// - Parameters:
-  ///   - id: The boundary identifier
+  ///   - boundaryId: The boundary identifier
   ///   - key: The key whose locks should be removed
   ///
   /// ## Complexity
   /// O(n) - Where n is the total number of locks in the boundary
   /// However, if k (locks to remove) << n (total locks), this is still efficient
   /// due to O(1) Set lookup for each item
-  func removeAll<B: LockmanBoundaryId>(id: B, key: K) {
-    let boundaryKey = AnyLockmanBoundaryId(id)
+  func removeAll<B: LockmanBoundaryId>(boundaryId: B, key: K) {
+    let boundaryKey = AnyLockmanBoundaryId(boundaryId)
 
     // Get all UUIDs for this key
     let uuidsToRemove = index.withCriticalRegion { index in
@@ -144,13 +144,13 @@ final class LockmanState<I: LockmanInfo, K: Hashable & Sendable>: Sendable {
   /// the key index by removing the lock from both data structures.
   ///
   /// - Parameters:
-  ///   - id: The boundary identifier
+  ///   - boundaryId: The boundary identifier
   ///   - info: The lock info to remove (identified by uniqueId)
   ///
   /// ## Complexity
   /// O(1) - Direct key removal from OrderedDictionary and dual index update
-  func remove<B: LockmanBoundaryId>(id: B, info: any LockmanInfo) {
-    let boundaryKey = AnyLockmanBoundaryId(id)
+  func remove<B: LockmanBoundaryId>(boundaryId: B, info: any LockmanInfo) {
+    let boundaryKey = AnyLockmanBoundaryId(boundaryId)
 
     // First, get the info to access key for index cleanup
     let removedInfo = storage.withCriticalRegion { storage -> I? in
@@ -214,10 +214,10 @@ final class LockmanState<I: LockmanInfo, K: Hashable & Sendable>: Sendable {
   /// OrderedDictionary preserves insertion order, so this method returns
   /// locks in the exact order they were added to the boundary.
   ///
-  /// - Parameter id: The boundary identifier to query
+  /// - Parameter boundaryId: The boundary identifier to query
   /// - Returns: Array of locks in insertion order
-  func currents<B: LockmanBoundaryId>(id: B) -> [I] {
-    let boundaryKey = AnyLockmanBoundaryId(id)
+  func currents<B: LockmanBoundaryId>(boundaryId: B) -> [I] {
+    let boundaryKey = AnyLockmanBoundaryId(boundaryId)
     return storage.withCriticalRegion { storage in
       guard let boundaryDict = storage[boundaryKey] else {
         return []
@@ -234,14 +234,14 @@ final class LockmanState<I: LockmanInfo, K: Hashable & Sendable>: Sendable {
   /// making it ideal for strategies that need to check conflicts.
   ///
   /// - Parameters:
-  ///   - id: The boundary identifier
+  ///   - boundaryId: The boundary identifier
   ///   - key: The key to check
   /// - Returns: true if the key exists in the boundary
   ///
   /// ## Complexity
   /// O(1) - Direct hash table lookup
-  func contains<B: LockmanBoundaryId>(id: B, key: K) -> Bool {
-    let boundaryKey = AnyLockmanBoundaryId(id)
+  func contains<B: LockmanBoundaryId>(boundaryId: B, key: K) -> Bool {
+    let boundaryKey = AnyLockmanBoundaryId(boundaryId)
     return index.withCriticalRegion { index in
       index[boundaryKey]?[key] != nil
     }
@@ -253,11 +253,11 @@ final class LockmanState<I: LockmanInfo, K: Hashable & Sendable>: Sendable {
   /// maintaining the original insertion order.
   ///
   /// - Parameters:
-  ///   - id: The boundary identifier
+  ///   - boundaryId: The boundary identifier
   ///   - key: The key to filter by
   /// - Returns: Array of locks with the specified key in insertion order
-  func currents<B: LockmanBoundaryId>(id: B, key: K) -> [I] {
-    let boundaryKey = AnyLockmanBoundaryId(id)
+  func currents<B: LockmanBoundaryId>(boundaryId: B, key: K) -> [I] {
+    let boundaryKey = AnyLockmanBoundaryId(boundaryId)
 
     let uuids = index.withCriticalRegion { index in
       index[boundaryKey]?[key] ?? []
@@ -288,11 +288,11 @@ final class LockmanState<I: LockmanInfo, K: Hashable & Sendable>: Sendable {
   /// Returns the count of locks with a specific key - O(1) operation.
   ///
   /// - Parameters:
-  ///   - id: The boundary identifier
+  ///   - boundaryId: The boundary identifier
   ///   - key: The key to count
   /// - Returns: Number of locks with the specified key
-  func count<B: LockmanBoundaryId>(id: B, key: K) -> Int {
-    let boundaryKey = AnyLockmanBoundaryId(id)
+  func count<B: LockmanBoundaryId>(boundaryId: B, key: K) -> Int {
+    let boundaryKey = AnyLockmanBoundaryId(boundaryId)
     return index.withCriticalRegion { index in
       index[boundaryKey]?[key]?.count ?? 0
     }
@@ -300,10 +300,10 @@ final class LockmanState<I: LockmanInfo, K: Hashable & Sendable>: Sendable {
 
   /// Returns all unique keys in the boundary - O(1) operation.
   ///
-  /// - Parameter id: The boundary identifier
+  /// - Parameter boundaryId: The boundary identifier
   /// - Returns: Set of all unique keys in the boundary
-  func keys<B: LockmanBoundaryId>(id: B) -> Set<K> {
-    let boundaryKey = AnyLockmanBoundaryId(id)
+  func keys<B: LockmanBoundaryId>(boundaryId: B) -> Set<K> {
+    let boundaryKey = AnyLockmanBoundaryId(boundaryId)
     return index.withCriticalRegion { index in
       if let boundaryIndex = index[boundaryKey] {
         return Set(boundaryIndex.keys)
@@ -325,8 +325,8 @@ final class LockmanState<I: LockmanInfo, K: Hashable & Sendable>: Sendable {
   }
 
   /// Removes all locks for a specific boundary.
-  func removeAll<B: LockmanBoundaryId>(id: B) {
-    let boundaryKey = AnyLockmanBoundaryId(id)
+  func removeAll<B: LockmanBoundaryId>(boundaryId: B) {
+    let boundaryKey = AnyLockmanBoundaryId(boundaryId)
     storage.withCriticalRegion { storage in
       storage.removeValue(forKey: boundaryKey)
     }
@@ -390,35 +390,35 @@ extension LockmanState where K == LockmanActionId {
   /// Checks if a specific actionId exists in the boundary.
   ///
   /// Convenience method that calls the generic key-based method.
-  func contains<B: LockmanBoundaryId>(id: B, actionId: LockmanActionId) -> Bool {
-    contains(id: id, key: actionId)
+  func contains<B: LockmanBoundaryId>(boundaryId: B, actionId: LockmanActionId) -> Bool {
+    contains(boundaryId: boundaryId, key: actionId)
   }
 
   /// Returns all locks with a specific actionId in the boundary.
   ///
   /// Convenience method that calls the generic key-based method.
-  func currents<B: LockmanBoundaryId>(id: B, actionId: LockmanActionId) -> [I] {
-    currents(id: id, key: actionId)
+  func currents<B: LockmanBoundaryId>(boundaryId: B, actionId: LockmanActionId) -> [I] {
+    currents(boundaryId: boundaryId, key: actionId)
   }
 
   /// Returns the count of locks with a specific actionId.
   ///
   /// Convenience method that calls the generic key-based method.
-  func count<B: LockmanBoundaryId>(id: B, actionId: LockmanActionId) -> Int {
-    count(id: id, key: actionId)
+  func count<B: LockmanBoundaryId>(boundaryId: B, actionId: LockmanActionId) -> Int {
+    count(boundaryId: boundaryId, key: actionId)
   }
 
   /// Removes all locks with a specific actionId from the boundary.
   ///
   /// Convenience method that calls the generic key-based method.
-  func removeAll<B: LockmanBoundaryId>(id: B, actionId: LockmanActionId) {
-    removeAll(id: id, key: actionId)
+  func removeAll<B: LockmanBoundaryId>(boundaryId: B, actionId: LockmanActionId) {
+    removeAll(boundaryId: boundaryId, key: actionId)
   }
 
   /// Returns all unique actionIds in the boundary.
   ///
   /// Convenience method that calls the generic key-based method.
-  func actionIds<B: LockmanBoundaryId>(id: B) -> Set<LockmanActionId> {
-    keys(id: id)
+  func actionIds<B: LockmanBoundaryId>(boundaryId: B) -> Set<LockmanActionId> {
+    keys(boundaryId: boundaryId)
   }
 }

--- a/Sources/Lockman/Core/Strategies/Core/LockmanStrategyContainer.swift
+++ b/Sources/Lockman/Core/Strategies/Core/LockmanStrategyContainer.swift
@@ -239,7 +239,7 @@ public final class LockmanStrategyContainer: @unchecked Sendable {
   /// ```swift
   /// let strategy: AnyLockmanStrategy<LockmanSingleExecutionInfo> =
   ///   try container.resolve(id: .singleExecution)
-  /// let result = strategy.canLock(id: boundaryId, info: lockInfo)
+  /// let result = strategy.canLock(boundaryId: boundaryId, info: lockInfo)
   /// ```
   public func resolve<I: LockmanInfo>(
     id: LockmanStrategyId,
@@ -390,13 +390,13 @@ public final class LockmanStrategyContainer: @unchecked Sendable {
     }
   }
 
-  /// Invokes `cleanUp(id:)` on all registered strategies for a specific boundary.
+  /// Invokes `cleanUp(boundaryId:)` on all registered strategies for a specific boundary.
   ///
   /// This method iterates through all registered strategies and calls their
-  /// `cleanUp(id:)` method to clear state associated with the given boundary identifier.
+  /// `cleanUp(boundaryId:)` method to clear state associated with the given boundary identifier.
   /// Useful when a feature or component is being deallocated.
   ///
-  /// - Parameter id: The `LockmanBoundaryId` whose associated lock state should be cleared
+  /// - Parameter boundaryId: The `LockmanBoundaryId` whose associated lock state should be cleared
   ///
   /// ## Error Handling
   /// Similar to `cleanUp()`, errors in individual strategy cleanup are logged

--- a/Sources/Lockman/Core/Strategies/DynamicConditionStrategy/LockmanDynamicConditionStrategy.swift
+++ b/Sources/Lockman/Core/Strategies/DynamicConditionStrategy/LockmanDynamicConditionStrategy.swift
@@ -105,7 +105,7 @@ public final class LockmanDynamicConditionStrategy: LockmanStrategy, @unchecked 
     boundaryId: B,
     info: LockmanDynamicConditionInfo
   ) {
-    state.add(id: boundaryId, info: info)
+    state.add(boundaryId: boundaryId, info: info)
   }
 
   /// Releases all locks with the same actionId.
@@ -122,7 +122,7 @@ public final class LockmanDynamicConditionStrategy: LockmanStrategy, @unchecked 
     info: LockmanDynamicConditionInfo
   ) {
     // Remove all locks with the same actionId
-    state.removeAll(id: boundaryId, key: info.actionId)
+    state.removeAll(boundaryId: boundaryId, key: info.actionId)
   }
 
   /// Removes all active locks across all boundaries and action groups.
@@ -134,7 +134,7 @@ public final class LockmanDynamicConditionStrategy: LockmanStrategy, @unchecked 
   ///
   /// - Parameter boundaryId: A unique boundary identifier conforming to `LockmanBoundaryId`
   public func cleanUp<B: LockmanBoundaryId>(boundaryId: B) {
-    state.removeAll(id: boundaryId)
+    state.removeAll(boundaryId: boundaryId)
   }
 
   /// Returns current locks information for debugging purposes.

--- a/Sources/Lockman/Core/Strategies/PriorityBasedStrategy/LockmanPriorityBasedStrategy.swift
+++ b/Sources/Lockman/Core/Strategies/PriorityBasedStrategy/LockmanPriorityBasedStrategy.swift
@@ -136,7 +136,7 @@ public final class LockmanPriorityBasedStrategy: LockmanStrategy, @unchecked Sen
     }
 
     // Get all current locks for this boundary
-    let currentLocks = state.currents(id: boundaryId)
+    let currentLocks = state.currents(boundaryId: boundaryId)
 
     // Filter out non-priority actions for priority comparison
     let priorityLocks = currentLocks.filter { $0.priority != .none }
@@ -224,7 +224,7 @@ public final class LockmanPriorityBasedStrategy: LockmanStrategy, @unchecked Sen
     boundaryId: B,
     info: LockmanPriorityBasedInfo
   ) {
-    state.add(id: boundaryId, info: info)
+    state.add(boundaryId: boundaryId, info: info)
   }
 
   /// Releases a previously acquired priority-based lock.
@@ -245,7 +245,7 @@ public final class LockmanPriorityBasedStrategy: LockmanStrategy, @unchecked Sen
     boundaryId: B,
     info: LockmanPriorityBasedInfo
   ) {
-    state.remove(id: boundaryId, info: info)
+    state.remove(boundaryId: boundaryId, info: info)
   }
 
   /// Removes all priority-based locks across all boundaries and priority levels.
@@ -257,7 +257,7 @@ public final class LockmanPriorityBasedStrategy: LockmanStrategy, @unchecked Sen
   ///
   /// - Parameter boundaryId: A unique boundary identifier conforming to `LockmanBoundaryId`
   public func cleanUp<B: LockmanBoundaryId>(boundaryId: B) {
-    state.removeAll(id: boundaryId)
+    state.removeAll(boundaryId: boundaryId)
   }
 
   /// Returns current locks information for debugging purposes.

--- a/Sources/Lockman/Core/Strategies/SingleExecutionStrategy/LockmanSingleExecutionStrategy.swift
+++ b/Sources/Lockman/Core/Strategies/SingleExecutionStrategy/LockmanSingleExecutionStrategy.swift
@@ -95,7 +95,7 @@ public final class LockmanSingleExecutionStrategy: LockmanStrategy, @unchecked S
 
     case .boundary:
       // Exclusive per boundary - check if any lock exists
-      let currentLocks = state.currents(id: boundaryId)
+      let currentLocks = state.currents(boundaryId: boundaryId)
       if currentLocks.isEmpty {
         result = .success
       } else {
@@ -111,8 +111,8 @@ public final class LockmanSingleExecutionStrategy: LockmanStrategy, @unchecked S
 
     case .action:
       // Exclusive per action - check if same actionId exists
-      if state.contains(id: boundaryId, key: info.actionId) {
-        let existingInfo = state.currents(id: boundaryId, key: info.actionId).first!
+      if state.contains(boundaryId: boundaryId, key: info.actionId) {
+        let existingInfo = state.currents(boundaryId: boundaryId, key: info.actionId).first!
         result = .cancel(
           LockmanSingleExecutionError.actionAlreadyRunning(
             existingInfo: existingInfo
@@ -162,7 +162,7 @@ public final class LockmanSingleExecutionStrategy: LockmanStrategy, @unchecked S
     boundaryId: B,
     info: LockmanSingleExecutionInfo
   ) {
-    state.add(id: boundaryId, info: info)
+    state.add(boundaryId: boundaryId, info: info)
   }
 
   /// Releases a previously acquired lock for the specified boundary and action.
@@ -204,7 +204,7 @@ public final class LockmanSingleExecutionStrategy: LockmanStrategy, @unchecked S
     boundaryId: B,
     info: LockmanSingleExecutionInfo
   ) {
-    state.remove(id: boundaryId, info: info)
+    state.remove(boundaryId: boundaryId, info: info)
   }
 
   /// Removes all active locks across all boundaries and execution modes.
@@ -216,7 +216,7 @@ public final class LockmanSingleExecutionStrategy: LockmanStrategy, @unchecked S
   ///
   /// - Parameter boundaryId: A unique boundary identifier conforming to `LockmanBoundaryId`
   public func cleanUp<B: LockmanBoundaryId>(boundaryId: B) {
-    state.removeAll(id: boundaryId)
+    state.removeAll(boundaryId: boundaryId)
   }
 
   /// Returns current locks information for debugging purposes.

--- a/Tests/LockmanTests/Core/LockmanStateActionIndexTests.swift
+++ b/Tests/LockmanTests/Core/LockmanStateActionIndexTests.swift
@@ -47,7 +47,7 @@ final class LockmanStateActionIndexTests: XCTestCase {
     let state = LockmanState<TestInfo, LockmanActionId>()
     let boundary = TestBoundaryId(value: "test")
 
-    XCTAssertFalse(state.contains(id: boundary, actionId: "nonexistent"))
+    XCTAssertFalse(state.contains(boundaryId: boundary, actionId: "nonexistent"))
   }
 
   func testContainsReturnsTrueAfterAddingAction() async throws {
@@ -55,10 +55,10 @@ final class LockmanStateActionIndexTests: XCTestCase {
     let boundary = TestBoundaryId(value: "test")
     let info = TestInfo(actionId: "action1")
 
-    state.add(id: boundary, info: info)
+    state.add(boundaryId: boundary, info: info)
 
-    XCTAssertTrue(state.contains(id: boundary, actionId: "action1"))
-    XCTAssertFalse(state.contains(id: boundary, actionId: "action2"))
+    XCTAssertTrue(state.contains(boundaryId: boundary, actionId: "action1"))
+    XCTAssertFalse(state.contains(boundaryId: boundary, actionId: "action2"))
   }
 
   func testContainsReturnsFalseAfterRemovingAction() async throws {
@@ -66,11 +66,11 @@ final class LockmanStateActionIndexTests: XCTestCase {
     let boundary = TestBoundaryId(value: "test")
     let info = TestInfo(actionId: "action1")
 
-    state.add(id: boundary, info: info)
-    XCTAssertTrue(state.contains(id: boundary, actionId: "action1"))
+    state.add(boundaryId: boundary, info: info)
+    XCTAssertTrue(state.contains(boundaryId: boundary, actionId: "action1"))
 
-    state.remove(id: boundary, info: info)
-    XCTAssertFalse(state.contains(id: boundary, actionId: "action1"))
+    state.remove(boundaryId: boundary, info: info)
+    XCTAssertFalse(state.contains(boundaryId: boundary, actionId: "action1"))
   }
 
   // MARK: - currents(id:actionId:) Tests
@@ -79,7 +79,7 @@ final class LockmanStateActionIndexTests: XCTestCase {
     let state = LockmanState<TestInfo, LockmanActionId>()
     let boundary = TestBoundaryId(value: "test")
 
-    let results = state.currents(id: boundary, actionId: "nonexistent")
+    let results = state.currents(boundaryId: boundary, actionId: "nonexistent")
     XCTAssertTrue(results.isEmpty)
   }
 
@@ -91,12 +91,12 @@ final class LockmanStateActionIndexTests: XCTestCase {
     let info2 = TestInfo(actionId: "action2")
     let info3 = TestInfo(actionId: "action1")
 
-    state.add(id: boundary, info: info1)
-    state.add(id: boundary, info: info2)
-    state.add(id: boundary, info: info3)
+    state.add(boundaryId: boundary, info: info1)
+    state.add(boundaryId: boundary, info: info2)
+    state.add(boundaryId: boundary, info: info3)
 
-    let action1Results = state.currents(id: boundary, actionId: "action1")
-    let action2Results = state.currents(id: boundary, actionId: "action2")
+    let action1Results = state.currents(boundaryId: boundary, actionId: "action1")
+    let action2Results = state.currents(boundaryId: boundary, actionId: "action2")
 
     XCTAssertEqual(action1Results.count, 2)
     XCTAssertEqual(action2Results.count, 1)
@@ -114,11 +114,11 @@ final class LockmanStateActionIndexTests: XCTestCase {
     let info2 = TestInfo(actionId: "action1")
     let info3 = TestInfo(actionId: "action1")
 
-    state.add(id: boundary, info: info1)
-    state.add(id: boundary, info: info2)
-    state.add(id: boundary, info: info3)
+    state.add(boundaryId: boundary, info: info1)
+    state.add(boundaryId: boundary, info: info2)
+    state.add(boundaryId: boundary, info: info3)
 
-    let results = state.currents(id: boundary, actionId: "action1")
+    let results = state.currents(boundaryId: boundary, actionId: "action1")
 
     XCTAssertEqual(results.count, 3)
     XCTAssertEqual(results[0].uniqueId, info1.uniqueId)
@@ -132,7 +132,7 @@ final class LockmanStateActionIndexTests: XCTestCase {
     let state = LockmanState<TestInfo, LockmanActionId>()
     let boundary = TestBoundaryId(value: "test")
 
-    XCTAssertEqual(state.count(id: boundary, actionId: "nonexistent"), 0)
+    XCTAssertEqual(state.count(boundaryId: boundary, actionId: "nonexistent"), 0)
   }
 
   func testCountReturnsCorrectNumber() async throws {
@@ -143,13 +143,13 @@ final class LockmanStateActionIndexTests: XCTestCase {
     let info2 = TestInfo(actionId: "action1")
     let info3 = TestInfo(actionId: "action2")
 
-    state.add(id: boundary, info: info1)
-    state.add(id: boundary, info: info2)
-    state.add(id: boundary, info: info3)
+    state.add(boundaryId: boundary, info: info1)
+    state.add(boundaryId: boundary, info: info2)
+    state.add(boundaryId: boundary, info: info3)
 
-    XCTAssertEqual(state.count(id: boundary, actionId: "action1"), 2)
-    XCTAssertEqual(state.count(id: boundary, actionId: "action2"), 1)
-    XCTAssertEqual(state.count(id: boundary, actionId: "action3"), 0)
+    XCTAssertEqual(state.count(boundaryId: boundary, actionId: "action1"), 2)
+    XCTAssertEqual(state.count(boundaryId: boundary, actionId: "action2"), 1)
+    XCTAssertEqual(state.count(boundaryId: boundary, actionId: "action3"), 0)
   }
 
   // MARK: - ActionIds Tests
@@ -158,7 +158,7 @@ final class LockmanStateActionIndexTests: XCTestCase {
     let state = LockmanState<TestInfo, LockmanActionId>()
     let boundary = TestBoundaryId(value: "test")
 
-    let actionIds = state.actionIds(id: boundary)
+    let actionIds = state.actionIds(boundaryId: boundary)
     XCTAssertTrue(actionIds.isEmpty)
   }
 
@@ -166,12 +166,12 @@ final class LockmanStateActionIndexTests: XCTestCase {
     let state = LockmanState<TestInfo, LockmanActionId>()
     let boundary = TestBoundaryId(value: "test")
 
-    state.add(id: boundary, info: TestInfo(actionId: "action1"))
-    state.add(id: boundary, info: TestInfo(actionId: "action2"))
-    state.add(id: boundary, info: TestInfo(actionId: "action1"))  // Duplicate
-    state.add(id: boundary, info: TestInfo(actionId: "action3"))
+    state.add(boundaryId: boundary, info: TestInfo(actionId: "action1"))
+    state.add(boundaryId: boundary, info: TestInfo(actionId: "action2"))
+    state.add(boundaryId: boundary, info: TestInfo(actionId: "action1"))  // Duplicate
+    state.add(boundaryId: boundary, info: TestInfo(actionId: "action3"))
 
-    let actionIds = state.actionIds(id: boundary)
+    let actionIds = state.actionIds(boundaryId: boundary)
 
     XCTAssertEqual(actionIds.count, 3)
     XCTAssertTrue(actionIds.contains("action1"))
@@ -186,16 +186,16 @@ final class LockmanStateActionIndexTests: XCTestCase {
     let boundary1 = TestBoundaryId(value: "boundary1")
     let boundary2 = TestBoundaryId(value: "boundary2")
 
-    state.add(id: boundary1, info: TestInfo(actionId: "action1"))
-    state.add(id: boundary2, info: TestInfo(actionId: "action1"))
+    state.add(boundaryId: boundary1, info: TestInfo(actionId: "action1"))
+    state.add(boundaryId: boundary2, info: TestInfo(actionId: "action1"))
 
-    XCTAssertTrue(state.contains(id: boundary1, actionId: "action1"))
-    XCTAssertTrue(state.contains(id: boundary2, actionId: "action1"))
+    XCTAssertTrue(state.contains(boundaryId: boundary1, actionId: "action1"))
+    XCTAssertTrue(state.contains(boundaryId: boundary2, actionId: "action1"))
 
-    state.removeAll(id: boundary1)
+    state.removeAll(boundaryId: boundary1)
 
-    XCTAssertFalse(state.contains(id: boundary1, actionId: "action1"))
-    XCTAssertTrue(state.contains(id: boundary2, actionId: "action1"))
+    XCTAssertFalse(state.contains(boundaryId: boundary1, actionId: "action1"))
+    XCTAssertTrue(state.contains(boundaryId: boundary2, actionId: "action1"))
   }
 
   // MARK: - Performance Tests
@@ -206,14 +206,14 @@ final class LockmanStateActionIndexTests: XCTestCase {
 
     // Add many different actions
     for i in 0..<1000 {
-      state.add(id: boundary, info: TestInfo(actionId: "action\(i)"))
+      state.add(boundaryId: boundary, info: TestInfo(actionId: "action\(i)"))
     }
 
     let startTime = CFAbsoluteTimeGetCurrent()
 
     // Perform many lookups
     for i in 0..<1000 {
-      _ = state.contains(id: boundary, actionId: "action\(i)")
+      _ = state.contains(boundaryId: boundary, actionId: "action\(i)")
     }
 
     let endTime = CFAbsoluteTimeGetCurrent()
@@ -230,10 +230,10 @@ final class LockmanStateActionIndexTests: XCTestCase {
     let boundary = TestBoundaryId(value: "test")
 
     let info = TestInfo(actionId: "")
-    state.add(id: boundary, info: info)
+    state.add(boundaryId: boundary, info: info)
 
-    XCTAssertTrue(state.contains(id: boundary, actionId: ""))
-    XCTAssertEqual(state.count(id: boundary, actionId: ""), 1)
+    XCTAssertTrue(state.contains(boundaryId: boundary, actionId: ""))
+    XCTAssertEqual(state.count(boundaryId: boundary, actionId: ""), 1)
   }
 
   func testHandlesUnicodeActionIds() async throws {
@@ -242,10 +242,10 @@ final class LockmanStateActionIndexTests: XCTestCase {
 
     let actionId = "🚀アクション💻"
     let info = TestInfo(actionId: actionId)
-    state.add(id: boundary, info: info)
+    state.add(boundaryId: boundary, info: info)
 
-    XCTAssertTrue(state.contains(id: boundary, actionId: actionId))
-    XCTAssertEqual(state.currents(id: boundary, actionId: actionId).count, 1)
+    XCTAssertTrue(state.contains(boundaryId: boundary, actionId: actionId))
+    XCTAssertEqual(state.currents(boundaryId: boundary, actionId: actionId).count, 1)
   }
 
   // MARK: - Cleanup Tests
@@ -254,14 +254,14 @@ final class LockmanStateActionIndexTests: XCTestCase {
     let state = LockmanState<TestInfo, LockmanActionId>()
     let boundary = TestBoundaryId(value: "test")
 
-    state.add(id: boundary, info: TestInfo(actionId: "action1"))
-    state.add(id: boundary, info: TestInfo(actionId: "action2"))
+    state.add(boundaryId: boundary, info: TestInfo(actionId: "action1"))
+    state.add(boundaryId: boundary, info: TestInfo(actionId: "action2"))
 
     state.removeAll()
 
-    XCTAssertFalse(state.contains(id: boundary, actionId: "action1"))
-    XCTAssertFalse(state.contains(id: boundary, actionId: "action2"))
-    XCTAssertTrue(state.actionIds(id: boundary).isEmpty)
+    XCTAssertFalse(state.contains(boundaryId: boundary, actionId: "action1"))
+    XCTAssertFalse(state.contains(boundaryId: boundary, actionId: "action2"))
+    XCTAssertTrue(state.actionIds(boundaryId: boundary).isEmpty)
   }
 
   func testRemoveAllWithBoundaryClearsBoundaryActionIndex() async throws {
@@ -269,13 +269,13 @@ final class LockmanStateActionIndexTests: XCTestCase {
     let boundary1 = TestBoundaryId(value: "boundary1")
     let boundary2 = TestBoundaryId(value: "boundary2")
 
-    state.add(id: boundary1, info: TestInfo(actionId: "action1"))
-    state.add(id: boundary2, info: TestInfo(actionId: "action1"))
+    state.add(boundaryId: boundary1, info: TestInfo(actionId: "action1"))
+    state.add(boundaryId: boundary2, info: TestInfo(actionId: "action1"))
 
-    state.removeAll(id: boundary1)
+    state.removeAll(boundaryId: boundary1)
 
-    XCTAssertFalse(state.contains(id: boundary1, actionId: "action1"))
-    XCTAssertTrue(state.contains(id: boundary2, actionId: "action1"))
+    XCTAssertFalse(state.contains(boundaryId: boundary1, actionId: "action1"))
+    XCTAssertTrue(state.contains(boundaryId: boundary2, actionId: "action1"))
   }
 
   // MARK: - removeAll(id:actionId:) Tests
@@ -289,22 +289,22 @@ final class LockmanStateActionIndexTests: XCTestCase {
     let info2 = TestInfo(actionId: "action1")
     let info3 = TestInfo(actionId: "action2")
 
-    state.add(id: boundary, info: info1)
-    state.add(id: boundary, info: info2)
-    state.add(id: boundary, info: info3)
+    state.add(boundaryId: boundary, info: info1)
+    state.add(boundaryId: boundary, info: info2)
+    state.add(boundaryId: boundary, info: info3)
 
     // Verify initial state
-    XCTAssertEqual(state.count(id: boundary, actionId: "action1"), 2)
-    XCTAssertEqual(state.count(id: boundary, actionId: "action2"), 1)
+    XCTAssertEqual(state.count(boundaryId: boundary, actionId: "action1"), 2)
+    XCTAssertEqual(state.count(boundaryId: boundary, actionId: "action2"), 1)
 
     // Remove all locks with actionId "action1"
-    state.removeAll(id: boundary, actionId: "action1")
+    state.removeAll(boundaryId: boundary, actionId: "action1")
 
     // Verify removal
-    XCTAssertEqual(state.count(id: boundary, actionId: "action1"), 0)
-    XCTAssertFalse(state.contains(id: boundary, actionId: "action1"))
-    XCTAssertEqual(state.count(id: boundary, actionId: "action2"), 1)
-    XCTAssertTrue(state.contains(id: boundary, actionId: "action2"))
+    XCTAssertEqual(state.count(boundaryId: boundary, actionId: "action1"), 0)
+    XCTAssertFalse(state.contains(boundaryId: boundary, actionId: "action1"))
+    XCTAssertEqual(state.count(boundaryId: boundary, actionId: "action2"), 1)
+    XCTAssertTrue(state.contains(boundaryId: boundary, actionId: "action2"))
   }
 
   func testRemoveAllByActionIdEmptyCase() async throws {
@@ -312,10 +312,10 @@ final class LockmanStateActionIndexTests: XCTestCase {
     let boundary = TestBoundaryId(value: "test")
 
     // Try to remove non-existent actionId
-    state.removeAll(id: boundary, actionId: "nonexistent")
+    state.removeAll(boundaryId: boundary, actionId: "nonexistent")
 
     // Should not crash and state should remain empty
-    XCTAssertEqual(state.currents(id: boundary).count, 0)
+    XCTAssertEqual(state.currents(boundaryId: boundary).count, 0)
   }
 
   func testRemoveAllByActionIdPreservesOtherActions() async throws {
@@ -323,18 +323,18 @@ final class LockmanStateActionIndexTests: XCTestCase {
     let boundary = TestBoundaryId(value: "test")
 
     // Add locks with different actionIds
-    state.add(id: boundary, info: TestInfo(actionId: "action1"))
-    state.add(id: boundary, info: TestInfo(actionId: "action2"))
-    state.add(id: boundary, info: TestInfo(actionId: "action3"))
+    state.add(boundaryId: boundary, info: TestInfo(actionId: "action1"))
+    state.add(boundaryId: boundary, info: TestInfo(actionId: "action2"))
+    state.add(boundaryId: boundary, info: TestInfo(actionId: "action3"))
 
     // Remove only action2
-    state.removeAll(id: boundary, actionId: "action2")
+    state.removeAll(boundaryId: boundary, actionId: "action2")
 
     // Verify only action2 was removed
-    XCTAssertTrue(state.contains(id: boundary, actionId: "action1"))
-    XCTAssertFalse(state.contains(id: boundary, actionId: "action2"))
-    XCTAssertTrue(state.contains(id: boundary, actionId: "action3"))
-    XCTAssertEqual(state.currents(id: boundary).count, 2)
+    XCTAssertTrue(state.contains(boundaryId: boundary, actionId: "action1"))
+    XCTAssertFalse(state.contains(boundaryId: boundary, actionId: "action2"))
+    XCTAssertTrue(state.contains(boundaryId: boundary, actionId: "action3"))
+    XCTAssertEqual(state.currents(boundaryId: boundary).count, 2)
   }
 
   func testRemoveAllByActionIdMultipleBoundaries() async throws {
@@ -343,15 +343,15 @@ final class LockmanStateActionIndexTests: XCTestCase {
     let boundary2 = TestBoundaryId(value: "boundary2")
 
     // Add same actionId to different boundaries
-    state.add(id: boundary1, info: TestInfo(actionId: "action1"))
-    state.add(id: boundary2, info: TestInfo(actionId: "action1"))
+    state.add(boundaryId: boundary1, info: TestInfo(actionId: "action1"))
+    state.add(boundaryId: boundary2, info: TestInfo(actionId: "action1"))
 
     // Remove from boundary1 only
-    state.removeAll(id: boundary1, actionId: "action1")
+    state.removeAll(boundaryId: boundary1, actionId: "action1")
 
     // Verify isolation between boundaries
-    XCTAssertFalse(state.contains(id: boundary1, actionId: "action1"))
-    XCTAssertTrue(state.contains(id: boundary2, actionId: "action1"))
+    XCTAssertFalse(state.contains(boundaryId: boundary1, actionId: "action1"))
+    XCTAssertTrue(state.contains(boundaryId: boundary2, actionId: "action1"))
   }
 
   func testRemoveAllByActionIdConcurrent() async throws {
@@ -364,7 +364,7 @@ final class LockmanStateActionIndexTests: XCTestCase {
       for i in 0..<iterations {
         group.addTask {
           let actionId = "action\(i % 10)"  // 10 different action IDs
-          state.add(id: boundary, info: TestInfo(actionId: actionId))
+          state.add(boundaryId: boundary, info: TestInfo(actionId: actionId))
         }
       }
     }
@@ -373,19 +373,19 @@ final class LockmanStateActionIndexTests: XCTestCase {
     await withTaskGroup(of: Void.self) { group in
       // Remove action5
       group.addTask {
-        state.removeAll(id: boundary, actionId: "action5")
+        state.removeAll(boundaryId: boundary, actionId: "action5")
       }
 
       // Add more action5 locks
       for _ in 0..<10 {
         group.addTask {
-          state.add(id: boundary, info: TestInfo(actionId: "action5"))
+          state.add(boundaryId: boundary, info: TestInfo(actionId: "action5"))
         }
       }
     }
 
     // Verify state is consistent (action5 count depends on timing)
-    let action5Count = state.count(id: boundary, actionId: "action5")
+    let action5Count = state.count(boundaryId: boundary, actionId: "action5")
     XCTAssertTrue(action5Count >= 0 && action5Count <= 10)
   }
 }

--- a/Tests/LockmanTests/Core/Strategies/Core/LockmanStateGenericTests.swift
+++ b/Tests/LockmanTests/Core/Strategies/Core/LockmanStateGenericTests.swift
@@ -59,28 +59,28 @@ final class LockmanStateGenericTests: XCTestCase {
     let info2 = TestInfo(actionId: "action2", category: "network")
     let info3 = TestInfo(actionId: "action3", category: "storage")
 
-    state.add(id: boundaryId, info: info1)
-    state.add(id: boundaryId, info: info2)
-    state.add(id: boundaryId, info: info3)
+    state.add(boundaryId: boundaryId, info: info1)
+    state.add(boundaryId: boundaryId, info: info2)
+    state.add(boundaryId: boundaryId, info: info3)
 
     // Test contains with custom key
-    XCTAssertTrue(state.contains(id: boundaryId, key: "network"))
-    XCTAssertTrue(state.contains(id: boundaryId, key: "storage"))
-    XCTAssertFalse(state.contains(id: boundaryId, key: "compute"))
+    XCTAssertTrue(state.contains(boundaryId: boundaryId, key: "network"))
+    XCTAssertTrue(state.contains(boundaryId: boundaryId, key: "storage"))
+    XCTAssertFalse(state.contains(boundaryId: boundaryId, key: "compute"))
 
     // Test count by custom key
-    XCTAssertEqual(state.count(id: boundaryId, key: "network"), 2)
-    XCTAssertEqual(state.count(id: boundaryId, key: "storage"), 1)
-    XCTAssertEqual(state.count(id: boundaryId, key: "compute"), 0)
+    XCTAssertEqual(state.count(boundaryId: boundaryId, key: "network"), 2)
+    XCTAssertEqual(state.count(boundaryId: boundaryId, key: "storage"), 1)
+    XCTAssertEqual(state.count(boundaryId: boundaryId, key: "compute"), 0)
 
     // Test currents by custom key
-    let networkInfos = state.currents(id: boundaryId, key: "network")
+    let networkInfos = state.currents(boundaryId: boundaryId, key: "network")
     XCTAssertEqual(networkInfos.count, 2)
     XCTAssertTrue(networkInfos.contains { $0.actionId == "action1" })
     XCTAssertTrue(networkInfos.contains { $0.actionId == "action2" })
 
     // Test keys retrieval
-    let keys = state.keys(id: boundaryId)
+    let keys = state.keys(boundaryId: boundaryId)
     XCTAssertEqual(keys, Set(["network", "storage"]))
   }
 
@@ -96,29 +96,29 @@ final class LockmanStateGenericTests: XCTestCase {
     let info3 = ComplexInfo(actionId: "a3", category: "network", priority: 2)
     let info4 = ComplexInfo(actionId: "a4", category: "storage", priority: 1)
 
-    state.add(id: boundaryId, info: info1)
-    state.add(id: boundaryId, info: info2)
-    state.add(id: boundaryId, info: info3)
-    state.add(id: boundaryId, info: info4)
+    state.add(boundaryId: boundaryId, info: info1)
+    state.add(boundaryId: boundaryId, info: info2)
+    state.add(boundaryId: boundaryId, info: info3)
+    state.add(boundaryId: boundaryId, info: info4)
 
     let key1 = CompositeKey(category: "network", priority: 1)
     let key2 = CompositeKey(category: "network", priority: 2)
     let key3 = CompositeKey(category: "storage", priority: 1)
 
     // Test contains with composite key
-    XCTAssertTrue(state.contains(id: boundaryId, key: key1))
-    XCTAssertTrue(state.contains(id: boundaryId, key: key2))
-    XCTAssertTrue(state.contains(id: boundaryId, key: key3))
+    XCTAssertTrue(state.contains(boundaryId: boundaryId, key: key1))
+    XCTAssertTrue(state.contains(boundaryId: boundaryId, key: key2))
+    XCTAssertTrue(state.contains(boundaryId: boundaryId, key: key3))
     XCTAssertFalse(
-      state.contains(id: boundaryId, key: CompositeKey(category: "compute", priority: 1)))
+      state.contains(boundaryId: boundaryId, key: CompositeKey(category: "compute", priority: 1)))
 
     // Test count with composite key
-    XCTAssertEqual(state.count(id: boundaryId, key: key1), 2)
-    XCTAssertEqual(state.count(id: boundaryId, key: key2), 1)
-    XCTAssertEqual(state.count(id: boundaryId, key: key3), 1)
+    XCTAssertEqual(state.count(boundaryId: boundaryId, key: key1), 2)
+    XCTAssertEqual(state.count(boundaryId: boundaryId, key: key2), 1)
+    XCTAssertEqual(state.count(boundaryId: boundaryId, key: key3), 1)
 
     // Test currents with composite key
-    let networkP1Infos = state.currents(id: boundaryId, key: key1)
+    let networkP1Infos = state.currents(boundaryId: boundaryId, key: key1)
     XCTAssertEqual(networkP1Infos.count, 2)
     XCTAssertTrue(networkP1Infos.allSatisfy { $0.category == "network" && $0.priority == 1 })
   }
@@ -130,25 +130,25 @@ final class LockmanStateGenericTests: XCTestCase {
     let boundaryId = TestBoundaryId("test")
 
     // Add multiple infos with different categories
-    state.add(id: boundaryId, info: TestInfo(actionId: "a1", category: "network"))
-    state.add(id: boundaryId, info: TestInfo(actionId: "a2", category: "network"))
-    state.add(id: boundaryId, info: TestInfo(actionId: "a3", category: "storage"))
-    state.add(id: boundaryId, info: TestInfo(actionId: "a4", category: "compute"))
+    state.add(boundaryId: boundaryId, info: TestInfo(actionId: "a1", category: "network"))
+    state.add(boundaryId: boundaryId, info: TestInfo(actionId: "a2", category: "network"))
+    state.add(boundaryId: boundaryId, info: TestInfo(actionId: "a3", category: "storage"))
+    state.add(boundaryId: boundaryId, info: TestInfo(actionId: "a4", category: "compute"))
 
-    XCTAssertEqual(state.currents(id: boundaryId).count, 4)
+    XCTAssertEqual(state.currents(boundaryId: boundaryId).count, 4)
 
     // Remove all with "network" category
-    state.removeAll(id: boundaryId, key: "network")
+    state.removeAll(boundaryId: boundaryId, key: "network")
 
-    let remaining = state.currents(id: boundaryId)
+    let remaining = state.currents(boundaryId: boundaryId)
     XCTAssertEqual(remaining.count, 2)
     XCTAssertFalse(remaining.contains { $0.category == "network" })
     XCTAssertTrue(remaining.contains { $0.category == "storage" })
     XCTAssertTrue(remaining.contains { $0.category == "compute" })
 
     // Try removing non-existent key
-    state.removeAll(id: boundaryId, key: "nonexistent")
-    XCTAssertEqual(state.currents(id: boundaryId).count, 2)  // Should not change
+    state.removeAll(boundaryId: boundaryId, key: "nonexistent")
+    XCTAssertEqual(state.currents(boundaryId: boundaryId).count, 2)  // Should not change
   }
 
   func testRemoveAllWithEmptyBoundary() {
@@ -156,10 +156,10 @@ final class LockmanStateGenericTests: XCTestCase {
     let boundaryId = TestBoundaryId("empty")
 
     // Try removing from empty boundary
-    state.removeAll(id: boundaryId, key: "network")
+    state.removeAll(boundaryId: boundaryId, key: "network")
 
     // Should not crash and should remain empty
-    XCTAssertTrue(state.currents(id: boundaryId).isEmpty)
+    XCTAssertTrue(state.currents(boundaryId: boundaryId).isEmpty)
   }
 
   func testRemoveAllLastKeyInBoundary() {
@@ -167,15 +167,15 @@ final class LockmanStateGenericTests: XCTestCase {
     let boundaryId = TestBoundaryId("test")
 
     // Add infos with only one category
-    state.add(id: boundaryId, info: TestInfo(actionId: "a1", category: "network"))
-    state.add(id: boundaryId, info: TestInfo(actionId: "a2", category: "network"))
+    state.add(boundaryId: boundaryId, info: TestInfo(actionId: "a1", category: "network"))
+    state.add(boundaryId: boundaryId, info: TestInfo(actionId: "a2", category: "network"))
 
     // Remove all with that category
-    state.removeAll(id: boundaryId, key: "network")
+    state.removeAll(boundaryId: boundaryId, key: "network")
 
     // Boundary should be completely empty
-    XCTAssertTrue(state.currents(id: boundaryId).isEmpty)
-    XCTAssertTrue(state.keys(id: boundaryId).isEmpty)
+    XCTAssertTrue(state.currents(boundaryId: boundaryId).isEmpty)
+    XCTAssertTrue(state.keys(boundaryId: boundaryId).isEmpty)
   }
 
   // MARK: - Bulk Query Operations Tests
@@ -191,9 +191,9 @@ final class LockmanStateGenericTests: XCTestCase {
     XCTAssertTrue(state.allBoundaryIds().isEmpty)
 
     // Add to different boundaries
-    state.add(id: boundary1, info: TestInfo(actionId: "a1", category: "cat1"))
-    state.add(id: boundary2, info: TestInfo(actionId: "a2", category: "cat2"))
-    state.add(id: boundary3, info: TestInfo(actionId: "a3", category: "cat3"))
+    state.add(boundaryId: boundary1, info: TestInfo(actionId: "a1", category: "cat1"))
+    state.add(boundaryId: boundary2, info: TestInfo(actionId: "a2", category: "cat2"))
+    state.add(boundaryId: boundary3, info: TestInfo(actionId: "a3", category: "cat3"))
 
     let allBoundaryIds = state.allBoundaryIds()
     XCTAssertEqual(allBoundaryIds.count, 3)
@@ -202,7 +202,7 @@ final class LockmanStateGenericTests: XCTestCase {
     XCTAssertTrue(allBoundaryIds.contains(AnyLockmanBoundaryId(boundary3)))
 
     // Remove one boundary
-    state.removeAll(id: boundary2)
+    state.removeAll(boundaryId: boundary2)
 
     let remainingBoundaryIds = state.allBoundaryIds()
     XCTAssertEqual(remainingBoundaryIds.count, 2)
@@ -219,20 +219,20 @@ final class LockmanStateGenericTests: XCTestCase {
     XCTAssertEqual(state.totalLockCount(), 0)
 
     // Add locks to different boundaries
-    state.add(id: boundary1, info: TestInfo(actionId: "a1", category: "cat1"))
-    state.add(id: boundary1, info: TestInfo(actionId: "a2", category: "cat2"))
-    state.add(id: boundary2, info: TestInfo(actionId: "a3", category: "cat1"))
-    state.add(id: boundary2, info: TestInfo(actionId: "a4", category: "cat2"))
-    state.add(id: boundary2, info: TestInfo(actionId: "a5", category: "cat3"))
+    state.add(boundaryId: boundary1, info: TestInfo(actionId: "a1", category: "cat1"))
+    state.add(boundaryId: boundary1, info: TestInfo(actionId: "a2", category: "cat2"))
+    state.add(boundaryId: boundary2, info: TestInfo(actionId: "a3", category: "cat1"))
+    state.add(boundaryId: boundary2, info: TestInfo(actionId: "a4", category: "cat2"))
+    state.add(boundaryId: boundary2, info: TestInfo(actionId: "a5", category: "cat3"))
 
     XCTAssertEqual(state.totalLockCount(), 5)
 
     // Remove some locks
-    state.removeAll(id: boundary1, key: "cat1")
+    state.removeAll(boundaryId: boundary1, key: "cat1")
     XCTAssertEqual(state.totalLockCount(), 4)
 
     // Remove entire boundary
-    state.removeAll(id: boundary2)
+    state.removeAll(boundaryId: boundary2)
     XCTAssertEqual(state.totalLockCount(), 1)
 
     // Remove all
@@ -254,9 +254,9 @@ final class LockmanStateGenericTests: XCTestCase {
     let info2 = TestInfo(actionId: "a2", category: "cat2")
     let info3 = TestInfo(actionId: "a3", category: "cat1")
 
-    state.add(id: boundary1, info: info1)
-    state.add(id: boundary1, info: info2)
-    state.add(id: boundary2, info: info3)
+    state.add(boundaryId: boundary1, info: info1)
+    state.add(boundaryId: boundary1, info: info2)
+    state.add(boundaryId: boundary2, info: info3)
 
     let allLocks = state.getAllLocks()
     XCTAssertEqual(allLocks.count, 2)
@@ -286,29 +286,29 @@ final class LockmanStateGenericTests: XCTestCase {
     ]
 
     for info in infos {
-      state.add(id: boundaryId, info: info)
+      state.add(boundaryId: boundaryId, info: info)
     }
 
     // Verify initial state
-    XCTAssertEqual(state.count(id: boundaryId, key: "network"), 2)
-    XCTAssertEqual(state.count(id: boundaryId, key: "storage"), 2)
-    XCTAssertEqual(state.count(id: boundaryId, key: "compute"), 1)
+    XCTAssertEqual(state.count(boundaryId: boundaryId, key: "network"), 2)
+    XCTAssertEqual(state.count(boundaryId: boundaryId, key: "storage"), 2)
+    XCTAssertEqual(state.count(boundaryId: boundaryId, key: "compute"), 1)
 
     // Remove individual items
-    state.remove(id: boundaryId, info: infos[0])  // Remove one network
-    XCTAssertEqual(state.count(id: boundaryId, key: "network"), 1)
+    state.remove(boundaryId: boundaryId, info: infos[0])  // Remove one network
+    XCTAssertEqual(state.count(boundaryId: boundaryId, key: "network"), 1)
 
     // Remove by key
-    state.removeAll(id: boundaryId, key: "storage")
-    XCTAssertEqual(state.count(id: boundaryId, key: "storage"), 0)
-    XCTAssertFalse(state.contains(id: boundaryId, key: "storage"))
+    state.removeAll(boundaryId: boundaryId, key: "storage")
+    XCTAssertEqual(state.count(boundaryId: boundaryId, key: "storage"), 0)
+    XCTAssertFalse(state.contains(boundaryId: boundaryId, key: "storage"))
 
     // Verify keys are updated
-    let keys = state.keys(id: boundaryId)
+    let keys = state.keys(boundaryId: boundaryId)
     XCTAssertEqual(keys, Set(["network", "compute"]))
 
     // Verify total count
-    XCTAssertEqual(state.currents(id: boundaryId).count, 2)
+    XCTAssertEqual(state.currents(boundaryId: boundaryId).count, 2)
   }
 
   func testIndexCleanupAfterPartialRemovals() {
@@ -319,18 +319,18 @@ final class LockmanStateGenericTests: XCTestCase {
     let info1 = TestInfo(actionId: "a1", category: "network")
     let info2 = TestInfo(actionId: "a2", category: "network")
 
-    state.add(id: boundaryId, info: info1)
-    state.add(id: boundaryId, info: info2)
+    state.add(boundaryId: boundaryId, info: info1)
+    state.add(boundaryId: boundaryId, info: info2)
 
     // Remove one by one
-    state.remove(id: boundaryId, info: info1)
-    XCTAssertTrue(state.contains(id: boundaryId, key: "network"))
-    XCTAssertEqual(state.count(id: boundaryId, key: "network"), 1)
+    state.remove(boundaryId: boundaryId, info: info1)
+    XCTAssertTrue(state.contains(boundaryId: boundaryId, key: "network"))
+    XCTAssertEqual(state.count(boundaryId: boundaryId, key: "network"), 1)
 
-    state.remove(id: boundaryId, info: info2)
-    XCTAssertFalse(state.contains(id: boundaryId, key: "network"))
-    XCTAssertEqual(state.count(id: boundaryId, key: "network"), 0)
-    XCTAssertTrue(state.keys(id: boundaryId).isEmpty)
+    state.remove(boundaryId: boundaryId, info: info2)
+    XCTAssertFalse(state.contains(boundaryId: boundaryId, key: "network"))
+    XCTAssertEqual(state.count(boundaryId: boundaryId, key: "network"), 0)
+    XCTAssertTrue(state.keys(boundaryId: boundaryId).isEmpty)
   }
 
   // MARK: - Memory and Performance Tests
@@ -342,16 +342,16 @@ final class LockmanStateGenericTests: XCTestCase {
     // Add many infos with unique categories
     for i in 0..<1000 {
       let info = TestInfo(actionId: "action\(i)", category: "category\(i)")
-      state.add(id: boundaryId, info: info)
+      state.add(boundaryId: boundaryId, info: info)
     }
 
     // Verify all keys are tracked
-    XCTAssertEqual(state.keys(id: boundaryId).count, 1000)
-    XCTAssertEqual(state.currents(id: boundaryId).count, 1000)
+    XCTAssertEqual(state.keys(boundaryId: boundaryId).count, 1000)
+    XCTAssertEqual(state.currents(boundaryId: boundaryId).count, 1000)
 
     // Each key should have exactly one info
     for i in 0..<1000 {
-      XCTAssertEqual(state.count(id: boundaryId, key: "category\(i)"), 1)
+      XCTAssertEqual(state.count(boundaryId: boundaryId, key: "category\(i)"), 1)
     }
   }
 
@@ -363,7 +363,7 @@ final class LockmanStateGenericTests: XCTestCase {
     for i in 0..<1000 {
       let category = "category\(i % 10)"  // Only 10 unique categories
       let info = TestInfo(actionId: "action\(i)", category: category)
-      state.add(id: boundaryId, info: info)
+      state.add(boundaryId: boundaryId, info: info)
     }
 
     // Measure key-based operations
@@ -372,8 +372,8 @@ final class LockmanStateGenericTests: XCTestCase {
     // These should be O(1) operations
     for i in 0..<100 {
       let category = "category\(i % 10)"
-      _ = state.contains(id: boundaryId, key: category)
-      _ = state.count(id: boundaryId, key: category)
+      _ = state.contains(boundaryId: boundaryId, key: category)
+      _ = state.count(boundaryId: boundaryId, key: category)
     }
 
     let duration = Date().timeIntervalSince(startTime)
@@ -381,7 +381,7 @@ final class LockmanStateGenericTests: XCTestCase {
 
     // Verify counts
     for i in 0..<10 {
-      XCTAssertEqual(state.count(id: boundaryId, key: "category\(i)"), 100)
+      XCTAssertEqual(state.count(boundaryId: boundaryId, key: "category\(i)"), 100)
     }
   }
 
@@ -401,12 +401,12 @@ final class LockmanStateGenericTests: XCTestCase {
 
     // Add should call extractor once
     let initialCount = extractorCallCount.withCriticalRegion { $0 }
-    state.add(id: boundaryId, info: info)
+    state.add(boundaryId: boundaryId, info: info)
     XCTAssertEqual(extractorCallCount.withCriticalRegion { $0 }, initialCount + 1)
 
     // Remove should call extractor once
     let countBeforeRemove = extractorCallCount.withCriticalRegion { $0 }
-    state.remove(id: boundaryId, info: info)
+    state.remove(boundaryId: boundaryId, info: info)
     XCTAssertEqual(extractorCallCount.withCriticalRegion { $0 }, countBeforeRemove + 1)
   }
 
@@ -424,15 +424,15 @@ final class LockmanStateGenericTests: XCTestCase {
     ]
 
     for info in infos {
-      state.add(id: boundaryId, info: info)
+      state.add(boundaryId: boundaryId, info: info)
     }
 
     // Get all currents - should preserve order
-    let allCurrents = state.currents(id: boundaryId)
+    let allCurrents = state.currents(boundaryId: boundaryId)
     XCTAssertEqual(allCurrents.map(\.actionId), ["first", "second", "third", "fourth", "fifth"])
 
     // Get currents by key - should preserve relative order
-    let networkCurrents = state.currents(id: boundaryId, key: "network")
+    let networkCurrents = state.currents(boundaryId: boundaryId, key: "network")
     XCTAssertEqual(networkCurrents.map(\.actionId), ["first", "third", "fifth"])
   }
 
@@ -446,7 +446,7 @@ final class LockmanStateGenericTests: XCTestCase {
         group.addTask {
           let category = "category\(i % 5)"
           let info = TestInfo(actionId: "action\(i)", category: category)
-          state.add(id: boundaryId, info: info)
+          state.add(boundaryId: boundaryId, info: info)
         }
       }
 
@@ -454,16 +454,16 @@ final class LockmanStateGenericTests: XCTestCase {
       for i in 0..<50 {
         group.addTask {
           let category = "category\(i % 5)"
-          _ = state.contains(id: boundaryId, key: category)
-          _ = state.count(id: boundaryId, key: category)
-          _ = state.currents(id: boundaryId, key: category)
+          _ = state.contains(boundaryId: boundaryId, key: category)
+          _ = state.count(boundaryId: boundaryId, key: category)
+          _ = state.currents(boundaryId: boundaryId, key: category)
         }
       }
     }
 
     // Verify final state
-    XCTAssertEqual(state.currents(id: boundaryId).count, 100)
-    XCTAssertEqual(state.keys(id: boundaryId).count, 5)
+    XCTAssertEqual(state.currents(boundaryId: boundaryId).count, 100)
+    XCTAssertEqual(state.keys(boundaryId: boundaryId).count, 5)
   }
 
   func testEmptyKeyHandling() {
@@ -472,15 +472,15 @@ final class LockmanStateGenericTests: XCTestCase {
 
     // Add info with empty category
     let info = TestInfo(actionId: "a1", category: "")
-    state.add(id: boundaryId, info: info)
+    state.add(boundaryId: boundaryId, info: info)
 
     // Should work with empty key
-    XCTAssertTrue(state.contains(id: boundaryId, key: ""))
-    XCTAssertEqual(state.count(id: boundaryId, key: ""), 1)
-    XCTAssertEqual(state.currents(id: boundaryId, key: "").count, 1)
+    XCTAssertTrue(state.contains(boundaryId: boundaryId, key: ""))
+    XCTAssertEqual(state.count(boundaryId: boundaryId, key: ""), 1)
+    XCTAssertEqual(state.currents(boundaryId: boundaryId, key: "").count, 1)
 
     // Remove with empty key
-    state.removeAll(id: boundaryId, key: "")
-    XCTAssertTrue(state.currents(id: boundaryId).isEmpty)
+    state.removeAll(boundaryId: boundaryId, key: "")
+    XCTAssertTrue(state.currents(boundaryId: boundaryId).isEmpty)
   }
 }

--- a/Tests/LockmanTests/Core/Strategies/Core/LockmanStateTests.swift
+++ b/Tests/LockmanTests/Core/Strategies/Core/LockmanStateTests.swift
@@ -66,9 +66,9 @@ final class LockmanStateTests: XCTestCase {
     let boundaryId = TestBoundaryId(value: "test")
     let info = TestLockmanInfo(id: "1")
 
-    state.add(id: boundaryId, info: info)
+    state.add(boundaryId: boundaryId, info: info)
 
-    let currents = state.currents(id: boundaryId)
+    let currents = state.currents(boundaryId: boundaryId)
     XCTAssertEqual(currents.count, 1)
     XCTAssertEqual(currents.first?.actionId, "1")
   }
@@ -80,11 +80,11 @@ final class LockmanStateTests: XCTestCase {
     let info2 = TestLockmanInfo(id: "2")
     let info3 = TestLockmanInfo(id: "3")
 
-    state.add(id: boundaryId, info: info1)
-    state.add(id: boundaryId, info: info2)
-    state.add(id: boundaryId, info: info3)
+    state.add(boundaryId: boundaryId, info: info1)
+    state.add(boundaryId: boundaryId, info: info2)
+    state.add(boundaryId: boundaryId, info: info3)
 
-    let currents = state.currents(id: boundaryId)
+    let currents = state.currents(boundaryId: boundaryId)
     XCTAssertEqual(currents.count, 3)
     XCTAssertEqual(currents.map(\.actionId), ["1", "2", "3"])
   }
@@ -96,11 +96,11 @@ final class LockmanStateTests: XCTestCase {
     let info1 = TestLockmanInfo(id: "1")
     let info2 = TestLockmanInfo(id: "2")
 
-    state.add(id: boundary1, info: info1)
-    state.add(id: boundary2, info: info2)
+    state.add(boundaryId: boundary1, info: info1)
+    state.add(boundaryId: boundary2, info: info2)
 
-    let currents1 = state.currents(id: boundary1)
-    let currents2 = state.currents(id: boundary2)
+    let currents1 = state.currents(boundaryId: boundary1)
+    let currents2 = state.currents(boundaryId: boundary2)
 
     XCTAssertEqual(currents1.count, 1)
     XCTAssertEqual(currents1.first?.actionId, "1")
@@ -113,10 +113,10 @@ final class LockmanStateTests: XCTestCase {
     let boundaryId = TestBoundaryId(value: "test")
     let info = TestLockmanInfo(id: "1")
 
-    state.add(id: boundaryId, info: info)
-    state.removeAll(id: boundaryId)
+    state.add(boundaryId: boundaryId, info: info)
+    state.removeAll(boundaryId: boundaryId)
 
-    let currents = state.currents(id: boundaryId)
+    let currents = state.currents(boundaryId: boundaryId)
     XCTAssertTrue(currents.isEmpty)
   }
 
@@ -127,13 +127,13 @@ final class LockmanStateTests: XCTestCase {
     let info2 = TestLockmanInfo(id: "2")
     let info3 = TestLockmanInfo(id: "3")
 
-    state.add(id: boundaryId, info: info1)
-    state.add(id: boundaryId, info: info2)
-    state.add(id: boundaryId, info: info3)
+    state.add(boundaryId: boundaryId, info: info1)
+    state.add(boundaryId: boundaryId, info: info2)
+    state.add(boundaryId: boundaryId, info: info3)
 
-    state.remove(id: boundaryId, info: info3)
+    state.remove(boundaryId: boundaryId, info: info3)
 
-    let currents = state.currents(id: boundaryId)
+    let currents = state.currents(boundaryId: boundaryId)
     XCTAssertEqual(currents.count, 2)
     XCTAssertEqual(currents.map(\.actionId), ["1", "2"])
   }
@@ -143,9 +143,9 @@ final class LockmanStateTests: XCTestCase {
     let boundaryId = TestBoundaryId(value: "non-existent")
 
     // Should not crash
-    state.removeAll(id: boundaryId)
+    state.removeAll(boundaryId: boundaryId)
 
-    let currents = state.currents(id: boundaryId)
+    let currents = state.currents(boundaryId: boundaryId)
     XCTAssertTrue(currents.isEmpty)
   }
 
@@ -153,7 +153,7 @@ final class LockmanStateTests: XCTestCase {
     let state = LockmanState<TestLockmanInfo, LockmanActionId>()
     let boundaryId = TestBoundaryId(value: "test")
 
-    let currents = state.currents(id: boundaryId)
+    let currents = state.currents(boundaryId: boundaryId)
     XCTAssertTrue(currents.isEmpty)
   }
 
@@ -164,13 +164,13 @@ final class LockmanStateTests: XCTestCase {
     let info1 = TestLockmanInfo(id: "1")
     let info2 = TestLockmanInfo(id: "2")
 
-    state.add(id: boundary1, info: info1)
-    state.add(id: boundary2, info: info2)
+    state.add(boundaryId: boundary1, info: info1)
+    state.add(boundaryId: boundary2, info: info2)
 
     state.removeAll()
 
-    let currents1 = state.currents(id: boundary1)
-    let currents2 = state.currents(id: boundary2)
+    let currents1 = state.currents(boundaryId: boundary1)
+    let currents2 = state.currents(boundaryId: boundary2)
 
     XCTAssertTrue(currents1.isEmpty)
     XCTAssertTrue(currents2.isEmpty)
@@ -183,13 +183,13 @@ final class LockmanStateTests: XCTestCase {
     let info1 = TestLockmanInfo(id: "1")
     let info2 = TestLockmanInfo(id: "2")
 
-    state.add(id: boundary1, info: info1)
-    state.add(id: boundary2, info: info2)
+    state.add(boundaryId: boundary1, info: info1)
+    state.add(boundaryId: boundary2, info: info2)
 
-    state.removeAll(id: boundary1)
+    state.removeAll(boundaryId: boundary1)
 
-    let currents1 = state.currents(id: boundary1)
-    let currents2 = state.currents(id: boundary2)
+    let currents1 = state.currents(boundaryId: boundary1)
+    let currents2 = state.currents(boundaryId: boundary2)
 
     XCTAssertTrue(currents1.isEmpty)
     XCTAssertEqual(currents2.count, 1)
@@ -207,12 +207,12 @@ final class LockmanStateTests: XCTestCase {
       for i in 0..<iterations {
         group.addTask {
           let info = TestLockmanInfo(id: "\(i)")
-          state.add(id: boundaryId, info: info)
+          state.add(boundaryId: boundaryId, info: info)
         }
       }
     }
 
-    let currents = state.currents(id: boundaryId)
+    let currents = state.currents(boundaryId: boundaryId)
     XCTAssertEqual(currents.count, iterations, "All concurrent adds should succeed")
   }
 
@@ -226,14 +226,14 @@ final class LockmanStateTests: XCTestCase {
         group.addTask {
           let boundaryId = TestBoundaryId("boundary\(i % boundaryCount)")
           let info = TestLockmanInfo(id: "\(i)")
-          state.add(id: boundaryId, info: info)
+          state.add(boundaryId: boundaryId, info: info)
         }
       }
     }
 
     for i in 0..<boundaryCount {
       let boundaryId = TestBoundaryId("boundary\(i)")
-      let currents = state.currents(id: boundaryId)
+      let currents = state.currents(boundaryId: boundaryId)
       let expectedCount = iterations / boundaryCount
       XCTAssertEqual(
         currents.count, expectedCount, "Each boundary should have \(expectedCount) entries")
@@ -249,7 +249,7 @@ final class LockmanStateTests: XCTestCase {
 
     // First, add some entries
     for info in infoList {
-      state.add(id: boundaryId, info: info)
+      state.add(boundaryId: boundaryId, info: info)
     }
 
     await withTaskGroup(of: Void.self) { group in
@@ -257,17 +257,17 @@ final class LockmanStateTests: XCTestCase {
       for i in iterations..<(iterations * 2) {
         group.addTask {
           let info = TestLockmanInfo(id: "\(i)")
-          state.add(id: boundaryId, info: info)
+          state.add(boundaryId: boundaryId, info: info)
         }
       }
 
       // Remove entries
       for info in infoList {
-        state.remove(id: boundaryId, info: info)
+        state.remove(boundaryId: boundaryId, info: info)
       }
     }
 
-    let currents = state.currents(id: boundaryId)
+    let currents = state.currents(boundaryId: boundaryId)
     XCTAssertEqual(currents.count, iterations)
   }
 
@@ -277,13 +277,13 @@ final class LockmanStateTests: XCTestCase {
 
     // Add some initial data
     for i in 0..<10 {
-      state.add(id: boundaryId, info: TestLockmanInfo(id: "\(i)"))
+      state.add(boundaryId: boundaryId, info: TestLockmanInfo(id: "\(i)"))
     }
 
     let results = await withTaskGroup(of: Int.self, returning: [Int].self) { group in
       for _ in 0..<100 {
         group.addTask {
-          state.currents(id: boundaryId).count
+          state.currents(boundaryId: boundaryId).count
         }
       }
 
@@ -306,17 +306,17 @@ final class LockmanStateTests: XCTestCase {
     let infoList = (1...5).map { TestLockmanInfo(id: "\($0)") }
     // Add in order
     for info in infoList {
-      state.add(id: boundaryId, info: info)
+      state.add(boundaryId: boundaryId, info: info)
     }
 
     // Remove and verify LIFO order
     for info in infoList.reversed() {
-      let currents = state.currents(id: boundaryId)
+      let currents = state.currents(boundaryId: boundaryId)
       XCTAssertEqual(currents.last?.uniqueId, info.uniqueId)
-      state.remove(id: boundaryId, info: info)
+      state.remove(boundaryId: boundaryId, info: info)
     }
 
-    XCTAssertTrue(state.currents(id: boundaryId).isEmpty)
+    XCTAssertTrue(state.currents(boundaryId: boundaryId).isEmpty)
   }
 
   func testLargeNumberOfEntries() {
@@ -325,10 +325,10 @@ final class LockmanStateTests: XCTestCase {
     let count = 1000  // Reduced from 10000 for reasonable test time
 
     for i in 0..<count {
-      state.add(id: boundaryId, info: TestLockmanInfo(id: "\(i)"))
+      state.add(boundaryId: boundaryId, info: TestLockmanInfo(id: "\(i)"))
     }
 
-    let currents = state.currents(id: boundaryId)
+    let currents = state.currents(boundaryId: boundaryId)
     XCTAssertEqual(currents.count, count)
 
     // Verify order is maintained
@@ -341,14 +341,14 @@ final class LockmanStateTests: XCTestCase {
     let state = LockmanState<TestLockmanInfo, LockmanActionId>()
     let boundaryId = TestBoundaryId(value: "test")
 
-    state.add(id: boundaryId, info: TestLockmanInfo(id: "1"))
+    state.add(boundaryId: boundaryId, info: TestLockmanInfo(id: "1"))
 
     // Multiple cleanups should be safe
-    state.removeAll(id: boundaryId)
-    state.removeAll(id: boundaryId)
+    state.removeAll(boundaryId: boundaryId)
+    state.removeAll(boundaryId: boundaryId)
     state.removeAll()
 
-    XCTAssertTrue(state.currents(id: boundaryId).isEmpty)
+    XCTAssertTrue(state.currents(boundaryId: boundaryId).isEmpty)
   }
 
   // MARK: - Data Integrity Tests
@@ -359,10 +359,10 @@ final class LockmanStateTests: XCTestCase {
     let testData = ["first", "second", "third", "fourth", "fifth"]
 
     for id in testData {
-      state.add(id: boundaryId, info: TestLockmanInfo(id: id))
+      state.add(boundaryId: boundaryId, info: TestLockmanInfo(id: id))
     }
 
-    let currents = state.currents(id: boundaryId)
+    let currents = state.currents(boundaryId: boundaryId)
     XCTAssertTrue(currents.map(\.actionId) == testData)
   }
 
@@ -373,18 +373,18 @@ final class LockmanStateTests: XCTestCase {
     let boundary3 = TestBoundaryId(value: "isolated3")
 
     // Add different data to each boundary
-    state.add(id: boundary1, info: TestLockmanInfo(id: "a"))
-    state.add(id: boundary2, info: TestLockmanInfo(id: "b"))
-    state.add(id: boundary3, info: TestLockmanInfo(id: "c"))
+    state.add(boundaryId: boundary1, info: TestLockmanInfo(id: "a"))
+    state.add(boundaryId: boundary2, info: TestLockmanInfo(id: "b"))
+    state.add(boundaryId: boundary3, info: TestLockmanInfo(id: "c"))
 
     // Operations on one boundary should not affect others
-    state.removeAll(id: boundary1)
+    state.removeAll(boundaryId: boundary1)
 
-    XCTAssertTrue(state.currents(id: boundary1).isEmpty)
-    XCTAssertTrue(state.currents(id: boundary2).count == 1)
-    XCTAssertTrue(state.currents(id: boundary3).count == 1)
-    XCTAssertTrue(state.currents(id: boundary2).first?.actionId == "b")
-    XCTAssertTrue(state.currents(id: boundary3).first?.actionId == "c")
+    XCTAssertTrue(state.currents(boundaryId: boundary1).isEmpty)
+    XCTAssertTrue(state.currents(boundaryId: boundary2).count == 1)
+    XCTAssertTrue(state.currents(boundaryId: boundary3).count == 1)
+    XCTAssertTrue(state.currents(boundaryId: boundary2).first?.actionId == "b")
+    XCTAssertTrue(state.currents(boundaryId: boundary3).first?.actionId == "c")
   }
 
   func testComplexSequenceOperations() {
@@ -392,14 +392,14 @@ final class LockmanStateTests: XCTestCase {
     let boundaryId = TestBoundaryId(value: "complex")
 
     // Complex sequence: add, add, remove, add, remove, remove
-    state.add(id: boundaryId, info: TestLockmanInfo(id: "1"))
-    state.add(id: boundaryId, info: TestLockmanInfo(id: "2"))
-    state.removeAll(id: boundaryId)  // Remove "2"
-    state.add(id: boundaryId, info: TestLockmanInfo(id: "3"))
-    state.removeAll(id: boundaryId)  // Remove "3"
-    state.removeAll(id: boundaryId)  // Remove "1"
+    state.add(boundaryId: boundaryId, info: TestLockmanInfo(id: "1"))
+    state.add(boundaryId: boundaryId, info: TestLockmanInfo(id: "2"))
+    state.removeAll(boundaryId: boundaryId)  // Remove "2"
+    state.add(boundaryId: boundaryId, info: TestLockmanInfo(id: "3"))
+    state.removeAll(boundaryId: boundaryId)  // Remove "3"
+    state.removeAll(boundaryId: boundaryId)  // Remove "1"
 
-    XCTAssertTrue(state.currents(id: boundaryId).isEmpty)
+    XCTAssertTrue(state.currents(boundaryId: boundaryId).isEmpty)
   }
 
   // MARK: - Memory Management Tests
@@ -410,20 +410,20 @@ final class LockmanStateTests: XCTestCase {
 
     // Add many entries
     for i in 0..<100 {
-      state.add(id: boundaryId, info: TestLockmanInfo(id: "\(i)"))
+      state.add(boundaryId: boundaryId, info: TestLockmanInfo(id: "\(i)"))
     }
 
     // Remove all entries
     for _ in 0..<100 {
-      state.removeAll(id: boundaryId)
+      state.removeAll(boundaryId: boundaryId)
     }
 
     // State should be completely empty
-    XCTAssertTrue(state.currents(id: boundaryId).isEmpty)
+    XCTAssertTrue(state.currents(boundaryId: boundaryId).isEmpty)
 
     // Should be able to add again without issues
-    state.add(id: boundaryId, info: TestLockmanInfo(id: "new"))
-    XCTAssertTrue(state.currents(id: boundaryId).count == 1)
+    state.add(boundaryId: boundaryId, info: TestLockmanInfo(id: "new"))
+    XCTAssertTrue(state.currents(boundaryId: boundaryId).count == 1)
   }
 
   func testCleanupWithMixedBoundaryStates() {
@@ -434,21 +434,21 @@ final class LockmanStateTests: XCTestCase {
 
     // fullBoundary has entries
     for i in 0..<5 {
-      state.add(id: fullBoundary, info: TestLockmanInfo(id: "full_\(i)"))
+      state.add(boundaryId: fullBoundary, info: TestLockmanInfo(id: "full_\(i)"))
     }
 
     // partialBoundary has entries then some removed
     for i in 0..<3 {
-      state.add(id: partialBoundary, info: TestLockmanInfo(id: "partial_\(i)"))
+      state.add(boundaryId: partialBoundary, info: TestLockmanInfo(id: "partial_\(i)"))
     }
 
     // Clean up specific boundaries
-    state.removeAll(id: emptyBoundary)  // Should be safe
-    state.removeAll(id: fullBoundary)
+    state.removeAll(boundaryId: emptyBoundary)  // Should be safe
+    state.removeAll(boundaryId: fullBoundary)
 
-    XCTAssertTrue(state.currents(id: emptyBoundary).isEmpty)
-    XCTAssertTrue(state.currents(id: fullBoundary).isEmpty)
-    XCTAssertTrue(state.currents(id: partialBoundary).count == 3)
+    XCTAssertTrue(state.currents(boundaryId: emptyBoundary).isEmpty)
+    XCTAssertTrue(state.currents(boundaryId: fullBoundary).isEmpty)
+    XCTAssertTrue(state.currents(boundaryId: partialBoundary).count == 3)
   }
 }
 
@@ -573,9 +573,9 @@ final class LockmanStatePerformanceTests: XCTestCase {
 
     for i in 0..<iterations {
       let info = TestLockmanInfo(id: "\(i)")
-      state.add(id: boundaryId, info: info)
+      state.add(boundaryId: boundaryId, info: info)
       if i % 2 == 0 {
-        state.remove(id: boundaryId, info: info)
+        state.remove(boundaryId: boundaryId, info: info)
       }
     }
 
@@ -586,7 +586,7 @@ final class LockmanStatePerformanceTests: XCTestCase {
     XCTAssertLessThan(duration, 1.0)
 
     // Verify final state
-    let finalCount = state.currents(id: boundaryId).count
+    let finalCount = state.currents(boundaryId: boundaryId).count
     XCTAssertEqual(finalCount, iterations / 2)  // Half were removed
   }
 
@@ -600,7 +600,7 @@ final class LockmanStatePerformanceTests: XCTestCase {
     for i in 0..<boundaryCount {
       let boundaryId = TestBoundaryId(value: "boundary_\(i)")
       for j in 0..<entriesPerBoundary {
-        state.add(id: boundaryId, info: TestLockmanInfo(id: "\(i)_\(j)"))
+        state.add(boundaryId: boundaryId, info: TestLockmanInfo(id: "\(i)_\(j)"))
       }
     }
 
@@ -612,7 +612,7 @@ final class LockmanStatePerformanceTests: XCTestCase {
     // Verify all boundaries have correct number of entries
     for i in 0..<boundaryCount {
       let boundaryId = TestBoundaryId(value: "boundary_\(i)")
-      XCTAssertTrue(state.currents(id: boundaryId).count == entriesPerBoundary)
+      XCTAssertTrue(state.currents(boundaryId: boundaryId).count == entriesPerBoundary)
     }
   }
 
@@ -629,9 +629,9 @@ final class LockmanStatePerformanceTests: XCTestCase {
           let boundaryId = TestBoundaryId(value: "task_\(taskId)")
           for i in 0..<operationsPerTask {
             let info = TestLockmanInfo(id: "\(taskId)_\(i)")
-            state.add(id: boundaryId, info: info)
+            state.add(boundaryId: boundaryId, info: info)
             if i % 3 == 0 {
-              state.remove(id: boundaryId, info: info)
+              state.remove(boundaryId: boundaryId, info: info)
             }
           }
         }
@@ -646,7 +646,7 @@ final class LockmanStatePerformanceTests: XCTestCase {
     // Verify each task's boundary has expected number of entries
     for taskId in 0..<taskCount {
       let boundaryId = TestBoundaryId(value: "task_\(taskId)")
-      let currents = state.currents(id: boundaryId)
+      let currents = state.currents(boundaryId: boundaryId)
       let currentCount = currents.count
       let expectedCount = operationsPerTask - (operationsPerTask / 3) - 1
       XCTAssertEqual(currentCount, expectedCount)

--- a/Tests/LockmanTests/Core/Strategies/PriorityBasedStrategy/LockmanPriorityBasedInfoTests.swift
+++ b/Tests/LockmanTests/Core/Strategies/PriorityBasedStrategy/LockmanPriorityBasedInfoTests.swift
@@ -402,33 +402,33 @@ final class LockmanPriorityBasedInfoIntegrationTests: XCTestCase {
   //    let info3 = TestInfoFactory.none("action3")
   //
   //    // Add infos to state
-  //    state.add(id: boundaryId, info: info1)
-  //    state.add(id: boundaryId, info: info2)
-  //    state.add(id: boundaryId, info: info3)
+  //    state.add(boundaryId: boundaryId, info: info1)
+  //    state.add(boundaryId: boundaryId, info: info2)
+  //    state.add(boundaryId: boundaryId, info: info3)
   //
   //    // Verify state contains all infos in order
-  //    let currents = state.currents(id: boundaryId)
+  //    let currents = state.currents(boundaryId: boundaryId)
   //    XCTAssertEqual(currents.count, 3)
   //    XCTAssertEqual(currents[0], info1)
   //    XCTAssertEqual(currents[1], info2)
   //    XCTAssertEqual(currents[2], info3)
   //
   //    // Remove by instance
-  //    state.remove(id: boundaryId, info: info2)
-  //    let afterRemove  = state.currents(id: boundaryId)
+  //    state.remove(boundaryId: boundaryId, info: info2)
+  //    let afterRemove  = state.currents(boundaryId: boundaryId)
   //    XCTAssertEqual(afterRemove.count, 2)
   //    XCTAssertEqual(afterRemove[0], info1)
   //    XCTAssertEqual(afterRemove[1], info3)
   //
   //    // Remove by action ID
-  //    state.remove(id: boundaryId, actionId: info1.actionId)
-  //    let afterActionIdRemove  = state.currents(id: boundaryId)
+  //    state.remove(boundaryId: boundaryId, actionId: info1.actionId)
+  //    let afterActionIdRemove  = state.currents(boundaryId: boundaryId)
   //    XCTAssertEqual(afterActionIdRemove.count, 1)
   //    XCTAssertEqual(afterActionIdRemove[0], info3)
   //
   //    // Clean up
   //    state.removeAll()
-  //    XCTAssertTrue(state.currents(id: boundaryId).isEmpty)
+  //    XCTAssertTrue(state.currents(boundaryId: boundaryId).isEmpty)
   //  }
 
   func testPriorityBasedSortingBehavior() {

--- a/Tests/LockmanTests/Core/Strategies/SingleExecutionStrategy/LockmanSingleExecutionInfoTests.swift
+++ b/Tests/LockmanTests/Core/Strategies/SingleExecutionStrategy/LockmanSingleExecutionInfoTests.swift
@@ -237,10 +237,10 @@ final class LockmanSingleExecutionInfoIntegrationTests: XCTestCase {
     let info1 = LockmanSingleExecutionInfo(actionId: "action1", mode: .boundary)
     let info2 = LockmanSingleExecutionInfo(actionId: "action2", mode: .boundary)
 
-    state.add(id: boundaryId, info: info1)
-    state.add(id: boundaryId, info: info2)
+    state.add(boundaryId: boundaryId, info: info1)
+    state.add(boundaryId: boundaryId, info: info2)
 
-    let currents = state.currents(id: boundaryId)
+    let currents = state.currents(boundaryId: boundaryId)
     XCTAssertEqual(currents.count, 2)
     XCTAssertTrue(currents.contains(info1))
     XCTAssertTrue(currents.contains(info2))
@@ -250,8 +250,8 @@ final class LockmanSingleExecutionInfoIntegrationTests: XCTestCase {
     XCTAssertEqual(currents[1], info2)
 
     // Test removal
-    state.remove(id: boundaryId, info: info2)
-    let afterRemoval = state.currents(id: boundaryId)
+    state.remove(boundaryId: boundaryId, info: info2)
+    let afterRemoval = state.currents(boundaryId: boundaryId)
     XCTAssertEqual(afterRemoval.count, 1)
     XCTAssertEqual(afterRemoval[0], info1)
   }


### PR DESCRIPTION
## Summary
- Unified parameter names from `id` to `boundaryId` in LockmanState class and related implementations
- Improved code consistency across internal implementation without breaking public APIs
- Enhanced developer experience with consistent parameter naming

## Changes
- **LockmanState**: Updated all method signatures to use `boundaryId` parameter
- **Strategy implementations**: Updated SingleExecution, PriorityBased, ConcurrencyLimited, and DynamicCondition strategies
- **Documentation**: Updated comments to reflect new parameter names
- **Tests**: Updated test files to use new parameter names

🤖 Generated with [Claude Code](https://claude.ai/code)