### PR TITLE
refactor: improve variable naming clarity in LockmanDynamicConditionReducer

### DIFF
--- a/Sources/Lockman/Composable/LockmanDynamicConditionReducer.swift
+++ b/Sources/Lockman/Composable/LockmanDynamicConditionReducer.swift
@@ -158,7 +158,7 @@ extension LockmanDynamicConditionReducer {
   ///   - lockFailure: Optional handler for dynamic condition lock acquisition failures
   ///   - lockAction: LockmanAction providing action information (not used for lock strategy in Pure Dynamic Condition mode)
   ///   - boundaryId: Unique identifier for effect cancellation and lock boundary
-  ///   - lockCondition: Optional action-level condition that supplements the reducer-level condition
+  ///   - actionLockCondition: Optional action-level condition that supplements the reducer-level condition
   ///   - fileID: Source file identifier for debugging (auto-populated)
   ///   - filePath: Source file path for debugging (auto-populated)
   ///   - line: Source line number for debugging (auto-populated)
@@ -178,14 +178,14 @@ extension LockmanDynamicConditionReducer {
     )? = nil,
     lockAction: LA,
     boundaryId: B,
-    lockCondition: (@Sendable (_ state: State, _ action: Action) -> LockmanResult)? = nil,
+    actionLockCondition: (@Sendable (_ state: State, _ action: Action) -> LockmanResult)? = nil,
     fileID: StaticString = #fileID,
     filePath: StaticString = #filePath,
     line: UInt = #line,
     column: UInt = #column
   ) -> Effect<Action> {
     let actionId = lockAction.lockmanInfo.actionId
-    let dynamicLockCondition = self.lockCondition
+    let reducerLockCondition = self.lockCondition
 
     // Step 1: Resolve strategies
     let dynamicStrategy: AnyLockmanStrategy<LockmanDynamicConditionInfo>
@@ -213,8 +213,8 @@ extension LockmanDynamicConditionReducer {
 
     // Step 2: Evaluate conditions (dynamic lock condition and lock call)
     let conditionResult = evaluateConditions(
-      dynamicLockCondition: dynamicLockCondition,
-      lockCondition: lockCondition,
+      dynamicLockCondition: reducerLockCondition,
+      lockCondition: actionLockCondition,
       state: state,
       action: action,
       dynamicStrategy: dynamicStrategy,

--- a/Sources/Lockman/Core/Strategies/CompositeStrategy/LockmanCompositeStrategy.swift
+++ b/Sources/Lockman/Core/Strategies/CompositeStrategy/LockmanCompositeStrategy.swift
@@ -202,7 +202,8 @@ where S1.I == I1, S2.I == I2 {
         break
       @unknown default:
         // Handle future enum cases defensively
-        LockmanLogger.shared.logLockState("CompositeStrategy: Unknown LockmanResult case: \(result)")
+        LockmanLogger.shared.logLockState(
+          "CompositeStrategy: Unknown LockmanResult case: \(result)")
         break
       }
     }
@@ -428,7 +429,8 @@ where S1.I == I1, S2.I == I2, S3.I == I3 {
         break
       @unknown default:
         // Handle future enum cases defensively
-        LockmanLogger.shared.logLockState("CompositeStrategy: Unknown LockmanResult case: \(result)")
+        LockmanLogger.shared.logLockState(
+          "CompositeStrategy: Unknown LockmanResult case: \(result)")
         break
       }
     }
@@ -670,7 +672,8 @@ where S1.I == I1, S2.I == I2, S3.I == I3, S4.I == I4 {
         break
       @unknown default:
         // Handle future enum cases defensively
-        LockmanLogger.shared.logLockState("CompositeStrategy: Unknown LockmanResult case: \(result)")
+        LockmanLogger.shared.logLockState(
+          "CompositeStrategy: Unknown LockmanResult case: \(result)")
         break
       }
     }
@@ -944,7 +947,8 @@ where S1.I == I1, S2.I == I2, S3.I == I3, S4.I == I4, S5.I == I5 {
         break
       @unknown default:
         // Handle future enum cases defensively
-        LockmanLogger.shared.logLockState("CompositeStrategy: Unknown LockmanResult case: \(result)")
+        LockmanLogger.shared.logLockState(
+          "CompositeStrategy: Unknown LockmanResult case: \(result)")
         break
       }
     }

--- a/Tests/LockmanTests/Composable/LockmanDynamicConditionReducerIntegrationTests.swift
+++ b/Tests/LockmanTests/Composable/LockmanDynamicConditionReducerIntegrationTests.swift
@@ -129,7 +129,7 @@ final class LockmanDynamicConditionReducerIntegrationTests: XCTestCase {
           },
           lockAction: TestLockAction(),
           boundaryId: cancelID,
-          lockCondition: { _, _ in
+          actionLockCondition: { _, _ in
             // Action-level condition
             return .success
           }
@@ -249,7 +249,7 @@ final class LockmanDynamicConditionReducerIntegrationTests: XCTestCase {
             },
             lockAction: TestLockAction(),
             boundaryId: TestLockAction().lockmanInfo.actionId,
-            lockCondition: { _, _ in
+            actionLockCondition: { _, _ in
               // Failing condition
               return .cancel(
                 ComposableTestDynamicConditionError.conditionNotMet(
@@ -333,7 +333,7 @@ final class LockmanDynamicConditionReducerIntegrationTests: XCTestCase {
             },
             lockAction: TestLockAction(),
             boundaryId: TestLockAction().lockmanInfo.actionId,
-            lockCondition: { _, _ in
+            actionLockCondition: { _, _ in
               tracker.step2Evaluated = true
               return .success  // Step 2 also passes
             }

--- a/Tests/LockmanTests/Composable/LockmanDynamicConditionReducerMethodChainTests.swift
+++ b/Tests/LockmanTests/Composable/LockmanDynamicConditionReducerMethodChainTests.swift
@@ -174,7 +174,7 @@ final class LockmanDynamicConditionReducerMethodChainTests: XCTestCase {
           },
           lockAction: PurchaseAction(),
           boundaryId: CancelID.payment,
-          lockCondition: { state, _ in
+          actionLockCondition: { state, _ in
             // Action-level condition
             guard state.balance >= amount else {
               return .cancel(


### PR DESCRIPTION
## Summary
Improve variable naming clarity in LockmanDynamicConditionReducer to make the code more readable and maintainable.

## Changes
- Renamed parameter `lockCondition` to `actionLockCondition` to better reflect its purpose as an action-level condition
- Renamed internal variable `dynamicLockCondition` to `reducerLockCondition` to clarify it represents the reducer-level condition
- Updated all related documentation and test files to use the new parameter names
- Applied automatic code formatting changes to CompositeStrategy files

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>