### PR TITLE
fix: replace force unwrap with safe optional chaining in GroupCoordinationStrategy

### DIFF
--- a/Sources/Lockman/Core/Strategies/GroupCoordinationStrategy/LockmanGroupCoordinationStrategy.swift
+++ b/Sources/Lockman/Core/Strategies/GroupCoordinationStrategy/LockmanGroupCoordinationStrategy.swift
@@ -200,7 +200,7 @@ public final class LockmanGroupCoordinationStrategy: LockmanStrategy, @unchecked
 
         case .member:
           // Members can only join when group has active participants
-          if groupState == nil || groupState!.isEmpty {
+          if groupState?.isEmpty != false {
             failureReason = "Member cannot join: group '\(groupId)' has no active participants"
             return .cancel(
               LockmanGroupCoordinationError.memberCannotJoinEmptyGroup(


### PR DESCRIPTION
## Summary
Replace force unwrap with safer optional chaining in GroupCoordinationStrategy member validation logic.

## Changes
- **Safety Improvement**: Replace `groupState\!.isEmpty` with `groupState?.isEmpty \!= false`
- **Identical Logic**: Maintains exact same behavior (handles both nil and empty cases)
- **Risk Elimination**: Removes potential crash from force unwrap

## Logic Verification
Both implementations handle the same cases:
- `groupState == nil` → condition is true → member cannot join
- `groupState.isEmpty == true` → condition is true → member cannot join  
- `groupState.isEmpty == false` → condition is false → member can join

## Test Plan
- [x] All existing tests pass
- [x] Identical behavior to previous implementation
- [x] Force unwrap eliminated with safe optional chaining

🤖 Generated with [Claude Code](https://claude.ai/code)