### PR TITLE
chore: prepare for 1.4.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ Add the dependency to your Package.swift file:
 
 ```swift
 dependencies: [
-  .package(url: "https://github.com/takeshishimada/Lockman", from: "1.3.2")
+  .package(url: "https://github.com/takeshishimada/Lockman", from: "1.4.0")
 ]
 ```
 
@@ -253,13 +253,14 @@ Add the dependency to your target:
 
 | Lockman | The Composable Architecture |
 |---------|----------------------------|
-| 1.3.2   | 1.20.2                     |
+| 1.4.0   | 1.20.2                     |
 
 <details>
 <summary>Other versions</summary>
 
 | Lockman | The Composable Architecture |
 |---------|----------------------------|
+| 1.3.2   | 1.20.2                     |
 | 1.3.1   | 1.20.2                     |
 | 1.3.0   | 1.20.2                     |
 | 1.2.0   | 1.20.2                     |


### PR DESCRIPTION
## Summary
Prepare for version 1.4.0 release by updating documentation and version references.

## Changes
- Update installation instructions in README.md from `1.3.2` to `1.4.0`
- Update Version Compatibility table to include 1.4.0 as current version
- Move 1.3.2 to "Other versions" section for historical reference

This PR prepares the repository for the 1.4.0 release which includes breaking changes introduced in recent commits.

🤖 Generated with [Claude Code](https://claude.ai/code)