### PR TITLE
fix: implement lock-first behavior in Effect.lock(concatenating:) to prevent reducer execution before lock acquisition

### DIFF
--- a/Examples/Strategies/Strategies/01-SingleExecutionStrategy.swift
+++ b/Examples/Strategies/Strategies/01-SingleExecutionStrategy.swift
@@ -19,7 +19,7 @@ struct SingleExecutionStrategyFeature {
     enum ViewAction {
       case startProcessButtonTapped
 
-      var lockmanInfo: LockmanSingleExecutionInfo {
+      func createLockmanInfo() -> LockmanSingleExecutionInfo {
         return .init(actionId: actionName, mode: .boundary)
       }
     }

--- a/Examples/Strategies/Strategies/02-PriorityBasedStrategy.swift
+++ b/Examples/Strategies/Strategies/02-PriorityBasedStrategy.swift
@@ -46,7 +46,7 @@ struct PriorityBasedStrategyFeature {
         }
       }
 
-      var lockmanInfo: LockmanCompositeInfo2<LockmanSingleExecutionInfo, LockmanPriorityBasedInfo> {
+      func createLockmanInfo() -> LockmanCompositeInfo2<LockmanSingleExecutionInfo, LockmanPriorityBasedInfo> {
         LockmanCompositeInfo2(
           strategyId: strategyId,
           actionId: actionId,

--- a/Examples/Strategies/Strategies/03-ConcurrencyLimitedStrategy.swift
+++ b/Examples/Strategies/Strategies/03-ConcurrencyLimitedStrategy.swift
@@ -70,9 +70,7 @@ struct ConcurrencyLimitedStrategyFeature {
         }
       }
 
-      var lockmanInfo:
-        LockmanCompositeInfo2<LockmanSingleExecutionInfo, LockmanConcurrencyLimitedInfo>
-      {
+      func createLockmanInfo() -> LockmanCompositeInfo2<LockmanSingleExecutionInfo, LockmanConcurrencyLimitedInfo> {
         LockmanCompositeInfo2(
           strategyId: strategyId,  // Use macro-generated strategyId
           actionId: actionId,

--- a/Examples/Strategies/Strategies/04-GroupCoordinationStrategy.swift
+++ b/Examples/Strategies/Strategies/04-GroupCoordinationStrategy.swift
@@ -36,7 +36,7 @@ struct GroupCoordinationStrategyFeature {
       case processDataTapped  // Member - can only run during sync
       case cancelSyncTapped  // None - can always run
 
-      var lockmanInfo: LockmanGroupCoordinatedInfo {
+      func createLockmanInfo() -> LockmanGroupCoordinatedInfo {
         switch self {
         case .startSyncTapped:
           return LockmanGroupCoordinatedInfo(

--- a/Examples/Strategies/Strategies/05-DynamicConditionStrategy.swift
+++ b/Examples/Strategies/Strategies/05-DynamicConditionStrategy.swift
@@ -58,8 +58,7 @@ struct DynamicConditionStrategyFeature {
     case view(ViewAction)
     case `internal`(InternalAction)
 
-    @LockmanDynamicCondition
-    enum ViewAction {
+    enum ViewAction: LockmanDynamicConditionAction {
       // Pattern 1: Login-based
       case syncDataTapped
       case toggleLoginTapped
@@ -72,7 +71,20 @@ struct DynamicConditionStrategyFeature {
       case generateReportTapped
       case selectDay(State.Weekday)
 
-      // マクロが自動生成するlockmanInfoを使用
+      var actionName: String {
+        switch self {
+        case .syncDataTapped: return "syncDataTapped"
+        case .toggleLoginTapped: return "toggleLoginTapped"
+        case .performMaintenanceTapped: return "performMaintenanceTapped"
+        case .setHour: return "setHour"
+        case .generateReportTapped: return "generateReportTapped"
+        case .selectDay: return "selectDay"
+        }
+      }
+
+      func createLockmanInfo() -> LockmanDynamicConditionInfo {
+        LockmanDynamicConditionInfo(actionId: actionName)
+      }
     }
 
     enum InternalAction {

--- a/Sources/Lockman/Composable/Effect+Lockman.swift
+++ b/Sources/Lockman/Composable/Effect+Lockman.swift
@@ -78,9 +78,9 @@ extension Effect {
       // Create concatenated effect from operations array
       let concatenatedEffect = Effect.concatenate(operations)
 
-      // ✨ CRITICAL: Capture lockmanInfo once to ensure consistent uniqueId throughout lock lifecycle
-      // This prevents lock/unlock mismatches that occur when computed properties generate new UUIDs
-      let lockmanInfo = action.lockmanInfo
+      // ✨ CRITICAL: Create lockmanInfo once to ensure consistent uniqueId throughout lock lifecycle
+      // This prevents lock/unlock mismatches that occur when methods are called multiple times
+      let lockmanInfo = action.createLockmanInfo()
 
       // Acquire lock using the captured lockmanInfo (consistent uniqueId)
       let lockResult = try concatenatedEffect.acquireLock(
@@ -178,9 +178,9 @@ extension Effect {
     // This method provides a method chain style API by combining acquireLock and buildLockEffect
 
     do {
-      // ✨ CRITICAL: Capture lockmanInfo once to ensure consistent uniqueId throughout lock lifecycle
-      // This prevents lock/unlock mismatches that occur when computed properties generate new UUIDs
-      let lockmanInfo = action.lockmanInfo
+      // ✨ CRITICAL: Create lockmanInfo once to ensure consistent uniqueId throughout lock lifecycle
+      // This prevents lock/unlock mismatches that occur when methods are called multiple times
+      let lockmanInfo = action.createLockmanInfo()
 
       // Acquire lock using captured lockmanInfo (consistent uniqueId)
       let lockResult = try acquireLock(

--- a/Sources/Lockman/Composable/Effect+Lockman.swift
+++ b/Sources/Lockman/Composable/Effect+Lockman.swift
@@ -16,11 +16,12 @@ extension Effect {
   /// - **Resource Coordination**: Maintaining exclusive access during complex state changes
   /// - **Migration Scenarios**: Gradual transition from multiple effects to single concatenated operation
   ///
-  /// ## Lock Lifecycle
-  /// 1. Lock is acquired before the first effect starts
-  /// 2. Lock is held during execution of all concatenated effects
-  /// 3. Lock is automatically released after all effects complete (using configured option)
-  /// 4. If any effect fails, lock is still properly released
+  /// ## Lock Lifecycle & UniqueId Consistency
+  /// 1. **LockmanInfo Capture**: Action's lockmanInfo is captured once at the beginning to ensure consistent uniqueId
+  /// 2. **Lock Acquisition**: Lock is acquired before the first effect starts using the captured lockmanInfo
+  /// 3. **Effect Execution**: Lock is held during execution of all concatenated effects
+  /// 4. **Guaranteed Unlock**: Lock is automatically released after all effects complete using the same lockmanInfo instance
+  /// 5. **Error Handling**: If any effect fails, lock is still properly released with matching uniqueId
   ///
   /// Effects execute sequentially. If any effect fails, subsequent effects are cancelled,
   /// but the unlock still executes to ensure proper cleanup.
@@ -77,15 +78,17 @@ extension Effect {
       // Create concatenated effect from operations array
       let concatenatedEffect = Effect.concatenate(operations)
 
+      // ✨ CRITICAL: Capture lockmanInfo once to ensure consistent uniqueId throughout lock lifecycle
+      // This prevents lock/unlock mismatches that occur when computed properties generate new UUIDs
       let lockmanInfo = action.lockmanInfo
 
-      // Acquire lock using the concatenated effect instance
+      // Acquire lock using the captured lockmanInfo (consistent uniqueId)
       let lockResult = try concatenatedEffect.acquireLock(
         lockmanInfo: lockmanInfo,
         boundaryId: boundaryId
       )
 
-      // Build lock effect using the same concatenated effect instance
+      // Build lock effect using the same lockmanInfo instance (guaranteed unlock)
       return concatenatedEffect.buildLockEffect(
         lockResult: lockResult,
         action: action,
@@ -124,6 +127,10 @@ extension Effect {
   ///
   /// This method provides a method chain style API for applying lock management to effects.
   /// The lock strategy is automatically resolved from the container using the action's strategy ID.
+  ///
+  /// ## UniqueId Consistency
+  /// This method captures the action's lockmanInfo once at the beginning to ensure consistent
+  /// uniqueId values throughout the lock lifecycle, preventing lock/unlock mismatches.
   ///
   /// ## Automatic Cancellation Management
   /// This method automatically applies `.cancellable(id: boundaryId)` to the chained effect,
@@ -171,14 +178,17 @@ extension Effect {
     // This method provides a method chain style API by combining acquireLock and buildLockEffect
 
     do {
+      // ✨ CRITICAL: Capture lockmanInfo once to ensure consistent uniqueId throughout lock lifecycle
+      // This prevents lock/unlock mismatches that occur when computed properties generate new UUIDs
       let lockmanInfo = action.lockmanInfo
 
-      // Acquire lock using instance method
+      // Acquire lock using captured lockmanInfo (consistent uniqueId)
       let lockResult = try acquireLock(
         lockmanInfo: lockmanInfo,
         boundaryId: boundaryId
       )
 
+      // Build lock effect using the same lockmanInfo instance (guaranteed unlock)
       return buildLockEffect(
         lockResult: lockResult,
         action: action,

--- a/Sources/Lockman/Composable/Effect+LockmanInternal.swift
+++ b/Sources/Lockman/Composable/Effect+LockmanInternal.swift
@@ -33,16 +33,80 @@ extension Effect {
   ///
   /// - Parameters:
   ///   - lockmanInfo: Lock information for the strategy (action ID, unique ID, etc.)
-  ///   - strategy: Type-erased strategy to use for lock operations
   ///   - boundaryId: Boundary identifier for this lock and cancellation
-  ///   - effect: Effect to execute if lock acquisition succeeds
-  /// - Returns: Effect to execute, or `.none` if lock acquisition fails
-  public static func acquireLock<B: LockmanBoundaryId, I: LockmanInfo>(
+  /// - Returns: LockmanResult indicating lock acquisition status
+  func acquireLock<B: LockmanBoundaryId, I: LockmanInfo>(
     lockmanInfo: I,
-    strategy: AnyLockmanStrategy<I>,
     boundaryId: B
-  ) -> LockmanResult {
-    LockmanManager.withBoundaryLock(for: boundaryId) {
+  ) throws -> LockmanResult {
+    return try acquireLockCore(
+      lockmanInfo: lockmanInfo,
+      strategyId: lockmanInfo.strategyId,
+      boundaryId: boundaryId
+    )
+  }
+
+  /// Attempts to acquire a lock using LockmanInfo directly (overload for internal use).
+  ///
+  /// This overload is designed for internal components that work directly with LockmanInfo
+  /// without needing to create temporary LockmanAction wrappers. It's particularly useful
+  /// for LockmanDynamicConditionReducer where we have LockmanDynamicConditionInfo but
+  /// need to perform lock acquisition without creating wrapper types.
+  ///
+  /// ## Use Cases
+  /// - Dynamic condition evaluation in LockmanDynamicConditionReducer
+  /// - Internal lock operations where LockmanAction wrapper is unnecessary
+  /// - Strategy resolution and lock acquisition with known info types
+  ///
+  /// ## Parameters
+  /// - lockmanInfo: The lock information containing strategy ID and lock data
+  /// - strategyId: Strategy identifier for container resolution
+  /// - boundaryId: Boundary identifier for this lock and cancellation
+  /// - Returns: LockmanResult indicating lock acquisition status
+  func acquireLock<B: LockmanBoundaryId, I: LockmanInfo>(
+    lockmanInfo: I,
+    strategyId: LockmanStrategyId,
+    boundaryId: B
+  ) throws -> LockmanResult {
+    return try acquireLockCore(
+      lockmanInfo: lockmanInfo,
+      strategyId: strategyId,
+      boundaryId: boundaryId
+    )
+  }
+
+  /// Core lock acquisition logic shared by all acquireLock overloads.
+  ///
+  /// This internal method contains the common implementation for lock acquisition,
+  /// including strategy resolution, boundary protection, and the complete lock lifecycle.
+  /// By centralizing this logic, we ensure consistency across all lock acquisition paths
+  /// while reducing code duplication.
+  ///
+  /// ## Implementation Details
+  /// - Strategy resolution from container
+  /// - Boundary lock protection for atomicity
+  /// - Lock feasibility check via canLock
+  /// - Preceding cancellation handling with cleanup
+  /// - Actual lock acquisition via lock
+  ///
+  /// ## Parameters
+  /// - lockmanInfo: The lock information for strategy operations
+  /// - strategyId: Strategy identifier for container resolution
+  /// - boundaryId: Boundary identifier for this lock operation
+  /// - Returns: LockmanResult indicating the outcome of lock acquisition
+  private func acquireLockCore<B: LockmanBoundaryId, I: LockmanInfo>(
+    lockmanInfo: I,
+    strategyId: LockmanStrategyId,
+    boundaryId: B
+  ) throws -> LockmanResult {
+    // Resolve the strategy from the container using the provided strategyId
+    let strategy: AnyLockmanStrategy<I> = try LockmanManager.container.resolve(
+      id: strategyId,
+      expecting: I.self
+    )
+
+    // Acquire lock with boundary protection
+    return LockmanManager.withBoundaryLock(for: boundaryId) {
       // Check if lock can be acquired
       let result = strategy.canLock(
         boundaryId: boundaryId,
@@ -52,6 +116,7 @@ extension Effect {
       // Handle immediate unlock for preceding cancellation
       if case .successWithPrecedingCancellation(let cancellationError) = result {
         // Immediately unlock the cancelled action to prevent resource leaks
+        // Only unlock if the cancelled action has compatible lock info type
         if let cancelledInfo = cancellationError.lockmanInfo as? I {
           strategy.unlock(boundaryId: cancellationError.boundaryId, info: cancelledInfo)
         }
@@ -70,6 +135,145 @@ extension Effect {
 
       // Return the result
       return result
+    }
+  }
+
+  /// Builds an effect with lock acquisition and automatic unlock.
+  ///
+  /// ## Purpose
+  /// This internal method contains the common logic shared by all lock variants:
+  /// 1. Strategy resolution from the container
+  /// 2. Lock information extraction from the action
+  /// 3. Lock acquisition and result handling
+  /// 4. Direct effect concatenation with unlock effect
+  ///
+  /// ## Simplified Architecture
+  /// This method directly creates the unlock effect and concatenates it with the operations,
+  /// eliminating the need for complex closure patterns and intermediate wrappers.
+  ///
+  /// ## Error Handling Strategy
+  /// This method uses a do-catch pattern to handle strategy resolution errors.
+  /// If strategy resolution fails, it calls `handleError` to provide detailed
+  /// diagnostic information and optionally calls the provided handler before
+  /// returning `.none` to prevent effect execution.
+  ///
+  /// ## Type Safety
+  /// The method maintains type safety through generic constraints:
+  /// - `B: LockmanBoundaryId`: Ensures valid boundary identifier
+  /// - `A: LockmanAction`: Ensures valid action with lock information
+  /// - `A.I`: Preserves lock information type relationship
+  ///
+  /// ## Effect Execution Order
+  /// The returned effect executes in this order:
+  /// 1. Operations (cancellable as a group)
+  /// 2. Unlock effect (non-cancellable, always executes)
+  ///
+  /// - Parameters:
+  ///   - lockResult: Result from prior lock acquisition attempt (must be provided)
+  ///   - action: LockmanAction providing lock information and strategy type
+  ///   - boundaryId: Unique identifier for cancellation and lock boundary
+  ///   - unlockOption: Unlock option configuration for when to execute the unlock
+  ///   - fileID: Source file ID for error reporting
+  ///   - filePath: Source file path for error reporting
+  ///   - line: Source line number for error reporting
+  ///   - column: Source column number for error reporting
+  ///   - handler: Optional error handler for lock acquisition failures
+  /// - Returns: Built effect with lock management, or `.none` if setup fails
+  func buildLockEffect<B: LockmanBoundaryId, A: LockmanAction, I: LockmanInfo>(
+    lockResult: LockmanResult,
+    action: A,
+    lockmanInfo: I,
+    boundaryId: B,
+    unlockOption: LockmanUnlockOption,
+    fileID: StaticString,
+    filePath: StaticString,
+    line: UInt,
+    column: UInt,
+    handler: (@Sendable (_ error: any Error, _ send: Send<Action>) async -> Void)? = nil
+  ) -> Effect<Action> {
+    do {
+      // Resolve the strategy from the container using strategyId
+      let strategy: AnyLockmanStrategy<I> = try LockmanManager.container.resolve(
+        id: lockmanInfo.strategyId,
+        expecting: I.self
+      )
+      let lockmanInfo = lockmanInfo
+
+      // Create unlock token for this specific lock acquisition with option
+      let unlockToken = LockmanUnlock(
+        id: boundaryId,
+        info: lockmanInfo,
+        strategy: strategy,
+        unlockOption: unlockOption
+      )
+
+      // Create unlock effect that executes the unlock operation
+      let unlockEffect = Effect<Action>.run { _ in
+        unlockToken()  // Execute unlock with configured option
+      }
+
+      // Create complete effect with conditional cancellation for operations only
+      let shouldBeCancellable = lockmanInfo.isCancellationTarget
+      let cancellableEffect = shouldBeCancellable ? self.cancellable(id: boundaryId) : self
+      let completeEffect = Effect<Action>.concatenate([cancellableEffect, unlockEffect])
+
+      // Handle lock acquisition result
+      switch lockResult {
+      case .success:
+        // Lock acquired successfully, execute complete effect immediately
+        return completeEffect
+
+      case .successWithPrecedingCancellation(let error):
+        // Lock acquired but need to cancel existing operation first
+        // Wrap the strategy error with action context
+        let cancellationError = LockmanCancellationError(
+          action: action,
+          boundaryId: boundaryId,
+          reason: error
+        )
+        if let handler = handler {
+          return .concatenate([
+            .run { send in await handler(cancellationError, send) },
+            .cancel(id: boundaryId),
+            completeEffect,
+          ])
+        }
+
+        return .concatenate([.cancel(id: boundaryId), completeEffect])
+
+      case .cancel(let error):
+        // Lock acquisition failed
+        // Wrap the strategy error with action context
+        let cancellationError = LockmanCancellationError(
+          action: action,
+          boundaryId: boundaryId,
+          reason: error
+        )
+        if let handler = handler {
+          return .run { send in
+            await handler(cancellationError, send)
+          }
+        }
+        return .none
+      @unknown default:
+        return .none
+      }
+
+    } catch {
+      // Handle and report strategy resolution errors
+      Effect.handleError(
+        error: error,
+        fileID: fileID,
+        filePath: filePath,
+        line: line,
+        column: column
+      )
+      if let handler = handler {
+        return .run { send in
+          await handler(error, send)
+        }
+      }
+      return .none
     }
   }
 
@@ -137,149 +341,5 @@ extension Effect {
       }
     }
   }
-
-  /// Builds an effect with lock acquisition and automatic unlock.
-  ///
-  /// ## Purpose
-  /// This internal method contains the common logic shared by all lock variants:
-  /// 1. Strategy resolution from the container
-  /// 2. Lock information extraction from the action
-  /// 3. Lock acquisition and result handling
-  /// 4. Direct effect concatenation with unlock effect
-  ///
-  /// ## Simplified Architecture
-  /// This method directly creates the unlock effect and concatenates it with the operations,
-  /// eliminating the need for complex closure patterns and intermediate wrappers.
-  ///
-  /// ## Error Handling Strategy
-  /// This method uses a do-catch pattern to handle strategy resolution errors.
-  /// If strategy resolution fails, it calls `handleError` to provide detailed
-  /// diagnostic information and optionally calls the provided handler before
-  /// returning `.none` to prevent effect execution.
-  ///
-  /// ## Type Safety
-  /// The method maintains type safety through generic constraints:
-  /// - `B: LockmanBoundaryId`: Ensures valid boundary identifier
-  /// - `A: LockmanAction`: Ensures valid action with lock information
-  /// - `A.I`: Preserves lock information type relationship
-  ///
-  /// ## Effect Execution Order
-  /// The returned effect executes in this order:
-  /// 1. Operations (cancellable as a group)
-  /// 2. Unlock effect (non-cancellable, always executes)
-  ///
-  /// - Parameters:
-  ///   - operations: Array of effects to execute while lock is held
-  ///   - action: LockmanAction providing lock information and strategy type
-  ///   - boundaryId: Unique identifier for cancellation and lock boundary
-  ///   - unlockOption: Unlock option configuration for when to execute the unlock
-  ///   - fileID: Source file ID for error reporting
-  ///   - filePath: Source file path for error reporting
-  ///   - line: Source line number for error reporting
-  ///   - column: Source column number for error reporting
-  ///   - handler: Optional error handler for lock acquisition failures
-  /// - Returns: Built effect, or `.none` if setup fails
-  static func buildLockEffect<B: LockmanBoundaryId, A: LockmanAction>(
-    operations: [Effect<Action>],
-    action: A,
-    boundaryId: B,
-    unlockOption: LockmanUnlockOption,
-    fileID: StaticString,
-    filePath: StaticString,
-    line: UInt,
-    column: UInt,
-    handler: (@Sendable (_ error: any Error, _ send: Send<Action>) async -> Void)? = nil
-  ) -> Effect<Action> {
-    do {
-      // Resolve the strategy from the container using strategyId
-      let strategy: AnyLockmanStrategy<A.I> = try LockmanManager.container.resolve(
-        id: action.lockmanInfo.strategyId,
-        expecting: A.I.self
-      )
-      let lockmanInfo = action.lockmanInfo
-
-      // Attempt to acquire lock
-      let lockResult = acquireLock(
-        lockmanInfo: lockmanInfo,
-        strategy: strategy,
-        boundaryId: boundaryId
-      )
-
-      // Create unlock token for this specific lock acquisition with option
-      let unlockToken = LockmanUnlock(
-        id: boundaryId,
-        info: lockmanInfo,
-        strategy: strategy,
-        unlockOption: unlockOption
-      )
-
-      // Create unlock effect that executes the unlock operation
-      let unlockEffect = Effect<Action>.run { _ in
-        unlockToken()  // Execute unlock with configured option
-      }
-
-      // Create complete effect with conditional cancellation for operations only
-      let shouldBeCancellable = action.lockmanInfo.isCancellationTarget
-      let finalOperations =
-        shouldBeCancellable
-        ? operations.map { $0.cancellable(id: boundaryId) }
-        : operations
-      let completeEffect = Effect<Action>.concatenate(finalOperations + [unlockEffect])
-
-      // Handle lock acquisition result
-      switch lockResult {
-      case .success:
-        // Lock acquired successfully, execute complete effect immediately
-        return completeEffect
-
-      case .successWithPrecedingCancellation(let error):
-        // Lock acquired but need to cancel existing operation first
-        // Wrap the strategy error with action context
-        let cancellationError = LockmanCancellationError(
-          action: action,
-          boundaryId: boundaryId,
-          reason: error
-        )
-        if let handler = handler {
-          return .concatenate([
-            .run { send in await handler(cancellationError, send) },
-            .cancel(id: boundaryId),
-            completeEffect,
-          ])
-        }
-
-        return .concatenate([.cancel(id: boundaryId), completeEffect])
-
-      case .cancel(let error):
-        // Lock acquisition failed
-        // Wrap the strategy error with action context
-        let cancellationError = LockmanCancellationError(
-          action: action,
-          boundaryId: boundaryId,
-          reason: error
-        )
-        if let handler = handler {
-          return .run { send in
-            await handler(cancellationError, send)
-          }
-        }
-        return .none
-      @unknown default:
-        return .none
-      }
-
-    } catch {
-      // Handle and report strategy resolution errors
-      handleError(
-        error: error,
-        fileID: fileID,
-        filePath: filePath,
-        line: line,
-        column: column
-      )
-      return .none
-    }
-  }
-
 
 }

--- a/Sources/Lockman/Composable/LockmanDynamicConditionReducer.swift
+++ b/Sources/Lockman/Composable/LockmanDynamicConditionReducer.swift
@@ -184,7 +184,8 @@ extension LockmanDynamicConditionReducer {
     line: UInt = #line,
     column: UInt = #column
   ) -> Effect<Action> {
-    let actionId = lockAction.lockmanInfo.actionId
+    let lockmanInfo = lockAction.lockmanInfo
+    let actionId = lockmanInfo.actionId
     let dynamicLockCondition = self.lockCondition
 
     // Step 1: Resolve strategies
@@ -196,7 +197,7 @@ extension LockmanDynamicConditionReducer {
         expecting: LockmanDynamicConditionInfo.self
       )
       actionStrategy = try LockmanManager.container.resolve(
-        id: lockAction.lockmanInfo.strategyId,
+        id: lockmanInfo.strategyId,
         expecting: LA.I.self
       )
     } catch {
@@ -219,6 +220,7 @@ extension LockmanDynamicConditionReducer {
       action: action,
       dynamicStrategy: dynamicStrategy,
       actionStrategy: actionStrategy,
+      lockmanInfo: lockmanInfo,
       lockmanAction: lockAction,
       actionId: actionId,
       boundaryId: boundaryId
@@ -231,6 +233,7 @@ extension LockmanDynamicConditionReducer {
       actionStrategy: actionStrategy,
       actionId: actionId,
       unlockOption: unlockOption ?? .immediate,
+      lockmanInfo: lockmanInfo,
       lockAction: lockAction,
       boundaryId: boundaryId,
       priority: priority,

--- a/Sources/Lockman/Composable/LockmanDynamicConditionReducer.swift
+++ b/Sources/Lockman/Composable/LockmanDynamicConditionReducer.swift
@@ -184,7 +184,7 @@ extension LockmanDynamicConditionReducer {
     line: UInt = #line,
     column: UInt = #column
   ) -> Effect<Action> {
-    let lockmanInfo = lockAction.lockmanInfo
+    let lockmanInfo = lockAction.createLockmanInfo()
     let actionId = lockmanInfo.actionId
     let dynamicLockCondition = self.lockCondition
 

--- a/Sources/Lockman/Composable/LockmanReducer.swift
+++ b/Sources/Lockman/Composable/LockmanReducer.swift
@@ -87,9 +87,9 @@ public struct LockmanReducer<Base: Reducer>: Reducer {
       let effectForLock: Effect<LockmanReducer<Base>.Action> = .none
 
       do {
-        // ✨ CRITICAL: Capture lockmanInfo once to ensure consistent uniqueId throughout lock lifecycle
-        // This prevents lock/unlock mismatches that occur when computed properties generate new UUIDs
-        let lockmanInfo = lockmanAction.lockmanInfo
+        // ✨ CRITICAL: Create lockmanInfo once to ensure consistent uniqueId throughout lock lifecycle
+        // This prevents lock/unlock mismatches that occur when methods are called multiple times
+        let lockmanInfo = lockmanAction.createLockmanInfo()
         let lockResult = try effectForLock.acquireLock(
           lockmanInfo: lockmanInfo,
           boundaryId: boundaryId

--- a/Sources/Lockman/Composable/LockmanReducer.swift
+++ b/Sources/Lockman/Composable/LockmanReducer.swift
@@ -2,35 +2,36 @@ import CasePaths
 import ComposableArchitecture
 import Foundation
 
-/// A reducer wrapper that applies Lockman locking to effects produced by actions conforming to `LockmanAction`.
+/// A reducer wrapper that applies Lockman locking with true lock-first behavior.
 ///
-/// ## Effect-Level Locking
+/// ## Lock-First Behavior
 ///
-/// **This reducer applies locking at the effect level**: Due to TCA's architectural constraints,
-/// state mutations in the base reducer occur synchronously before lock acquisition. However,
-/// effects are locked, ensuring exclusive control over async operations.
+/// **This reducer implements true lock-first behavior**: Lock acquisition feasibility is checked
+/// BEFORE the base reducer executes, preventing state mutations when locks cannot be acquired.
+/// This ensures complete exclusive control over both state changes and effects.
 ///
 /// ## Lock Execution Flow
-/// 1. **State Mutation**: Base reducer executes synchronously (state changes occur)
-/// 2. **Lock Acquisition**: Attempt to acquire lock for the returned effect
-/// 3. **Effect Execution**: Run effects ONLY if lock acquisition succeeds
-/// 4. **Automatic Unlock**: Release lock when effects complete
+/// 1. **Lock Feasibility Check**: Determine if lock can be acquired using strategy's `canLock`
+/// 2. **Conditional State Mutation**: Base reducer executes ONLY if lock acquisition succeeded
+/// 3. **Effect Execution**: Run effects with the already-acquired lock
+/// 4. **Automatic Unlock**: Release lock when effects complete or fail
 ///
 /// ## When Lock Fails
-/// - State mutations have already occurred (TCA limitation)
-/// - Effects are cancelled (`.none` is returned)
+/// - No state mutations occur (true lock-first behavior)
+/// - Base reducer is never called
 /// - Lock failure handler is invoked if provided
+/// - Effect returns `.none` (operation is completely cancelled)
 ///
-/// ## For True Lock-First Behavior
-/// Use `LockmanDynamicConditionReducer` with explicit `.lock()` calls for scenarios
-/// requiring lock acquisition before any state changes.
+/// ## Strategy Resolution
+/// The reducer uses Effect-based strategy resolution to work around Swift's existential type
+/// limitations, allowing type-safe strategy resolution before reducer execution.
 ///
 /// ## Example
 /// ```swift
 /// @Reducer
 /// struct Feature {
 ///   struct State: Equatable {
-///     var counter = 0  // ⚠️ This will be mutated before lock acquisition
+///     var counter = 0  // ✅ Only mutated when lock can be acquired
 ///   }
 ///
 ///   enum Action: LockmanSingleExecutionAction {
@@ -49,13 +50,13 @@ import Foundation
 ///     Reduce { state, action in
 ///       switch action {
 ///       case .increment:
-///         state.counter += 1  // ⚠️ Executes BEFORE lock acquisition
+///         state.counter += 1  // ✅ Executes ONLY after lock feasibility check
 ///         return .run { send in
-///           // This effect executes AFTER lock acquisition
+///           // This effect executes with the acquired lock
 ///           await performSideEffect()
 ///         }
 ///       case .decrement:
-///         state.counter -= 1  // ⚠️ Executes BEFORE lock acquisition
+///         state.counter -= 1  // ✅ Executes ONLY after lock feasibility check
 ///         return .none
 ///       }
 ///     }
@@ -81,17 +82,60 @@ public struct LockmanReducer<Base: Reducer>: Reducer {
         return self.base.reduce(into: &state, action: action)
       }
 
-      // Execute base reducer to get the effect (state mutations happen here)
-      let baseEffect = self.base.reduce(into: &state, action: action)
-      
-      // Apply lock to the effect - lock acquisition will happen before effect executes
-      // If lock cannot be acquired, the effect will not execute (returns .none)
-      return baseEffect.lock(
-        action: lockmanAction,
-        boundaryId: boundaryId,
-        unlockOption: unlockOption,
-        lockFailure: lockFailure
-      )
+      // ✨ LOCK-FIRST IMPLEMENTATION: Check lock feasibility BEFORE base.reduce()
+      let effectForLock: Effect<LockmanReducer<Base>.Action> = .none
+
+      do {
+        let lockmanInfo = lockmanAction.lockmanInfo
+        let lockResult = try effectForLock.acquireLock(
+          lockmanInfo: lockmanInfo,
+          boundaryId: boundaryId
+        )
+
+        // Make decision based on lock result BEFORE executing base reducer
+        switch lockResult {
+        case .success, .successWithPrecedingCancellation:
+          // ✅ Lock can be acquired - proceed with base reducer execution
+          let baseEffect = self.base.reduce(into: &state, action: action)
+
+          // Build effect with the existing lock result (lock is already acquired)
+          return baseEffect.buildLockEffect(
+            lockResult: lockResult,
+            action: lockmanAction,
+            lockmanInfo: lockmanInfo,
+            boundaryId: boundaryId,
+            unlockOption: unlockOption,
+            fileID: #fileID,
+            filePath: #filePath,
+            line: #line,
+            column: #column,
+            handler: lockFailure
+          )
+
+        case .cancel(let error):
+          // ❌ Lock cannot be acquired - do NOT execute base reducer
+          // State mutations are prevented, achieving true lock-first behavior
+          if let lockFailure = self.lockFailure {
+            return .run { send in
+              await lockFailure(error, send)
+            }
+          } else {
+            // No lock failure handler - return .none (effect is cancelled)
+            return .none
+          }
+        }
+
+      } catch {
+        // Strategy resolution failed - handle as lock failure
+        if let lockFailure = self.lockFailure {
+          return .run { send in
+            await lockFailure(error, send)
+          }
+        } else {
+          // No lock failure handler - return .none
+          return .none
+        }
+      }
     }
   }
 }

--- a/Sources/Lockman/Core/Strategies/CompositeStrategy/LockmanCompositeAction.swift
+++ b/Sources/Lockman/Core/Strategies/CompositeStrategy/LockmanCompositeAction.swift
@@ -14,7 +14,7 @@
 ///
 ///   let actionName = "myCompositeAction"
 ///
-///   var lockmanInfo: LockmanCompositeInfo2<I1, I2> {
+///   func createLockmanInfo() -> LockmanCompositeInfo2<I1, I2> {
 ///     LockmanCompositeInfo2(
 ///       actionId: actionName,
 ///       lockmanInfoForStrategy1: LockmanSingleExecutionInfo(actionId: actionName),
@@ -36,9 +36,9 @@ public protocol LockmanCompositeAction2: LockmanAction {
   /// The second strategy type used in the composite strategy.
   associatedtype S2: LockmanStrategy where S2.I == I2
 
-  /// Composite lock information containing details for both strategies.
+  /// Creates composite lock information containing details for both strategies.
   /// This includes action identifiers and strategy-specific information.
-  var lockmanInfo: LockmanCompositeInfo2<I1, I2> { get }
+  func createLockmanInfo() -> LockmanCompositeInfo2<I1, I2>
 }
 
 /// Protocol for actions that use composite locking behavior with 3 strategies.
@@ -64,9 +64,9 @@ public protocol LockmanCompositeAction3: LockmanAction {
   /// The third strategy type used in the composite strategy.
   associatedtype S3: LockmanStrategy where S3.I == I3
 
-  /// Composite lock information containing details for all three strategies.
+  /// Creates composite lock information containing details for all three strategies.
   /// This includes action identifiers and strategy-specific information.
-  var lockmanInfo: LockmanCompositeInfo3<I1, I2, I3> { get }
+  func createLockmanInfo() -> LockmanCompositeInfo3<I1, I2, I3>
 }
 
 /// Protocol for actions that use composite locking behavior with 4 strategies.
@@ -98,9 +98,9 @@ public protocol LockmanCompositeAction4: LockmanAction {
   /// The fourth strategy type used in the composite strategy.
   associatedtype S4: LockmanStrategy where S4.I == I4
 
-  /// Composite lock information containing details for all four strategies.
+  /// Creates composite lock information containing details for all four strategies.
   /// This includes action identifiers and strategy-specific information.
-  var lockmanInfo: LockmanCompositeInfo4<I1, I2, I3, I4> { get }
+  func createLockmanInfo() -> LockmanCompositeInfo4<I1, I2, I3, I4>
 }
 
 /// Protocol for actions that use composite locking behavior with 5 strategies.
@@ -138,9 +138,9 @@ public protocol LockmanCompositeAction5: LockmanAction {
   /// The fifth strategy type used in the composite strategy.
   associatedtype S5: LockmanStrategy where S5.I == I5
 
-  /// Composite lock information containing details for all five strategies.
+  /// Creates composite lock information containing details for all five strategies.
   /// This includes action identifiers and strategy-specific information.
-  var lockmanInfo: LockmanCompositeInfo5<I1, I2, I3, I4, I5> { get }
+  func createLockmanInfo() -> LockmanCompositeInfo5<I1, I2, I3, I4, I5>
 }
 
 // MARK: - Default Implementations

--- a/Sources/Lockman/Core/Strategies/DynamicConditionStrategy/LockmanDynamicConditionAction.swift
+++ b/Sources/Lockman/Core/Strategies/DynamicConditionStrategy/LockmanDynamicConditionAction.swift
@@ -64,8 +64,8 @@ extension LockmanDynamicConditionAction {
 
   // Strategy ID is now provided by lockmanInfo
 
-  /// Provides default lock info with always-success condition.
-  public var lockmanInfo: LockmanDynamicConditionInfo {
+  /// Creates default lock info with always-success condition.
+  public func createLockmanInfo() -> LockmanDynamicConditionInfo {
     LockmanDynamicConditionInfo(actionId: actionName)
   }
 }

--- a/Sources/Lockman/Core/Strategies/GroupCoordinationStrategy/LockmanGroupCoordinatedAction.swift
+++ b/Sources/Lockman/Core/Strategies/GroupCoordinationStrategy/LockmanGroupCoordinatedAction.swift
@@ -81,12 +81,12 @@ where I == LockmanGroupCoordinatedInfo {
   /// Actions with the same name within the same group cannot execute concurrently.
   var actionName: String { get }
 
-  /// Lock information that provides group coordination details.
+  /// Creates lock information that provides group coordination details.
   ///
-  /// This property must be implemented to specify:
+  /// This method must be implemented to specify:
   /// - The group ID(s) this action belongs to
   /// - The coordination role (leader or member)
-  var lockmanInfo: LockmanGroupCoordinatedInfo { get }
+  func createLockmanInfo() -> LockmanGroupCoordinatedInfo
 }
 
 // MARK: - Default Implementations

--- a/Sources/Lockman/Core/Strategies/SingleExecutionStrategy/LockmanPriorityBasedAction.swift
+++ b/Sources/Lockman/Core/Strategies/SingleExecutionStrategy/LockmanPriorityBasedAction.swift
@@ -1,7 +1,7 @@
 /// A `LockmanAction` subtype that enforces priority-based locking semantics.
 ///
 /// Conforming types must provide:
-/// - `lockmanInfo`: An instance of `LockmanPriorityBasedInfo` containing priority and lock information.
+/// - `createLockmanInfo()`: A method that creates `LockmanPriorityBasedInfo` instances containing priority and lock information.
 /// - `actionName`: A unique identifier used for naming locks.
 ///
 /// The priority-based locking system ensures that higher priority actions can preempt or override
@@ -12,19 +12,19 @@
 /// struct LoginAction: LockmanPriorityBasedAction {
 ///   let actionName = "login"
 ///
-///   var lockmanInfo: LockmanPriorityBasedInfo {
+///   func createLockmanInfo() -> LockmanPriorityBasedInfo {
 ///     priority(.high(.preferLater))
 ///   }
 /// }
 /// ```
 public protocol LockmanPriorityBasedAction: LockmanAction
 where I == LockmanPriorityBasedInfo {
-  /// Provides lock information, including the priority level, for this action.
+  /// Creates lock information, including the priority level, for this action.
   ///
   /// The priority level determines the action's precedence in lock conflict resolution.
   /// Higher priority actions can cancel lower priority ones, and equal priority actions
   /// follow the configured `SamePriorityPolicy`.
-  var lockmanInfo: LockmanPriorityBasedInfo { get }
+  func createLockmanInfo() -> LockmanPriorityBasedInfo
 
   /// A unique name identifying this action, used as part of the lock's identifier.
   ///
@@ -53,7 +53,7 @@ extension LockmanPriorityBasedAction {
   ///
   /// Example usage:
   /// ```swift
-  /// var lockmanInfo: LockmanPriorityBasedInfo {
+  /// func createLockmanInfo() -> LockmanPriorityBasedInfo {
   ///   priority(.high(.preferLater))
   /// }
   /// ```
@@ -74,7 +74,7 @@ extension LockmanPriorityBasedAction {
   ///
   /// Example usage:
   /// ```swift
-  /// var lockmanInfo: LockmanPriorityBasedInfo {
+  /// func createLockmanInfo() -> LockmanPriorityBasedInfo {
   ///   priority("_user123", .high(.preferLater))
   /// }
   /// ```

--- a/Sources/LockmanMacros/Internal/MemberGenerator.swift
+++ b/Sources/LockmanMacros/Internal/MemberGenerator.swift
@@ -245,39 +245,39 @@ func generateActionNameMembers(for enumDecl: EnumDeclSyntax) -> [DeclSyntax] {
 // Deprecated: generateStrategyTypeMembers is no longer used.
 // Strategy identification is now handled through strategyId instead of strategyType.
 
-/// Generates the `lockmanInfo` computed property for single execution actions.
+/// Generates the `createLockmanInfo()` method for single execution actions.
 ///
-/// This function creates a computed property that returns lock information
-/// specific to single execution strategies. The generated property creates
+/// This function creates a method that returns lock information
+/// specific to single execution strategies. The generated method creates
 /// a `LockmanSingleExecutionInfo` instance using the action name.
 ///
-/// ## Generated Property Structure
+/// ## Generated Method Structure
 /// ```swift
-/// var lockmanInfo: LockmanSingleExecutionInfo {
+/// func createLockmanInfo() -> LockmanSingleExecutionInfo {
 ///   .init(actionId: actionName)
 /// }
 /// ```
 ///
 /// ## Integration
-/// The generated property integrates with other generated members:
+/// The generated method integrates with other generated members:
 /// - Uses the `actionName` property for the action identifier
 /// - Returns the appropriate info type for the strategy
 /// - Maintains consistent access level with other members
 ///
 /// - Parameter enumDecl: The enum declaration to process
-/// - Returns: Array containing the generated property declaration
+/// - Returns: Array containing the generated method declaration
 func generateLockmanInfoMembers(for enumDecl: EnumDeclSyntax) -> [DeclSyntax] {
   let accessLevel = extractAccessLevel(from: enumDecl)
 
-  let propertyDeclaration = DeclSyntax(
+  let methodDeclaration = DeclSyntax(
     """
-    \(raw: accessLevel) var lockmanInfo: LockmanSingleExecutionInfo {
+    \(raw: accessLevel) func createLockmanInfo() -> LockmanSingleExecutionInfo {
       .init(actionId: actionName)
     }
     """
   )
 
-  return [propertyDeclaration]
+  return [methodDeclaration]
 }
 
 // MARK: - Switch Case Generation

--- a/Sources/LockmanMacros/LockmanCompositeStrategyMacro.swift
+++ b/Sources/LockmanMacros/LockmanCompositeStrategyMacro.swift
@@ -402,15 +402,15 @@ private func generateStrategyIdPropertyMulti(
     """
 }
 
-/// Generates the lockmanInfo property for 2-strategy compositions.
+/// Generates the createLockmanInfo method for 2-strategy compositions.
 ///
-/// This function creates a computed property that returns the composite
-/// lock information for 2-strategy combinations. The property integrates
+/// This function creates a method that returns the composite
+/// lock information for 2-strategy combinations. The method integrates
 /// with the protocol requirements to provide the necessary lock data.
 ///
-/// ## Generated Property Structure
+/// ## Generated Method Structure
 /// ```swift
-/// public var lockmanInfo: LockmanCompositeInfo2<S1.I, S2.I> {
+/// public func createLockmanInfo() -> LockmanCompositeInfo2<S1.I, S2.I> {
 ///   return LockmanCompositeInfo2(
 ///     actionId: actionName,
 ///     lockmanInfoForStrategy1: lockmanInfoForStrategy1,
@@ -420,7 +420,7 @@ private func generateStrategyIdPropertyMulti(
 /// ```
 ///
 /// ## Integration Points
-/// The generated property integrates with:
+/// The generated method integrates with:
 /// - `actionName` property for the action identifier
 /// - `lockmanInfoForStrategy1` and `lockmanInfoForStrategy2` protocol requirements
 /// - The composite info type system for type safety
@@ -428,15 +428,15 @@ private func generateStrategyIdPropertyMulti(
 /// - Parameters:
 ///   - strategy1: Name of the first strategy type
 ///   - strategy2: Name of the second strategy type
-///   - accessLevel: Access level for the property
-/// - Returns: Complete property declaration
+///   - accessLevel: Access level for the method
+/// - Returns: Complete method declaration
 private func generateLockmanInfoProperty2(
   strategy1: String,
   strategy2: String,
   accessLevel: String
 ) -> DeclSyntax {
   """
-  \(raw: accessLevel) var lockmanInfo: LockmanCompositeInfo2<\(raw: strategy1).I, \(raw: strategy2).I> {
+  \(raw: accessLevel) func createLockmanInfo() -> LockmanCompositeInfo2<\(raw: strategy1).I, \(raw: strategy2).I> {
     return LockmanCompositeInfo2(
       actionId: actionName,
       lockmanInfoForStrategy1: lockmanInfoForStrategy1,
@@ -446,15 +446,15 @@ private func generateLockmanInfoProperty2(
   """
 }
 
-/// Generates the lockmanInfo property for 3-strategy compositions.
+/// Generates the createLockmanInfo method for 3-strategy compositions.
 ///
-/// This function creates a computed property that returns the composite
+/// This function creates a method that returns the composite
 /// lock information for 3-strategy combinations.
 ///
 /// - Parameters:
 ///   - strategyNames: Array of strategy type names
-///   - accessLevel: Access level for the property
-/// - Returns: Complete property declaration
+///   - accessLevel: Access level for the method
+/// - Returns: Complete method declaration
 private func generateLockmanInfoProperty3(
   strategyNames: [String],
   accessLevel: String
@@ -464,7 +464,7 @@ private func generateLockmanInfoProperty3(
   let strategy3 = strategyNames[2]
 
   return """
-    \(raw: accessLevel) var lockmanInfo: LockmanCompositeInfo3<\(raw: strategy1).I, \(raw: strategy2).I, \(raw: strategy3).I> {
+    \(raw: accessLevel) func createLockmanInfo() -> LockmanCompositeInfo3<\(raw: strategy1).I, \(raw: strategy2).I, \(raw: strategy3).I> {
       return LockmanCompositeInfo3(
         actionId: actionName,
         lockmanInfoForStrategy1: lockmanInfoForStrategy1,
@@ -475,12 +475,12 @@ private func generateLockmanInfoProperty3(
     """
 }
 
-/// Generates the lockmanInfo property for 4-strategy compositions.
+/// Generates the createLockmanInfo method for 4-strategy compositions.
 ///
 /// - Parameters:
 ///   - strategyNames: Array of strategy type names
-///   - accessLevel: Access level for the property
-/// - Returns: Complete property declaration
+///   - accessLevel: Access level for the method
+/// - Returns: Complete method declaration
 private func generateLockmanInfoProperty4(
   strategyNames: [String],
   accessLevel: String
@@ -491,7 +491,7 @@ private func generateLockmanInfoProperty4(
   let strategy4 = strategyNames[3]
 
   return """
-    \(raw: accessLevel) var lockmanInfo: LockmanCompositeInfo4<\(raw: strategy1).I, \(raw: strategy2).I, \(raw: strategy3).I, \(raw: strategy4).I> {
+    \(raw: accessLevel) func createLockmanInfo() -> LockmanCompositeInfo4<\(raw: strategy1).I, \(raw: strategy2).I, \(raw: strategy3).I, \(raw: strategy4).I> {
       return LockmanCompositeInfo4(
         actionId: actionName,
         lockmanInfoForStrategy1: lockmanInfoForStrategy1,
@@ -503,12 +503,12 @@ private func generateLockmanInfoProperty4(
     """
 }
 
-/// Generates the lockmanInfo property for 5-strategy compositions.
+/// Generates the createLockmanInfo method for 5-strategy compositions.
 ///
 /// - Parameters:
 ///   - strategyNames: Array of strategy type names
-///   - accessLevel: Access level for the property
-/// - Returns: Complete property declaration
+///   - accessLevel: Access level for the method
+/// - Returns: Complete method declaration
 private func generateLockmanInfoProperty5(
   strategyNames: [String],
   accessLevel: String
@@ -520,7 +520,7 @@ private func generateLockmanInfoProperty5(
   let strategy5 = strategyNames[4]
 
   return """
-    \(raw: accessLevel) var lockmanInfo: LockmanCompositeInfo5<\(raw: strategy1).I, \(raw: strategy2).I, \(raw: strategy3).I, \(raw: strategy4).I, \(raw: strategy5).I> {
+    \(raw: accessLevel) func createLockmanInfo() -> LockmanCompositeInfo5<\(raw: strategy1).I, \(raw: strategy2).I, \(raw: strategy3).I, \(raw: strategy4).I, \(raw: strategy5).I> {
       return LockmanCompositeInfo5(
         actionId: actionName,
         lockmanInfoForStrategy1: lockmanInfoForStrategy1,
@@ -544,7 +544,7 @@ private func generateLockmanInfoProperty5(
 /// ## Generated Members
 /// - `actionName`: Maps enum cases to string identifiers
 /// - `strategyType`: Returns the composite strategy type
-/// - `lockmanInfo`: Provides composite lock information
+/// - `createLockmanInfo()`: Provides composite lock information
 ///
 /// ## Protocol Conformance
 /// The macro adds conformance to `LockmanCompositeAction2` which requires:
@@ -615,7 +615,7 @@ public struct LockmanCompositeStrategy2Macro: ExtensionMacro, MemberMacro {
   /// ## Generated Members
   /// 1. `actionName`: Switch-based property mapping cases to strings
   /// 2. `strategyType`: Property returning the composite strategy type
-  /// 3. `lockmanInfo`: Property providing composite lock information
+  /// 3. `createLockmanInfo()`: Method providing composite lock information
   ///
   /// ## Validation Process
   /// The method performs several validation steps:
@@ -667,7 +667,7 @@ public struct LockmanCompositeStrategy2Macro: ExtensionMacro, MemberMacro {
     )
     members.append(strategyIdProperty)
 
-    // Do not generate lockmanInfo property - user must implement it
+    // Do not generate createLockmanInfo method - user must implement it
     // This allows users to specify strategy-specific details like mode
 
     // Generate type aliases for protocol conformance
@@ -748,7 +748,7 @@ public struct LockmanCompositeStrategy3Macro: ExtensionMacro, MemberMacro {
     )
     members.append(strategyIdProperty)
 
-    // Do not generate lockmanInfo property - user must implement it
+    // Do not generate createLockmanInfo method - user must implement it
     // This allows users to specify strategy-specific details
 
     // Generate type aliases for protocol conformance
@@ -820,7 +820,7 @@ public struct LockmanCompositeStrategy4Macro: ExtensionMacro, MemberMacro {
     )
     members.append(strategyIdProperty)
 
-    // Do not generate lockmanInfo property - user must implement it
+    // Do not generate createLockmanInfo method - user must implement it
     // This allows users to specify strategy-specific details
 
     // Generate type aliases for protocol conformance
@@ -894,7 +894,7 @@ public struct LockmanCompositeStrategy5Macro: ExtensionMacro, MemberMacro {
     )
     members.append(strategyIdProperty)
 
-    // Do not generate lockmanInfo property - user must implement it
+    // Do not generate createLockmanInfo method - user must implement it
     // This allows users to specify strategy-specific details
 
     // Generate type aliases for protocol conformance

--- a/Sources/LockmanMacros/LockmanConcurrencyLimitedMacro.swift
+++ b/Sources/LockmanMacros/LockmanConcurrencyLimitedMacro.swift
@@ -81,7 +81,7 @@ extension LockmanConcurrencyLimitedMacro: MemberMacro {
 
 /// Generates member declarations specific to LockmanConcurrencyLimited actions.
 /// Currently generates only the `actionName` property. Users must implement
-/// `lockmanInfo` themselves to specify the concurrency group or limit.
+/// `createLockmanInfo()` themselves to specify the concurrency group or limit.
 ///
 /// - Parameter enumDecl: The `EnumDeclSyntax` representing the enum to process.
 /// - Returns: An array of `DeclSyntax` nodes containing the generated member declarations.
@@ -91,7 +91,7 @@ private func generateConcurrencyLimitedMembers(for enumDecl: EnumDeclSyntax) -> 
   // Generate standard actionName property
   members.append(contentsOf: generateActionNameMembers(for: enumDecl))
 
-  // Do NOT generate lockmanInfo - users must implement it themselves
+  // Do NOT generate createLockmanInfo method - users must implement it themselves
   // to specify the concurrency group or limit using the overloaded initializers
 
   return members

--- a/Sources/LockmanMacros/LockmanDynamicConditionMacro.swift
+++ b/Sources/LockmanMacros/LockmanDynamicConditionMacro.swift
@@ -13,7 +13,7 @@ import SwiftSyntaxMacros
 /// This macro:
 /// 1. Adds protocol conformance to `LockmanDynamicConditionAction`
 /// 2. Generates `actionName` property
-/// 3. Generates `lockmanInfo` property with default condition
+/// 3. Generates `createLockmanInfo()` method with default condition
 public struct LockmanDynamicConditionMacro: ExtensionMacro {
   /// Generates an extension that conforms to `LockmanDynamicConditionAction`.
   public static func expansion(
@@ -72,7 +72,7 @@ private func generateDynamicConditionMembers(for enumDecl: EnumDeclSyntax) -> [D
   // Generate actionName property
   members.append(contentsOf: generateActionNameMembers(for: enumDecl))
 
-  // Generate lockmanInfo property with default condition
+  // Generate createLockmanInfo method with default condition
   if let lockmanInfo = generateDefaultLockmanInfo(for: enumDecl) {
     members.append(lockmanInfo)
   }
@@ -80,18 +80,18 @@ private func generateDynamicConditionMembers(for enumDecl: EnumDeclSyntax) -> [D
   return members
 }
 
-/// Generates the default lockmanInfo property.
+/// Generates the default createLockmanInfo method.
 private func generateDefaultLockmanInfo(for enumDecl: EnumDeclSyntax) -> DeclSyntax? {
   let accessLevel = extractAccessLevel(from: enumDecl.modifiers)
 
-  let propertyDecl = """
+  let methodDecl = """
 
-    \(accessLevel) var lockmanInfo: LockmanDynamicConditionInfo {
+    \(accessLevel) func createLockmanInfo() -> LockmanDynamicConditionInfo {
       LockmanDynamicConditionInfo(
         actionId: actionName
       )
     }
     """
 
-  return DeclSyntax(stringLiteral: propertyDecl)
+  return DeclSyntax(stringLiteral: methodDecl)
 }

--- a/Sources/LockmanMacros/LockmanGroupCoordinationMacro.swift
+++ b/Sources/LockmanMacros/LockmanGroupCoordinationMacro.swift
@@ -45,7 +45,7 @@ struct SimpleDiagnosticMessage: DiagnosticMessage, Error {
 /// enum NavigationAction {
 ///   case navigate(to: String)
 ///
-///   var lockmanInfo: LockmanGroupCoordinatedInfo {
+///   func createLockmanInfo() -> LockmanGroupCoordinatedInfo {
 ///     switch self {
 ///     case .navigate:
 ///       return LockmanGroupCoordinatedInfo(

--- a/Sources/LockmanMacros/LockmanSingleExecutionMacro.swift
+++ b/Sources/LockmanMacros/LockmanSingleExecutionMacro.swift
@@ -81,7 +81,7 @@ extension LockmanSingleExecutionMacro: MemberMacro {
 
 /// Generates member declarations specific to LockmanSingleExecution actions.
 /// Currently generates only the `actionName` property. Users must implement
-/// `lockmanInfo` themselves to specify the execution mode.
+/// `createLockmanInfo()` themselves to specify the execution mode.
 ///
 /// - Parameter enumDecl: The `EnumDeclSyntax` representing the enum to process.
 /// - Returns: An array of `DeclSyntax` nodes containing the generated member declarations.
@@ -91,7 +91,7 @@ private func generateSingleExecutionMembers(for enumDecl: EnumDeclSyntax) -> [De
   // Generate standard actionName property
   members.append(contentsOf: generateActionNameMembers(for: enumDecl))
 
-  // Do NOT generate lockmanInfo - users must implement it themselves
+  // Do NOT generate createLockmanInfo method - users must implement it themselves
   // to specify the execution mode (.none, .boundary, or .action)
 
   return members

--- a/Tests/LockmanMacrosTests/LockmanDynamicConditionMacroTests.swift
+++ b/Tests/LockmanMacrosTests/LockmanDynamicConditionMacroTests.swift
@@ -31,7 +31,7 @@
               }
             }
 
-            internal var lockmanInfo: LockmanDynamicConditionInfo {
+            internal func createLockmanInfo() -> LockmanDynamicConditionInfo {
               LockmanDynamicConditionInfo(
                 actionId: actionName
               )
@@ -74,7 +74,7 @@
               }
             }
 
-            internal var lockmanInfo: LockmanDynamicConditionInfo {
+            internal func createLockmanInfo() -> LockmanDynamicConditionInfo {
               LockmanDynamicConditionInfo(
                 actionId: actionName
               )
@@ -113,7 +113,7 @@
               }
             }
 
-            internal var lockmanInfo: LockmanDynamicConditionInfo {
+            internal func createLockmanInfo() -> LockmanDynamicConditionInfo {
               LockmanDynamicConditionInfo(
                 actionId: actionName
               )
@@ -148,7 +148,7 @@
               }
             }
 
-            public var lockmanInfo: LockmanDynamicConditionInfo {
+            public func createLockmanInfo() -> LockmanDynamicConditionInfo {
               LockmanDynamicConditionInfo(
                 actionId: actionName
               )
@@ -187,7 +187,7 @@
               }
             }
 
-            internal var lockmanInfo: LockmanDynamicConditionInfo {
+            internal func createLockmanInfo() -> LockmanDynamicConditionInfo {
               LockmanDynamicConditionInfo(
                 actionId: actionName
               )
@@ -294,7 +294,7 @@
               }
             }
 
-            internal var lockmanInfo: LockmanDynamicConditionInfo {
+            internal func createLockmanInfo() -> LockmanDynamicConditionInfo {
               LockmanDynamicConditionInfo(
                 actionId: actionName
               )

--- a/Tests/LockmanTests/Composable/EffectAutomaticCancellationTests.swift
+++ b/Tests/LockmanTests/Composable/EffectAutomaticCancellationTests.swift
@@ -13,7 +13,7 @@ private enum AutoCancellationTestAction: Equatable, LockmanAction {
   case operationCancelled
   case lockFailed
 
-  var lockmanInfo: LockmanSingleExecutionInfo {
+  func createLockmanInfo() -> LockmanSingleExecutionInfo {
     switch self {
     case .startOperation:
       return LockmanSingleExecutionInfo(

--- a/Tests/LockmanTests/Composable/EffectImmediateUnlockTests.swift
+++ b/Tests/LockmanTests/Composable/EffectImmediateUnlockTests.swift
@@ -287,7 +287,7 @@ final class EffectImmediateUnlockTests: XCTestCase {
       }
     }
 
-    var lockmanInfo: LockmanPriorityBasedInfo {
+    func createLockmanInfo() -> LockmanPriorityBasedInfo {
       switch self {
       case .lowPriority:
         return LockmanPriorityBasedInfo(actionId: actionName, priority: .low(.exclusive))

--- a/Tests/LockmanTests/Composable/EffectLockMethodTests.swift
+++ b/Tests/LockmanTests/Composable/EffectLockMethodTests.swift
@@ -11,7 +11,7 @@ private enum TestFeatureAction: Equatable, LockmanAction {
   case fetchCompleted(Int)
   case lockFailed
 
-  var lockmanInfo: LockmanSingleExecutionInfo {
+  func createLockmanInfo() -> LockmanSingleExecutionInfo {
     switch self {
     case .fetch:
       return LockmanSingleExecutionInfo(

--- a/Tests/LockmanTests/Composable/EffectLockmanErrorTests.swift
+++ b/Tests/LockmanTests/Composable/EffectLockmanErrorTests.swift
@@ -25,7 +25,7 @@ final class EffectLockmanErrorTests: XCTestCase {
       LockmanStrategyId("MockUnregisteredStrategy")
     }
 
-    var lockmanInfo: LockmanSingleExecutionInfo {
+    func createLockmanInfo() -> LockmanSingleExecutionInfo {
       LockmanSingleExecutionInfo(actionId: actionName, mode: .boundary)
     }
   }
@@ -36,7 +36,7 @@ final class EffectLockmanErrorTests: XCTestCase {
 
     var actionName: String { "testAction" }
     var strategyId: LockmanStrategyId { .singleExecution }
-    var lockmanInfo: LockmanSingleExecutionInfo {
+    func createLockmanInfo() -> LockmanSingleExecutionInfo {
       LockmanSingleExecutionInfo(actionId: actionName, mode: .boundary)
     }
   }
@@ -379,7 +379,7 @@ final class EffectLockmanErrorTests: XCTestCase {
       case empty
       var actionName: String { "" }
       var strategyId: LockmanStrategyId { LockmanStrategyId("MockUnregisteredStrategy") }
-      var lockmanInfo: LockmanSingleExecutionInfo {
+      func createLockmanInfo() -> LockmanSingleExecutionInfo {
         LockmanSingleExecutionInfo(actionId: actionName, mode: .boundary)
       }
     }
@@ -404,7 +404,7 @@ final class EffectLockmanErrorTests: XCTestCase {
       case unicode
       var actionName: String { "🔒アクション测试🚀" }
       var strategyId: LockmanStrategyId { LockmanStrategyId("MockUnregisteredStrategy") }
-      var lockmanInfo: LockmanSingleExecutionInfo {
+      func createLockmanInfo() -> LockmanSingleExecutionInfo {
         LockmanSingleExecutionInfo(actionId: actionName, mode: .boundary)
       }
     }

--- a/Tests/LockmanTests/Composable/EffectLockmanExclusiveTests.swift
+++ b/Tests/LockmanTests/Composable/EffectLockmanExclusiveTests.swift
@@ -392,7 +392,7 @@ private struct TestFeature {
       }
     }
 
-    var lockmanInfo: LockmanSingleExecutionInfo {
+    func createLockmanInfo() -> LockmanSingleExecutionInfo {
       .init(actionId: actionName, mode: .boundary)
     }
 

--- a/Tests/LockmanTests/Composable/EffectLockmanPrecedingCancellationTests.swift
+++ b/Tests/LockmanTests/Composable/EffectLockmanPrecedingCancellationTests.swift
@@ -97,7 +97,7 @@ final class EffectWithLockPrecedingCancellationTests: XCTestCase {
       }
     }
 
-    var lockmanInfo: LockmanPriorityBasedInfo {
+    func createLockmanInfo() -> LockmanPriorityBasedInfo {
       switch self {
       case .lowPriority:
         return LockmanPriorityBasedInfo(actionId: actionName, priority: .low(.exclusive))

--- a/Tests/LockmanTests/Composable/EffectLockmanTests.swift
+++ b/Tests/LockmanTests/Composable/EffectLockmanTests.swift
@@ -438,7 +438,7 @@ private struct TestConcatenateWithLockFeature {
       }
     }
 
-    var lockmanInfo: LockmanSingleExecutionInfo {
+    func createLockmanInfo() -> LockmanSingleExecutionInfo {
       .init(actionId: actionName, mode: .boundary)
     }
 
@@ -536,7 +536,7 @@ private struct TestSingleExecutionFeature {
       }
     }
 
-    var lockmanInfo: LockmanSingleExecutionInfo {
+    func createLockmanInfo() -> LockmanSingleExecutionInfo {
       .init(actionId: actionName, mode: .boundary)
     }
 
@@ -605,7 +605,7 @@ private struct TestMultiIdFeature {
       }
     }
 
-    var lockmanInfo: LockmanSingleExecutionInfo {
+    func createLockmanInfo() -> LockmanSingleExecutionInfo {
       .init(actionId: actionName, mode: .boundary)
     }
 

--- a/Tests/LockmanTests/Composable/LockmanDynamicConditionReducerIntegrationTests.swift
+++ b/Tests/LockmanTests/Composable/LockmanDynamicConditionReducerIntegrationTests.swift
@@ -43,7 +43,7 @@ final class LockmanDynamicConditionReducerIntegrationTests: XCTestCase {
 
   struct TestLockAction: LockmanSingleExecutionAction {
     var actionName: String { "test" }
-    var lockmanInfo: LockmanSingleExecutionInfo {
+    func createLockmanInfo() -> LockmanSingleExecutionInfo {
       LockmanSingleExecutionInfo(actionId: actionName, mode: .boundary)
     }
   }
@@ -72,7 +72,7 @@ final class LockmanDynamicConditionReducerIntegrationTests: XCTestCase {
     // Get strategy reference
     let dynamicStrategy = LockmanDynamicConditionStrategy.shared
     let singleExecutionStrategy = LockmanSingleExecutionStrategy.shared
-    let cancelID = TestLockAction().lockmanInfo.actionId
+    let cancelID = TestLockAction().createLockmanInfo().actionId
 
     // Create a class to track lock states
     final class LockTracker: @unchecked Sendable {
@@ -181,7 +181,7 @@ final class LockmanDynamicConditionReducerIntegrationTests: XCTestCase {
   func testMultipleDynamicConditionLocksWithSameActionId() async {
     let dynamicStrategy = LockmanDynamicConditionStrategy.shared
     let actionId = "testAction"
-    let boundary = TestLockAction().lockmanInfo.actionId
+    let boundary = TestLockAction().createLockmanInfo().actionId
 
     // Create multiple dynamic condition infos with same actionId
     let info1 = LockmanDynamicConditionInfo(
@@ -218,7 +218,7 @@ final class LockmanDynamicConditionReducerIntegrationTests: XCTestCase {
   @MainActor
   func testDynamicConditionFailureDoesNotAcquireLock() async {
     let dynamicStrategy = LockmanDynamicConditionStrategy.shared
-    let cancelID = TestLockAction().lockmanInfo.actionId
+    let cancelID = TestLockAction().createLockmanInfo().actionId
 
     // Create a class to track operation execution
     final class ExecutionTracker: @unchecked Sendable {
@@ -248,7 +248,7 @@ final class LockmanDynamicConditionReducerIntegrationTests: XCTestCase {
               tracker.errorHandlerCalled = true
             },
             lockAction: TestLockAction(),
-            boundaryId: TestLockAction().lockmanInfo.actionId,
+            boundaryId: TestLockAction().createLockmanInfo().actionId,
             lockCondition: { _, _ in
               // Failing condition
               return .cancel(
@@ -298,7 +298,7 @@ final class LockmanDynamicConditionReducerIntegrationTests: XCTestCase {
   func disabled_testDynamicConditionLocksAreCleanedUpOnFailure() async {
     let dynamicStrategy = LockmanDynamicConditionStrategy.shared
     let singleExecutionStrategy = LockmanSingleExecutionStrategy.shared
-    let cancelID = TestLockAction().lockmanInfo.actionId
+    let cancelID = TestLockAction().createLockmanInfo().actionId
 
     final class EvaluationTracker: @unchecked Sendable {
       var step1Evaluated = false
@@ -332,7 +332,7 @@ final class LockmanDynamicConditionReducerIntegrationTests: XCTestCase {
               XCTFail("Operation should not execute when step 3 fails")
             },
             lockAction: TestLockAction(),
-            boundaryId: TestLockAction().lockmanInfo.actionId,
+            boundaryId: TestLockAction().createLockmanInfo().actionId,
             lockCondition: { _, _ in
               tracker.step2Evaluated = true
               return .success  // Step 2 also passes

--- a/Tests/LockmanTests/Composable/LockmanDynamicConditionReducerMethodChainTests.swift
+++ b/Tests/LockmanTests/Composable/LockmanDynamicConditionReducerMethodChainTests.swift
@@ -46,14 +46,14 @@ final class LockmanDynamicConditionReducerMethodChainTests: XCTestCase {
 
   struct IncrementAction: LockmanSingleExecutionAction {
     var actionName: String { "increment" }
-    var lockmanInfo: LockmanSingleExecutionInfo {
+    func createLockmanInfo() -> LockmanSingleExecutionInfo {
       LockmanSingleExecutionInfo(actionId: actionName, mode: .boundary)
     }
   }
 
   struct PurchaseAction: LockmanSingleExecutionAction {
     var actionName: String { "purchase" }
-    var lockmanInfo: LockmanSingleExecutionInfo {
+    func createLockmanInfo() -> LockmanSingleExecutionInfo {
       LockmanSingleExecutionInfo(actionId: actionName, mode: .boundary)
     }
   }

--- a/Tests/LockmanTests/Composable/NestedActionLockTests.swift
+++ b/Tests/LockmanTests/Composable/NestedActionLockTests.swift
@@ -15,7 +15,7 @@ private enum TestAction: Equatable {
   enum ViewAction: LockmanAction {
     case tap
 
-    var lockmanInfo: some LockmanInfo {
+    func createLockmanInfo() -> some LockmanInfo {
       LockmanSingleExecutionInfo(actionId: "tap", mode: .boundary)
     }
   }

--- a/Tests/LockmanTests/Composable/ReducerLockMethodTests.swift
+++ b/Tests/LockmanTests/Composable/ReducerLockMethodTests.swift
@@ -13,7 +13,7 @@ private enum TestReducerAction: Equatable, LockmanAction {
   case nonLockableResponse(String)
   case lockFailureAction
 
-  var lockmanInfo: LockmanSingleExecutionInfo {
+  func createLockmanInfo() -> LockmanSingleExecutionInfo {
     switch self {
     case .lockableAction:
       return LockmanSingleExecutionInfo(

--- a/Tests/LockmanTests/Composable/Swift59CrashInvestigationTests.swift
+++ b/Tests/LockmanTests/Composable/Swift59CrashInvestigationTests.swift
@@ -18,7 +18,7 @@ private enum FiveNestedAction: Equatable {
   enum NestedAction: LockmanAction, Equatable {
     case test
 
-    var lockmanInfo: some LockmanInfo {
+    func createLockmanInfo() -> some LockmanInfo {
       LockmanSingleExecutionInfo(actionId: "nested", mode: .boundary)
     }
   }
@@ -50,14 +50,14 @@ private enum RootLockmanAction: LockmanAction, Equatable {
   case another(AnotherAction)
   case last(LastAction)
 
-  var lockmanInfo: some LockmanInfo {
+  func createLockmanInfo() -> some LockmanInfo {
     LockmanSingleExecutionInfo(actionId: "root", mode: .boundary)
   }
 
   enum NestedAction: LockmanAction, Equatable {
     case test
 
-    var lockmanInfo: some LockmanInfo {
+    func createLockmanInfo() -> some LockmanInfo {
       LockmanSingleExecutionInfo(actionId: "nested", mode: .boundary)
     }
   }

--- a/Tests/LockmanTests/Core/Strategies/CompositeStrategy/LockmanCompositeActionTests.swift
+++ b/Tests/LockmanTests/Core/Strategies/CompositeStrategy/LockmanCompositeActionTests.swift
@@ -15,7 +15,7 @@ final class LockmanCompositeActionTests: XCTestCase {
 
     let actionName = "mockComposite2"
 
-    var lockmanInfo: LockmanCompositeInfo2<I1, I2> {
+    func createLockmanInfo() -> LockmanCompositeInfo2<I1, I2> {
       LockmanCompositeInfo2(
         strategyId: LockmanStrategyId(name: "MockComposite2"),
         actionId: actionName,
@@ -36,7 +36,7 @@ final class LockmanCompositeActionTests: XCTestCase {
 
     let actionName = "mockComposite3"
 
-    var lockmanInfo: LockmanCompositeInfo3<I1, I2, I3> {
+    func createLockmanInfo() -> LockmanCompositeInfo3<I1, I2, I3> {
       LockmanCompositeInfo3(
         strategyId: LockmanStrategyId(name: "MockComposite3"),
         actionId: actionName,
@@ -62,7 +62,7 @@ final class LockmanCompositeActionTests: XCTestCase {
 
     let actionName = "mockComposite4"
 
-    var lockmanInfo: LockmanCompositeInfo4<I1, I2, I3, I4> {
+    func createLockmanInfo() -> LockmanCompositeInfo4<I1, I2, I3, I4> {
       LockmanCompositeInfo4(
         strategyId: LockmanStrategyId(name: "MockComposite4"),
         actionId: actionName,
@@ -92,7 +92,7 @@ final class LockmanCompositeActionTests: XCTestCase {
 
     let actionName = "mockComposite5"
 
-    var lockmanInfo: LockmanCompositeInfo5<I1, I2, I3, I4, I5> {
+    func createLockmanInfo() -> LockmanCompositeInfo5<I1, I2, I3, I4, I5> {
       LockmanCompositeInfo5(
         strategyId: LockmanStrategyId(name: "MockComposite5"),
         actionId: actionName,
@@ -119,10 +119,10 @@ final class LockmanCompositeActionTests: XCTestCase {
     XCTAssertEqual(action.actionName, "mockComposite2")
 
     // Test strategy ID
-    XCTAssertEqual(action.lockmanInfo.strategyId.value, "MockComposite2")
+    XCTAssertEqual(action.createLockmanInfo().strategyId.value, "MockComposite2")
 
     // Test lockmanInfo
-    let lockmanInfo = action.lockmanInfo
+    let lockmanInfo = action.createLockmanInfo()
     XCTAssertEqual(lockmanInfo.actionId, "mockComposite2")
     XCTAssertEqual(lockmanInfo.lockmanInfoForStrategy1.actionId, "mockComposite2")
     XCTAssertEqual(lockmanInfo.lockmanInfoForStrategy2.actionId, "mockComposite2")
@@ -154,7 +154,7 @@ final class LockmanCompositeActionTests: XCTestCase {
 
     // Test that the composite strategy works
     let boundaryId = "test-boundary"
-    let info = action.lockmanInfo
+    let info = action.createLockmanInfo()
 
     XCTAssertEqual(compositeStrategy.canLock(boundaryId: boundaryId, info: info), .success)
     compositeStrategy.lock(boundaryId: boundaryId, info: info)
@@ -172,7 +172,7 @@ final class LockmanCompositeActionTests: XCTestCase {
     XCTAssertEqual(action.actionName, "mockComposite3")
 
     // Test lockmanInfo
-    let lockmanInfo = action.lockmanInfo
+    let lockmanInfo = action.createLockmanInfo()
     XCTAssertEqual(lockmanInfo.actionId, "mockComposite3")
     XCTAssertEqual(lockmanInfo.lockmanInfoForStrategy1.actionId, "mockComposite3-1")
     XCTAssertEqual(lockmanInfo.lockmanInfoForStrategy2.actionId, "mockComposite3-2")
@@ -200,7 +200,7 @@ final class LockmanCompositeActionTests: XCTestCase {
 
     // Test that the composite strategy works
     let boundaryId = "test-boundary"
-    let info = action.lockmanInfo
+    let info = action.createLockmanInfo()
 
     XCTAssertEqual(compositeStrategy.canLock(boundaryId: boundaryId, info: info), .success)
     compositeStrategy.lock(boundaryId: boundaryId, info: info)
@@ -216,7 +216,7 @@ final class LockmanCompositeActionTests: XCTestCase {
     XCTAssertEqual(action.actionName, "mockComposite4")
 
     // Test lockmanInfo
-    let lockmanInfo = action.lockmanInfo
+    let lockmanInfo = action.createLockmanInfo()
     XCTAssertEqual(lockmanInfo.actionId, "mockComposite4")
     XCTAssertEqual(lockmanInfo.lockmanInfoForStrategy1.actionId, "mockComposite4-1")
     XCTAssertEqual(lockmanInfo.lockmanInfoForStrategy2.actionId, "mockComposite4-2")
@@ -243,7 +243,7 @@ final class LockmanCompositeActionTests: XCTestCase {
 
     // Test that the composite strategy works
     let boundaryId = "test-boundary"
-    let info = action.lockmanInfo
+    let info = action.createLockmanInfo()
 
     XCTAssertEqual(compositeStrategy.canLock(boundaryId: boundaryId, info: info), .success)
   }
@@ -257,7 +257,7 @@ final class LockmanCompositeActionTests: XCTestCase {
     XCTAssertEqual(action.actionName, "mockComposite5")
 
     // Test lockmanInfo
-    let lockmanInfo = action.lockmanInfo
+    let lockmanInfo = action.createLockmanInfo()
     XCTAssertEqual(lockmanInfo.actionId, "mockComposite5")
     XCTAssertEqual(lockmanInfo.lockmanInfoForStrategy1.actionId, "mockComposite5-1")
     XCTAssertEqual(lockmanInfo.lockmanInfoForStrategy2.actionId, "mockComposite5-2")
@@ -287,7 +287,7 @@ final class LockmanCompositeActionTests: XCTestCase {
 
     // Test that the composite strategy works
     let boundaryId = "test-boundary"
-    let info = action.lockmanInfo
+    let info = action.createLockmanInfo()
 
     let result = compositeStrategy.canLock(boundaryId: boundaryId, info: info)
     XCTAssertEqual(result, .success)
@@ -311,21 +311,21 @@ final class LockmanCompositeActionTests: XCTestCase {
 
     // Verify we can access protocol requirements
     XCTAssertNotNil(
-      action2.lockmanInfo
+      action2.createLockmanInfo()
         as? LockmanCompositeInfo2<LockmanSingleExecutionInfo, LockmanPriorityBasedInfo>)
     XCTAssertNotNil(
-      action3.lockmanInfo
+      action3.createLockmanInfo()
         as? LockmanCompositeInfo3<
           LockmanSingleExecutionInfo, LockmanPriorityBasedInfo, LockmanSingleExecutionInfo
         >)
     XCTAssertNotNil(
-      action4.lockmanInfo
+      action4.createLockmanInfo()
         as? LockmanCompositeInfo4<
           LockmanSingleExecutionInfo, LockmanPriorityBasedInfo, LockmanSingleExecutionInfo,
           LockmanPriorityBasedInfo
         >)
     XCTAssertNotNil(
-      action5.lockmanInfo
+      action5.createLockmanInfo()
         as? LockmanCompositeInfo5<
           LockmanSingleExecutionInfo, LockmanPriorityBasedInfo, LockmanSingleExecutionInfo,
           LockmanPriorityBasedInfo, LockmanSingleExecutionInfo

--- a/Tests/LockmanTests/Core/Strategies/GroupCoordinationStrategy/LockmanGroupCoordinatedActionTests.swift
+++ b/Tests/LockmanTests/Core/Strategies/GroupCoordinationStrategy/LockmanGroupCoordinatedActionTests.swift
@@ -11,7 +11,7 @@ final class LockmanGroupCoordinatedActionTests: XCTestCase {
   private struct StartLoadingAction: LockmanGroupCoordinatedAction {
     let actionName = "startLoading"
 
-    var lockmanInfo: LockmanGroupCoordinatedInfo {
+    func createLockmanInfo() -> LockmanGroupCoordinatedInfo {
       LockmanGroupCoordinatedInfo(
         actionId: actionName,
         groupId: "dataLoading",
@@ -24,7 +24,7 @@ final class LockmanGroupCoordinatedActionTests: XCTestCase {
   private struct UpdateProgressAction: LockmanGroupCoordinatedAction {
     let actionName = "updateProgress"
 
-    var lockmanInfo: LockmanGroupCoordinatedInfo {
+    func createLockmanInfo() -> LockmanGroupCoordinatedInfo {
       LockmanGroupCoordinatedInfo(
         actionId: actionName,
         groupId: "dataLoading",
@@ -37,7 +37,7 @@ final class LockmanGroupCoordinatedActionTests: XCTestCase {
   private struct MultiGroupAction: LockmanGroupCoordinatedAction {
     let actionName = "multiGroupOperation"
 
-    var lockmanInfo: LockmanGroupCoordinatedInfo {
+    func createLockmanInfo() -> LockmanGroupCoordinatedInfo {
       LockmanGroupCoordinatedInfo(
         actionId: actionName,
         groupIds: ["navigation", "dataLoading", "ui"],
@@ -63,7 +63,7 @@ final class LockmanGroupCoordinatedActionTests: XCTestCase {
       }
     }
 
-    var lockmanInfo: LockmanGroupCoordinatedInfo {
+    func createLockmanInfo() -> LockmanGroupCoordinatedInfo {
       let screenId: String
       switch self {
       case .startNavigation(let id),
@@ -100,7 +100,7 @@ final class LockmanGroupCoordinatedActionTests: XCTestCase {
       self.coordinationRole = role
     }
 
-    var lockmanInfo: LockmanGroupCoordinatedInfo {
+    func createLockmanInfo() -> LockmanGroupCoordinatedInfo {
       LockmanGroupCoordinatedInfo(
         actionId: actionName,
         groupId: groupId,
@@ -118,10 +118,10 @@ final class LockmanGroupCoordinatedActionTests: XCTestCase {
     XCTAssertEqual(action.actionName, "startLoading")
 
     // Test automatic strategyId
-    XCTAssertEqual(action.lockmanInfo.strategyId, .groupCoordination)
+    XCTAssertEqual(action.createLockmanInfo().strategyId, .groupCoordination)
 
     // Test lockmanInfo
-    let info = action.lockmanInfo
+    let info = action.createLockmanInfo()
     XCTAssertEqual(info.actionId, "startLoading")
     XCTAssertEqual(info.groupIds, [AnyLockmanGroupId("dataLoading")])
     XCTAssertEqual(info.coordinationRole, .none)
@@ -132,9 +132,9 @@ final class LockmanGroupCoordinatedActionTests: XCTestCase {
     let action = UpdateProgressAction()
 
     XCTAssertEqual(action.actionName, "updateProgress")
-    XCTAssertEqual(action.lockmanInfo.strategyId, .groupCoordination)
+    XCTAssertEqual(action.createLockmanInfo().strategyId, .groupCoordination)
 
-    let info = action.lockmanInfo
+    let info = action.createLockmanInfo()
     XCTAssertEqual(info.actionId, "updateProgress")
     XCTAssertEqual(info.groupIds, [AnyLockmanGroupId("dataLoading")])
     XCTAssertEqual(info.coordinationRole, .member)
@@ -145,7 +145,7 @@ final class LockmanGroupCoordinatedActionTests: XCTestCase {
     let startNav = NavigationAction.startNavigation(screenId: "detail")
     XCTAssertEqual(startNav.actionName, "startNavigation")
 
-    let startInfo = startNav.lockmanInfo
+    let startInfo = startNav.createLockmanInfo()
     XCTAssertEqual(startInfo.groupIds, [AnyLockmanGroupId("navigation-detail")])
     XCTAssertEqual(startInfo.coordinationRole, .none)
 
@@ -153,20 +153,20 @@ final class LockmanGroupCoordinatedActionTests: XCTestCase {
     let animate = NavigationAction.animateTransition(screenId: "detail")
     XCTAssertEqual(animate.actionName, "animateTransition")
 
-    let animateInfo = animate.lockmanInfo
+    let animateInfo = animate.createLockmanInfo()
     XCTAssertEqual(animateInfo.groupIds, [AnyLockmanGroupId("navigation-detail")])
     XCTAssertEqual(animateInfo.coordinationRole, .member)
 
     let complete = NavigationAction.completeNavigation(screenId: "detail")
     XCTAssertEqual(complete.actionName, "completeNavigation")
 
-    let completeInfo = complete.lockmanInfo
+    let completeInfo = complete.createLockmanInfo()
     XCTAssertEqual(completeInfo.groupIds, [AnyLockmanGroupId("navigation-detail")])
     XCTAssertEqual(completeInfo.coordinationRole, .member)
 
     // Different screen IDs create different groups
     let otherNav = NavigationAction.startNavigation(screenId: "settings")
-    let otherInfo = otherNav.lockmanInfo
+    let otherInfo = otherNav.createLockmanInfo()
     XCTAssertEqual(otherInfo.groupIds, [AnyLockmanGroupId("navigation-settings")])
   }
 
@@ -185,25 +185,25 @@ final class LockmanGroupCoordinatedActionTests: XCTestCase {
     )
 
     XCTAssertEqual(leader.actionName, "fetchData")
-    let leaderInfo = leader.lockmanInfo
+    let leaderInfo = leader.createLockmanInfo()
     XCTAssertEqual(leaderInfo.groupIds, [AnyLockmanGroupId("api-users")])
     XCTAssertEqual(leaderInfo.coordinationRole, .none)
 
     XCTAssertEqual(member.actionName, "cacheData")
-    let memberInfo = member.lockmanInfo
+    let memberInfo = member.createLockmanInfo()
     XCTAssertEqual(memberInfo.groupIds, [AnyLockmanGroupId("api-users")])
     XCTAssertEqual(memberInfo.coordinationRole, .member)
 
     // Both use the same strategy
-    XCTAssertEqual(leader.lockmanInfo.strategyId, .groupCoordination)
-    XCTAssertEqual(member.lockmanInfo.strategyId, .groupCoordination)
+    XCTAssertEqual(leader.createLockmanInfo().strategyId, .groupCoordination)
+    XCTAssertEqual(member.createLockmanInfo().strategyId, .groupCoordination)
   }
 
   // MARK: - LockmanInfo Generation Tests
 
   func testGeneratedLockmanInfoHasCorrectProperties() {
     let action = StartLoadingAction()
-    let info = action.lockmanInfo
+    let info = action.createLockmanInfo()
 
     // Verify type
     XCTAssertTrue(type(of: info) == LockmanGroupCoordinatedInfo.self)
@@ -214,7 +214,7 @@ final class LockmanGroupCoordinatedActionTests: XCTestCase {
     XCTAssertEqual(info.coordinationRole, .none)
 
     // Each call generates new unique ID
-    let info2 = action.lockmanInfo
+    let info2 = action.createLockmanInfo()
     XCTAssertNotEqual(info.uniqueId, info2.uniqueId)
   }
 
@@ -222,8 +222,8 @@ final class LockmanGroupCoordinatedActionTests: XCTestCase {
     let action1 = StartLoadingAction()
     let action2 = UpdateProgressAction()
 
-    let info1 = action1.lockmanInfo
-    let info2 = action2.lockmanInfo
+    let info1 = action1.createLockmanInfo()
+    let info2 = action2.createLockmanInfo()
 
     // Different action IDs
     XCTAssertNotEqual(info1.actionId, info2.actionId)
@@ -249,12 +249,12 @@ final class LockmanGroupCoordinatedActionTests: XCTestCase {
     let progressAction = UpdateProgressAction()
 
     // Leader can start
-    let startInfo = startAction.lockmanInfo
+    let startInfo = startAction.createLockmanInfo()
     XCTAssertEqual(strategy.canLock(boundaryId: boundaryId, info: startInfo), .success)
     strategy.lock(boundaryId: boundaryId, info: startInfo)
 
     // Member can join
-    let progressInfo = progressAction.lockmanInfo
+    let progressInfo = progressAction.createLockmanInfo()
     XCTAssertEqual(strategy.canLock(boundaryId: boundaryId, info: progressInfo), .success)
     strategy.lock(boundaryId: boundaryId, info: progressInfo)
 
@@ -272,8 +272,8 @@ final class LockmanGroupCoordinatedActionTests: XCTestCase {
     let navSettings = NavigationAction.startNavigation(screenId: "settings")
 
     // Both can start (different groups)
-    let detailInfo = navDetail.lockmanInfo
-    let settingsInfo = navSettings.lockmanInfo
+    let detailInfo = navDetail.createLockmanInfo()
+    let settingsInfo = navSettings.createLockmanInfo()
 
     // Debug: check what groupIds are being generated
     XCTAssertEqual(detailInfo.groupIds, [AnyLockmanGroupId("navigation-detail")])
@@ -290,9 +290,9 @@ final class LockmanGroupCoordinatedActionTests: XCTestCase {
     let animateSettings = NavigationAction.animateTransition(screenId: "settings")
 
     XCTAssertEqual(
-      strategy.canLock(boundaryId: boundaryId, info: animateDetail.lockmanInfo), .success)
+      strategy.canLock(boundaryId: boundaryId, info: animateDetail.createLockmanInfo()), .success)
     XCTAssertEqual(
-      strategy.canLock(boundaryId: boundaryId, info: animateSettings.lockmanInfo), .success)
+      strategy.canLock(boundaryId: boundaryId, info: animateSettings.createLockmanInfo()), .success)
   }
 
   // MARK: - Multiple Groups Tests
@@ -301,9 +301,9 @@ final class LockmanGroupCoordinatedActionTests: XCTestCase {
     let action = MultiGroupAction()
 
     XCTAssertEqual(action.actionName, "multiGroupOperation")
-    XCTAssertEqual(action.lockmanInfo.strategyId, .groupCoordination)
+    XCTAssertEqual(action.createLockmanInfo().strategyId, .groupCoordination)
 
-    let info = action.lockmanInfo
+    let info = action.createLockmanInfo()
     XCTAssertEqual(info.actionId, "multiGroupOperation")
     XCTAssertEqual(
       info.groupIds,
@@ -316,7 +316,7 @@ final class LockmanGroupCoordinatedActionTests: XCTestCase {
     struct SingleGroupDynamicAction: LockmanGroupCoordinatedAction {
       let actionName = "dynamic"
 
-      var lockmanInfo: LockmanGroupCoordinatedInfo {
+      func createLockmanInfo() -> LockmanGroupCoordinatedInfo {
         LockmanGroupCoordinatedInfo(
           actionId: actionName,
           groupId: "singleGroup",
@@ -328,7 +328,7 @@ final class LockmanGroupCoordinatedActionTests: XCTestCase {
     struct MultiGroupDynamicAction: LockmanGroupCoordinatedAction {
       let actionName = "dynamic"
 
-      var lockmanInfo: LockmanGroupCoordinatedInfo {
+      func createLockmanInfo() -> LockmanGroupCoordinatedInfo {
         LockmanGroupCoordinatedInfo(
           actionId: actionName,
           groupIds: ["group1", "group2"],
@@ -339,12 +339,12 @@ final class LockmanGroupCoordinatedActionTests: XCTestCase {
 
     // Single group mode
     let singleMode = SingleGroupDynamicAction()
-    let singleInfo = singleMode.lockmanInfo
+    let singleInfo = singleMode.createLockmanInfo()
     XCTAssertEqual(singleInfo.groupIds, [AnyLockmanGroupId("singleGroup")])
 
     // Multiple group mode
     let multiMode = MultiGroupDynamicAction()
-    let multiInfo = multiMode.lockmanInfo
+    let multiInfo = multiMode.createLockmanInfo()
     XCTAssertEqual(multiInfo.groupIds, [AnyLockmanGroupId("group1"), AnyLockmanGroupId("group2")])
   }
 
@@ -359,7 +359,7 @@ final class LockmanGroupCoordinatedActionTests: XCTestCase {
 
     XCTAssertEqual(action.actionName, "")
 
-    let info = action.lockmanInfo
+    let info = action.createLockmanInfo()
     XCTAssertEqual(info.actionId, "")
     XCTAssertEqual(info.groupIds, [AnyLockmanGroupId("")])
   }
@@ -373,7 +373,7 @@ final class LockmanGroupCoordinatedActionTests: XCTestCase {
 
     XCTAssertEqual(action.actionName, "action@#$%")
 
-    let info = action.lockmanInfo
+    let info = action.createLockmanInfo()
     XCTAssertEqual(info.actionId, "action@#$%")
     XCTAssertEqual(info.groupIds, [AnyLockmanGroupId("group-with-特殊文字-🔒")])
   }

--- a/Tests/LockmanTests/Core/Strategies/PriorityBasedStrategy/LockmanPriorityBasedActionTests.swift
+++ b/Tests/LockmanTests/Core/Strategies/PriorityBasedStrategy/LockmanPriorityBasedActionTests.swift
@@ -27,7 +27,7 @@ private struct TestPriorityAction: LockmanPriorityBasedAction {
   let actionName: String
   private let _priority: LockmanPriorityBasedInfo.Priority
 
-  var lockmanInfo: LockmanPriorityBasedInfo {
+  func createLockmanInfo() -> LockmanPriorityBasedInfo {
     LockmanPriorityBasedInfo(actionId: actionName, priority: _priority)
   }
 
@@ -67,7 +67,7 @@ private struct DynamicPriorityAction: LockmanPriorityBasedAction {
   let actionName: String
   private var _priority: LockmanPriorityBasedInfo.Priority
 
-  var lockmanInfo: LockmanPriorityBasedInfo {
+  func createLockmanInfo() -> LockmanPriorityBasedInfo {
     LockmanPriorityBasedInfo(actionId: actionName, priority: _priority)
   }
 
@@ -94,8 +94,8 @@ final class LockmanPriorityBasedActionTests: XCTestCase {
     let action = TestPriorityAction.lowExclusive("testAction")
 
     XCTAssertEqual(action.actionName, "testAction")
-    XCTAssertEqual(action.lockmanInfo.actionId, "testAction")
-    XCTAssertEqual(action.lockmanInfo.priority, .low(.exclusive))
+    XCTAssertEqual(action.createLockmanInfo().actionId, "testAction")
+    XCTAssertEqual(action.createLockmanInfo().priority, .low(.exclusive))
     XCTAssertTrue(action.strategyType == LockmanPriorityBasedStrategy.self)
   }
 
@@ -110,7 +110,7 @@ final class LockmanPriorityBasedActionTests: XCTestCase {
       ]
 
     for (action, expectedPriority) in testCases {
-      XCTAssertEqual(action.lockmanInfo.priority, expectedPriority)
+      XCTAssertEqual(action.createLockmanInfo().priority, expectedPriority)
     }
   }
 
@@ -181,7 +181,7 @@ final class LockmanPriorityBasedActionTests: XCTestCase {
     let action = TestPriorityAction.highExclusive("test")
 
     // Original lockmanInfo should remain unchanged
-    XCTAssertEqual(action.lockmanInfo.priority, .high(.exclusive))
+    XCTAssertEqual(action.createLockmanInfo().priority, .high(.exclusive))
 
     // New info should be different
     let newInfo = action.priority(.low(.replaceable))
@@ -189,7 +189,7 @@ final class LockmanPriorityBasedActionTests: XCTestCase {
     XCTAssertEqual(newInfo.actionId, "test")
 
     // Original should still be unchanged
-    XCTAssertEqual(action.lockmanInfo.priority, .high(.exclusive))
+    XCTAssertEqual(action.createLockmanInfo().priority, .high(.exclusive))
   }
 
   // MARK: - Description and String Representation (Removed)
@@ -199,7 +199,7 @@ final class LockmanPriorityBasedActionTests: XCTestCase {
   func testDynamicPriorityActionSupportsRuntimeChanges() {
     var action = DynamicPriorityAction(actionName: "dynamic", priority: .low(.exclusive))
 
-    XCTAssertEqual(action.lockmanInfo.priority, .low(.exclusive))
+    XCTAssertEqual(action.createLockmanInfo().priority, .low(.exclusive))
     XCTAssertEqual(action.actionName, "dynamic")
 
     // Test priority updates
@@ -211,7 +211,7 @@ final class LockmanPriorityBasedActionTests: XCTestCase {
 
     for newPriority in priorityUpdates {
       action.updatePriority(newPriority)
-      XCTAssertEqual(action.lockmanInfo.priority, newPriority)
+      XCTAssertEqual(action.createLockmanInfo().priority, newPriority)
     }
   }
 
@@ -241,12 +241,12 @@ final class LockmanPriorityBasedActionTests: XCTestCase {
     let action3 = TestPriorityAction.lowExclusive("differentAction")
 
     // Same actionId but different instances
-    XCTAssertEqual(action1.lockmanInfo.actionId, action2.lockmanInfo.actionId)
-    XCTAssertNotEqual(action1.lockmanInfo, action2.lockmanInfo)  // Different uniqueId
+    XCTAssertEqual(action1.createLockmanInfo().actionId, action2.createLockmanInfo().actionId)
+    XCTAssertNotEqual(action1.createLockmanInfo(), action2.createLockmanInfo())  // Different uniqueId
 
     // Different actionIds
-    XCTAssertNotEqual(action1.lockmanInfo.actionId, action3.lockmanInfo.actionId)
-    XCTAssertNotEqual(action2.lockmanInfo.actionId, action3.lockmanInfo.actionId)
+    XCTAssertNotEqual(action1.createLockmanInfo().actionId, action3.createLockmanInfo().actionId)
+    XCTAssertNotEqual(action2.createLockmanInfo().actionId, action3.createLockmanInfo().actionId)
   }
 
   // MARK: - Error Handling
@@ -298,7 +298,7 @@ final class LockmanPriorityBasedActionTests: XCTestCase {
   //
   //    // Runtime verification
   //    let action = TestPriorityAction.highExclusive()
-  //    XCTAssertTrue(action.lockmanInfo is LockmanPriorityBasedInfo)
+  //    XCTAssertTrue(action.createLockmanInfo() is LockmanPriorityBasedInfo)
   //  }
   //
   //  //  func testProtocolInheritanceHierarchyWorksCorrectly() {
@@ -331,7 +331,7 @@ final class LockmanPriorityBasedActionTests: XCTestCase {
     for name in specialNames {
       let action = TestPriorityAction.highReplaceable(name)
       XCTAssertEqual(action.actionName, name)
-      XCTAssertEqual(action.lockmanInfo.actionId, name)
+      XCTAssertEqual(action.createLockmanInfo().actionId, name)
 
       // Should work with priority methods
       let infoWithSuffix = action.priority("_test", .low(.exclusive))
@@ -343,7 +343,7 @@ final class LockmanPriorityBasedActionTests: XCTestCase {
     let action = TestPriorityAction.none("")
 
     XCTAssertEqual(action.actionName, "")
-    XCTAssertEqual(action.lockmanInfo.actionId, "")
+    XCTAssertEqual(action.createLockmanInfo().actionId, "")
 
     // Should work with priority methods
     let infoWithSuffix = action.priority("_suffix", .high(.exclusive))


### PR DESCRIPTION
## Summary

Change `LockmanAction` protocol's `lockmanInfo` property to `createLockmanInfo()` method to clarify that this should only be called once per lock operation. This prevents lock/unlock mismatches due to different `uniqueId` values generated from multiple calls.

## Background

Previously, `action.lockmanInfo` was called multiple times throughout the lock acquisition and release process, generating different `uniqueId` values each time due to the computed property nature. This caused lock/unlock mismatches where:
- Lock acquisition used uniqueId A (from first `action.lockmanInfo` call)
- Unlock operation used uniqueId B (from second `action.lockmanInfo` call)
- Since A ≠ B, the unlock failed and locks remained active

## Changes

### Core Protocol Update
- Changed `LockmanAction` from `var lockmanInfo: I { get }` to `func createLockmanInfo() -> I`
- Updated documentation to emphasize calling once per operation for consistent `uniqueId`

### Source Code Updates
- Updated `Effect+Lockman.swift` to use `action.createLockmanInfo()`
- Updated `LockmanReducer.swift` to use `lockmanAction.createLockmanInfo()`
- Updated `LockmanDynamicConditionReducer.swift` to use `lockAction.createLockmanInfo()`
- Updated all strategy action protocols to use method signature

### Macro Updates
- Updated all macro implementations to generate `createLockmanInfo()` methods instead of properties
- Updated documentation in macro-generated code to reflect new pattern
- Changed `MemberGenerator` to create methods instead of properties

### Test Updates
- Updated all test files (32 files) to use new method pattern
- Changed `var lockmanInfo` implementations to `func createLockmanInfo()`
- Updated test assertions to call `.createLockmanInfo()` method

## Breaking Change

⚠️ **This is a breaking change** that requires updating all `LockmanAction` implementations from property to method pattern:

**Before:**
```swift
var lockmanInfo: LockmanSingleExecutionInfo {
  .init(actionId: actionName, mode: .boundary)
}
```

**After:**
```swift
func createLockmanInfo() -> LockmanSingleExecutionInfo {
  .init(actionId: actionName, mode: .boundary)
}
```

## Testing

- ✅ All existing tests pass
- ✅ Verified proper lock/unlock behavior with consistent `uniqueId` values
- ✅ Confirmed macro-generated code works correctly
- ✅ No functional regressions detected

## Benefits

1. **Clearer Intent**: Method name makes it obvious this should be called once
2. **Consistent uniqueId**: Encourages capturing the result and reusing it
3. **Better Lock Management**: Prevents lock/unlock mismatches
4. **Improved Documentation**: Method signature is self-documenting

🤖 Generated with [Claude Code](https://claude.ai/code)