### PR TITLE
docs: fix cleanup comment inconsistency in LockmanStrategyContainer

### DIFF
--- a/Sources/Lockman/Core/Strategies/Core/LockmanStrategyContainer.swift
+++ b/Sources/Lockman/Core/Strategies/Core/LockmanStrategyContainer.swift
@@ -377,8 +377,8 @@ public final class LockmanStrategyContainer: @unchecked Sendable {
   /// shutdown or global reset scenarios.
   ///
   /// ## Error Handling
-  /// If any strategy's cleanup operation fails, the error is logged but
-  /// cleanup continues for remaining strategies to ensure best-effort cleanup.
+  /// This operation is designed to be safe and cannot fail. Individual strategy
+  /// cleanup operations are expected to handle their own cleanup gracefully.
   ///
   /// ## Complexity
   /// O(n) where n is the number of registered strategies
@@ -399,8 +399,8 @@ public final class LockmanStrategyContainer: @unchecked Sendable {
   /// - Parameter boundaryId: The `LockmanBoundaryId` whose associated lock state should be cleared
   ///
   /// ## Error Handling
-  /// Similar to `cleanUp()`, errors in individual strategy cleanup are logged
-  /// but don't prevent cleanup of other strategies.
+  /// This operation is designed to be safe and cannot fail. Individual strategy
+  /// cleanup operations are expected to handle their own cleanup gracefully.
   ///
   /// ## Complexity
   /// O(n) where n is the number of registered strategies

--- a/Tests/LockmanTests/Core/Strategies/Core/LockmanStateGenericTests.swift
+++ b/Tests/LockmanTests/Core/Strategies/Core/LockmanStateGenericTests.swift
@@ -110,7 +110,8 @@ final class LockmanStateGenericTests: XCTestCase {
     XCTAssertTrue(state.hasActiveLocks(in: boundaryId, matching: key2))
     XCTAssertTrue(state.hasActiveLocks(in: boundaryId, matching: key3))
     XCTAssertFalse(
-      state.hasActiveLocks(in: boundaryId, matching: CompositeKey(category: "compute", priority: 1)))
+      state.hasActiveLocks(in: boundaryId, matching: CompositeKey(category: "compute", priority: 1))
+    )
 
     // Test count with composite key
     XCTAssertEqual(state.activeLockCount(in: boundaryId, matching: key1), 2)


### PR DESCRIPTION
## Summary
- Fix documentation comments in LockmanStrategyContainer that incorrectly described error logging behavior
- The cleanup operations are designed to be safe and cannot fail, but comments suggested error logging was implemented
- Updated comments to accurately reflect the actual implementation behavior

## Changes
- Update `cleanUp()` method comments to match implementation
- Update `cleanUp(boundaryId:)` method comments to match implementation  
- Apply code formatting to maintain consistency

## Testing
- ✅ All existing tests pass
- ✅ No functional changes to implementation
- ✅ Documentation now accurately reflects code behavior

🤖 Generated with [Claude Code](https://claude.ai/code)