### PR TITLE
fix: remove unnecessary LockmanCancellationError conditions in Examples

### DIFF
--- a/Examples/Strategies/Strategies/01-SingleExecutionStrategy.swift
+++ b/Examples/Strategies/Strategies/01-SingleExecutionStrategy.swift
@@ -96,14 +96,7 @@ struct SingleExecutionStrategyFeature {
       return .none
 
     case .handleLockFailure(let error):
-      if let cancellationError = error as? LockmanCancellationError {
-        // Handle cancellation errors that contain the actual strategy errors
-        if cancellationError.reason is LockmanSingleExecutionError {
-          state.taskStatus = .blocked
-        } else {
-          state.taskStatus = .failed("Lock acquisition failed")
-        }
-      } else if error is LockmanSingleExecutionError {
+      if error is LockmanSingleExecutionError {
         state.taskStatus = .blocked
       } else {
         state.taskStatus = .failed("Lock acquisition failed")

--- a/Examples/Strategies/Strategies/03-ConcurrencyLimitedStrategy.swift
+++ b/Examples/Strategies/Strategies/03-ConcurrencyLimitedStrategy.swift
@@ -70,7 +70,9 @@ struct ConcurrencyLimitedStrategyFeature {
         }
       }
 
-      func createLockmanInfo() -> LockmanCompositeInfo2<LockmanSingleExecutionInfo, LockmanConcurrencyLimitedInfo> {
+      func createLockmanInfo() -> LockmanCompositeInfo2<
+        LockmanSingleExecutionInfo, LockmanConcurrencyLimitedInfo
+      > {
         LockmanCompositeInfo2(
           strategyId: strategyId,  // Use macro-generated strategyId
           actionId: actionId,
@@ -109,13 +111,7 @@ struct ConcurrencyLimitedStrategyFeature {
       boundaryId: CancelID.downloads,
       lockFailure: { error, send in
         // Handle errors from both strategies at reducer level
-        if let cancellationError = error as? LockmanCancellationError {
-          // Handle cancellation errors that contain the actual strategy errors
-          if let id = extractDownloadId(from: cancellationError.reason) {
-            let reason = getSimpleErrorMessage(for: cancellationError.reason)
-            await send(.internal(.downloadRejected(id: id, reason: reason)))
-          }
-        } else if let singleExecutionError = error as? LockmanSingleExecutionError {
+        if let singleExecutionError = error as? LockmanSingleExecutionError {
           // SingleExecutionStrategy error (first strategy)
           if let id = extractDownloadId(from: error) {
             await send(.internal(.downloadRejected(id: id, reason: "Already running")))

--- a/Examples/Strategies/Strategies/04-GroupCoordinationStrategy.swift
+++ b/Examples/Strategies/Strategies/04-GroupCoordinationStrategy.swift
@@ -104,14 +104,8 @@ struct GroupCoordinationStrategyFeature {
       boundaryId: CancelID.sync,
       lockFailure: { error, send in
         // Handle group coordination errors using simplified error messages
-        if let cancellationError = error as? LockmanCancellationError {
-          // Handle cancellation errors that contain the actual strategy errors
-          let simpleMessage = getSimpleErrorMessage(for: cancellationError.reason)
-          await send(.internal(.syncFailed(simpleMessage)))
-        } else if let groupError = error as? LockmanGroupCoordinationError {
-          let simpleMessage = getSimpleErrorMessage(for: groupError)
-          await send(.internal(.syncFailed(simpleMessage)))
-        }
+        let simpleMessage = getSimpleErrorMessage(for: error)
+        await send(.internal(.syncFailed(simpleMessage)))
       },
       for: \.view
     )

--- a/Tests/LockmanTests/Core/Strategies/ConcurrencyLimitedStrategy/LockmanConcurrencyLimitedActionTests.swift
+++ b/Tests/LockmanTests/Core/Strategies/ConcurrencyLimitedStrategy/LockmanConcurrencyLimitedActionTests.swift
@@ -125,7 +125,8 @@ final class LockmanConcurrencyLimitedActionTests: XCTestCase {
     let action2 = TestAction.fetchUser(id: "456")
 
     XCTAssertEqual(action1.actionName, action2.actionName)
-    XCTAssertEqual(action1.createLockmanInfo().concurrencyId, action2.createLockmanInfo().concurrencyId)
+    XCTAssertEqual(
+      action1.createLockmanInfo().concurrencyId, action2.createLockmanInfo().concurrencyId)
     XCTAssertEqual(action1.createLockmanInfo().limit, action2.createLockmanInfo().limit)
   }
 

--- a/Tests/LockmanTests/Core/Strategies/SingleExecutionStrategy/LockmanSingleExecutionActionTests.swift
+++ b/Tests/LockmanTests/Core/Strategies/SingleExecutionStrategy/LockmanSingleExecutionActionTests.swift
@@ -114,7 +114,8 @@ final class LockmanSingleExecutionActionTests: XCTestCase {
 
     // They should conflict with each other
     XCTAssertEqual(saveAction.createLockmanInfo().actionId, loadAction.createLockmanInfo().actionId)
-    XCTAssertNotEqual(saveAction.createLockmanInfo().actionId, resetAction.createLockmanInfo().actionId)
+    XCTAssertNotEqual(
+      saveAction.createLockmanInfo().actionId, resetAction.createLockmanInfo().actionId)
   }
 
   // MARK: - LockmanAction Protocol Tests
@@ -173,15 +174,18 @@ final class LockmanSingleExecutionActionTests: XCTestCase {
     let action2 = ParameterizedAction.fetchUser(id: "123")
 
     // First lock should succeed
-    XCTAssertEqual(strategy.canLock(boundaryId: boundaryId, info: action1.createLockmanInfo()), .success)
+    XCTAssertEqual(
+      strategy.canLock(boundaryId: boundaryId, info: action1.createLockmanInfo()), .success)
     strategy.lock(boundaryId: boundaryId, info: action1.createLockmanInfo())
 
     // Second lock should fail (boundary is locked)
-    XCTAssertLockFailure(strategy.canLock(boundaryId: boundaryId, info: action2.createLockmanInfo()))
+    XCTAssertLockFailure(
+      strategy.canLock(boundaryId: boundaryId, info: action2.createLockmanInfo()))
 
     // Different action should also fail (boundary is locked)
     let action3 = ParameterizedAction.fetchUser(id: "456")
-    XCTAssertLockFailure(strategy.canLock(boundaryId: boundaryId, info: action3.createLockmanInfo()))
+    XCTAssertLockFailure(
+      strategy.canLock(boundaryId: boundaryId, info: action3.createLockmanInfo()))
 
     // Cleanup
     strategy.cleanUp()


### PR DESCRIPTION
## Summary
- Remove unnecessary LockmanCancellationError conditions in Examples/Strategies project
- Fix error handling to target correct buttons in PriorityBasedStrategy
- Replace LockmanCancellationError checks with direct error type checking

## Changes
- **01-SingleExecutionStrategy.swift**: Simplify error handling to check LockmanSingleExecutionError directly
- **02-PriorityBasedStrategy.swift**: 
  - Remove LockmanCancellationError wrapper usage
  - Extract actionId from error info to target correct buttons
  - Improve error message accuracy for different conflict scenarios
- **03-ConcurrencyLimitedStrategy.swift**: Remove LockmanCancellationError condition, keep individual error type checks
- **04-GroupCoordinationStrategy.swift**: Simplify error handling to use getSimpleErrorMessage directly

## Problem Fixed
Previously, exclusive control errors were incorrectly wrapped in LockmanCancellationError conditions, and error messages were displayed on wrong buttons (always high priority button regardless of which was tapped).

## Verification
- ✅ All Examples build successfully
- ✅ All tests pass
- ✅ Error messages now display on correct buttons

🤖 Generated with [Claude Code](https://claude.ai/code)