### PR TITLE
refactor: optimize cleanUp method in ConcurrencyLimitedStrategy

### DIFF
--- a/Sources/Lockman/Core/Strategies/ConcurrencyLimitedStrategy/LockmanConcurrencyLimitedStrategy.swift
+++ b/Sources/Lockman/Core/Strategies/ConcurrencyLimitedStrategy/LockmanConcurrencyLimitedStrategy.swift
@@ -109,11 +109,7 @@ public final class LockmanConcurrencyLimitedStrategy: LockmanStrategy, @unchecke
   public func cleanUp<B: LockmanBoundaryId>(
     boundaryId: B
   ) {
-    // Get all locks for this boundary and remove them one by one
-    let currentLocks = state.currentLocks(in: boundaryId)
-    for info in currentLocks {
-      state.remove(boundaryId: boundaryId, info: info)
-    }
+    state.removeAll(boundaryId: boundaryId)
   }
 
   /// Removes all locks across all boundaries and concurrency groups.


### PR DESCRIPTION
## Summary
- Optimize the `cleanUp(boundaryId:)` method in `ConcurrencyLimitedStrategy` to use the efficient `state.removeAll(boundaryId:)` call instead of an inefficient loop
- Align implementation with the pattern used by all other strategies (`SingleExecutionStrategy` and `PriorityBasedStrategy`)

## Changes
- **Before**: Loop through all locks and remove them individually
  ```swift
  let currentLocks = state.currentLocks(in: boundaryId)
  for info in currentLocks {
    state.remove(boundaryId: boundaryId, info: info)
  }
  ```
- **After**: Use optimized single call
  ```swift
  state.removeAll(boundaryId: boundaryId)
  ```

## Benefits
- **Performance**: Eliminates O(n) individual removals in favor of optimized internal batch removal
- **Consistency**: Matches the implementation pattern used by all other strategies
- **Maintainability**: Reduces code complexity and potential for bugs

## Testing
- All existing tests pass
- No functional changes to behavior, only performance optimization

🤖 Generated with [Claude Code](https://claude.ai/code)