### PR TITLE
fix: prioritize nested action evaluation over root action in Reducer.lock()

### DIFF
--- a/Sources/Lockman/Composable/Reducer+Lockman.swift
+++ b/Sources/Lockman/Composable/Reducer+Lockman.swift
@@ -146,13 +146,15 @@ extension Reducer {
       unlockOption: unlockOption,
       lockFailure: lockFailure,
       extractLockmanAction: { action in
-        // First check if root action conforms to LockmanAction
+        // First check the provided path (more specific)
+        if let value = action[case: path1] {
+          if let lockmanAction = value as? any LockmanAction {
+            return lockmanAction
+          }
+        }
+        // Fallback to root action (less specific)
         if let lockmanAction = action as? any LockmanAction {
           return lockmanAction
-        }
-        // Then check the provided path
-        if let value = action[case: path1] {
-          return value as? any LockmanAction
         }
         return nil
       }
@@ -197,11 +199,7 @@ extension Reducer {
       unlockOption: unlockOption,
       lockFailure: lockFailure,
       extractLockmanAction: { action in
-        // First check if root action conforms to LockmanAction
-        if let lockmanAction = action as? any LockmanAction {
-          return lockmanAction
-        }
-        // Then check the provided paths
+        // First check the provided paths (more specific)
         let paths: [(Action) -> Any?] = [
           { $0[case: path1] },
           { $0[case: path2] },
@@ -212,6 +210,10 @@ extension Reducer {
               return lockmanAction
             }
           }
+        }
+        // Fallback to root action (less specific)
+        if let lockmanAction = action as? any LockmanAction {
+          return lockmanAction
         }
         return nil
       }
@@ -245,11 +247,7 @@ extension Reducer {
       unlockOption: unlockOption,
       lockFailure: lockFailure,
       extractLockmanAction: { action in
-        // First check if root action conforms to LockmanAction
-        if let lockmanAction = action as? any LockmanAction {
-          return lockmanAction
-        }
-        // Then check the provided paths
+        // First check the provided paths (more specific)
         let paths: [(Action) -> Any?] = [
           { $0[case: path1] },
           { $0[case: path2] },
@@ -261,6 +259,10 @@ extension Reducer {
               return lockmanAction
             }
           }
+        }
+        // Fallback to root action (less specific)
+        if let lockmanAction = action as? any LockmanAction {
+          return lockmanAction
         }
         return nil
       }
@@ -296,11 +298,7 @@ extension Reducer {
       unlockOption: unlockOption,
       lockFailure: lockFailure,
       extractLockmanAction: { action in
-        // First check if root action conforms to LockmanAction
-        if let lockmanAction = action as? any LockmanAction {
-          return lockmanAction
-        }
-        // Then check the provided paths
+        // First check the provided paths (more specific)
         let paths: [(Action) -> Any?] = [
           { $0[case: path1] },
           { $0[case: path2] },
@@ -313,6 +311,10 @@ extension Reducer {
               return lockmanAction
             }
           }
+        }
+        // Fallback to root action (less specific)
+        if let lockmanAction = action as? any LockmanAction {
+          return lockmanAction
         }
         return nil
       }
@@ -350,11 +352,7 @@ extension Reducer {
       unlockOption: unlockOption,
       lockFailure: lockFailure,
       extractLockmanAction: { action in
-        // First check if root action conforms to LockmanAction
-        if let lockmanAction = action as? any LockmanAction {
-          return lockmanAction
-        }
-        // Then check the provided paths
+        // First check the provided paths (more specific)
         let paths: [(Action) -> Any?] = [
           { $0[case: path1] },
           { $0[case: path2] },
@@ -368,6 +366,10 @@ extension Reducer {
               return lockmanAction
             }
           }
+        }
+        // Fallback to root action (less specific)
+        if let lockmanAction = action as? any LockmanAction {
+          return lockmanAction
         }
         return nil
       }


### PR DESCRIPTION
## Summary

Fix evaluation order in `Reducer.lock()` methods to properly prioritize nested actions over root actions when both conform to `LockmanAction`.

## Problem

When using ViewAction pattern where both root action and nested actions conform to `LockmanAction`, the previous implementation would always use the root action's `lockmanInfo`, ignoring the more specific nested action configuration.

```swift
enum RootAction: LockmanAction {
  case view(ViewAction)  // ViewAction also conforms to LockmanAction
  var lockmanInfo: SomeInfo { ... }  // Root configuration
}

enum ViewAction: LockmanAction {
  case buttonTapped
  var lockmanInfo: SomeInfo { ... }  // More specific configuration - was ignored
}
```

## Solution

Changed evaluation order in all 5 `Reducer.lock()` overloaded methods:

**Before**: Root action → Provided paths
**After**: Provided paths → Root action (fallback)

This ensures more specific nested action configurations are used when available, with root action serving as appropriate fallback.

## Changes

- Fix evaluation order in `lock(for: path1)` method
- Fix evaluation order in `lock(for: path1, path2)` method  
- Fix evaluation order in `lock(for: path1, path2, path3)` method
- Fix evaluation order in `lock(for: path1, path2, path3, path4)` method
- Fix evaluation order in `lock(for: path1, path2, path3, path4, path5)` method
- Update comments to clarify "more specific" vs "less specific" priority

## Test Plan

- [ ] Verify nested ViewAction configurations are properly applied
- [ ] Confirm root action still works as fallback when paths don't match
- [ ] Test all 5 overloaded methods handle evaluation order correctly

🤖 Generated with [Claude Code](https://claude.ai/code)