### PR TITLE
refactor!: introduce LockmanStrategyError protocol for consistent error handling

### DIFF
--- a/Examples/Strategies/Strategies/02-PriorityBasedStrategy.swift
+++ b/Examples/Strategies/Strategies/02-PriorityBasedStrategy.swift
@@ -95,21 +95,21 @@ struct PriorityBasedStrategyFeature {
           // SingleExecutionStrategy error (first strategy)
           // For SingleExecutionError, we can get the existing action info but not the requested one
           switch singleExecutionError {
-          case .boundaryAlreadyLocked(_, let existingInfo):
-            let button = buttonType(for: existingInfo.actionId)
+          case .boundaryAlreadyLocked(_, let lockmanInfo):
+            let button = buttonType(for: lockmanInfo.actionId)
             await send(.internal(.updateResult(button: button, result: "Boundary already locked")))
-          case .actionAlreadyRunning(let existingInfo):
-            let button = buttonType(for: existingInfo.actionId)
+          case .actionAlreadyRunning(_, let lockmanInfo):
+            let button = buttonType(for: lockmanInfo.actionId)
             await send(.internal(.updateResult(button: button, result: "Already running")))
           }
         } else if let priorityError = error as? LockmanPriorityBasedError {
           // PriorityBasedStrategy error (second strategy)
           switch priorityError {
-          case .precedingActionCancelled(let cancelledInfo, _):
+          case .precedingActionCancelled(let lockmanInfo, _):
             // An existing action was cancelled
-            let button = buttonType(for: cancelledInfo.actionId)
+            let button = buttonType(for: lockmanInfo.actionId)
             let message: String
-            if case .low(.replaceable) = cancelledInfo.priority {
+            if case .low(.replaceable) = lockmanInfo.priority {
               message = "Replaced by exclusive"
             } else {
               message = "Cancelled by higher priority"

--- a/Examples/Strategies/Strategies/03-ConcurrencyLimitedStrategy.swift
+++ b/Examples/Strategies/Strategies/03-ConcurrencyLimitedStrategy.swift
@@ -216,16 +216,16 @@ struct ConcurrencyLimitedStrategyFeature {
     if let singleExecutionError = error as? LockmanSingleExecutionError {
       // SingleExecutionStrategy error (first strategy)
       switch singleExecutionError {
-      case .boundaryAlreadyLocked(_, let existingInfo):
-        actionId = existingInfo.actionId
-      case .actionAlreadyRunning(let existingInfo):
-        actionId = existingInfo.actionId
+      case .boundaryAlreadyLocked(_, let lockmanInfo):
+        actionId = lockmanInfo.actionId
+      case .actionAlreadyRunning(_, let lockmanInfo):
+        actionId = lockmanInfo.actionId
       }
     } else if let concurrencyError = error as? LockmanConcurrencyLimitedError {
       // ConcurrencyLimitedStrategy error (second strategy)
       switch concurrencyError {
-      case .concurrencyLimitReached(let requestedInfo, _, _):
-        actionId = requestedInfo.actionId
+      case .concurrencyLimitReached(let lockmanInfo, _, _):
+        actionId = lockmanInfo.actionId
       }
     } else {
       return nil

--- a/Sources/Lockman/Core/Errors/LockmanStrategyError.swift
+++ b/Sources/Lockman/Core/Errors/LockmanStrategyError.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+// MARK: - LockmanStrategyError
+
+/// A protocol that all strategy-specific errors must conform to.
+///
+/// This protocol provides a unified interface for errors that occur within
+/// Lockman strategies, ensuring consistent error handling and debugging capabilities
+/// across all strategy implementations.
+///
+/// ## Common Properties
+/// All strategy errors provide:
+/// - `lockmanInfo`: Information about the action involved in the error
+/// - `boundaryId`: The boundary where the error occurred (if applicable)
+///
+/// ## Usage Example
+/// ```swift
+/// func handleStrategyError(_ error: any LockmanStrategyError) {
+///   print("Strategy error: \(error.localizedDescription)")
+///   print("Action: \(error.lockmanInfo.actionId)")
+///   if let boundaryId = error.boundaryId {
+///     print("Boundary: \(boundaryId)")
+///   }
+/// }
+/// ```
+public protocol LockmanStrategyError: LockmanError {
+  /// Information about the action involved in the error.
+  ///
+  /// This typically represents the action that was affected by the error,
+  /// such as the action that was rejected, cancelled, or caused a conflict.
+  var lockmanInfo: any LockmanInfo { get }
+
+  /// The boundary identifier where the error occurred.
+  ///
+  /// All strategy errors occur within a specific boundary context,
+  /// so this is always available for debugging and error handling.
+  var boundaryId: any LockmanBoundaryId { get }
+}

--- a/Sources/Lockman/Core/Protocols/LockmanPrecedingCancellationError.swift
+++ b/Sources/Lockman/Core/Protocols/LockmanPrecedingCancellationError.swift
@@ -31,7 +31,7 @@ import Foundation
 /// ## Design Principle
 /// This protocol uses simple property access rather than complex methods,
 /// making the interface clear and implementation straightforward.
-public protocol LockmanPrecedingCancellationError: LockmanError {
+public protocol LockmanPrecedingCancellationError: LockmanStrategyError {
   /// The LockmanInfo of the preceding action being cancelled.
   ///
   /// This property provides access to the lock information of the action

--- a/Sources/Lockman/Core/Strategies/ConcurrencyLimitedStrategy/LockmanConcurrencyLimitedStrategy.swift
+++ b/Sources/Lockman/Core/Strategies/ConcurrencyLimitedStrategy/LockmanConcurrencyLimitedStrategy.swift
@@ -45,13 +45,10 @@ public final class LockmanConcurrencyLimitedStrategy: LockmanStrategy, @unchecke
 
     if info.limit.isExceeded(currentCount: currentCount) {
       if case .limited(let limit) = info.limit {
-        // Get existing infos in the same concurrency group
-        let existingInfos = state.currentLocks(in: boundaryId, matching: info.concurrencyId)
-
         result = .cancel(
           LockmanConcurrencyLimitedError.concurrencyLimitReached(
-            requestedInfo: info,
-            existingInfos: existingInfos,
+            lockmanInfo: info,
+            boundaryId: boundaryId,
             currentCount: currentCount
           )
         )

--- a/Sources/Lockman/Core/Strategies/GroupCoordinationStrategy/LockmanGroupCoordinationError.swift
+++ b/Sources/Lockman/Core/Strategies/GroupCoordinationStrategy/LockmanGroupCoordinationError.swift
@@ -5,22 +5,32 @@ import Foundation
 /// An error that occurs when group coordination strategy blocks a new action.
 ///
 /// This error is returned when a new action cannot proceed due to group coordination rules.
-public enum LockmanGroupCoordinationError: LockmanError {
+public enum LockmanGroupCoordinationError: LockmanStrategyError {
   /// Leader cannot join a non-empty group.
-  case leaderCannotJoinNonEmptyGroup(groupIds: Set<AnyLockmanGroupId>)
+  case leaderCannotJoinNonEmptyGroup(
+    lockmanInfo: LockmanGroupCoordinatedInfo,
+    boundaryId: any LockmanBoundaryId,
+    groupIds: Set<AnyLockmanGroupId>
+  )
 
   /// Member cannot join an empty group.
-  case memberCannotJoinEmptyGroup(groupIds: Set<AnyLockmanGroupId>)
+  case memberCannotJoinEmptyGroup(
+    lockmanInfo: LockmanGroupCoordinatedInfo,
+    boundaryId: any LockmanBoundaryId,
+    groupIds: Set<AnyLockmanGroupId>
+  )
 
   /// Action with the same ID is already in the group.
   case actionAlreadyInGroup(
-    existingInfo: LockmanGroupCoordinatedInfo,
+    lockmanInfo: LockmanGroupCoordinatedInfo,
+    boundaryId: any LockmanBoundaryId,
     groupIds: Set<AnyLockmanGroupId>
   )
 
   /// Action is blocked by an exclusive leader.
   case blockedByExclusiveLeader(
-    leaderInfo: LockmanGroupCoordinatedInfo,
+    lockmanInfo: LockmanGroupCoordinatedInfo,
+    boundaryId: any LockmanBoundaryId,
     groupId: AnyLockmanGroupId,
     entryPolicy: LockmanGroupCoordinationRole.LeaderEntryPolicy
   )
@@ -31,18 +41,18 @@ public enum LockmanGroupCoordinationError: LockmanError {
 extension LockmanGroupCoordinationError: LocalizedError {
   public var errorDescription: String? {
     switch self {
-    case .leaderCannotJoinNonEmptyGroup(let groupIds):
+    case .leaderCannotJoinNonEmptyGroup(let lockmanInfo, _, let groupIds):
       return
-        "Cannot acquire lock: leader cannot join non-empty groups \(groupIds.map { "\($0)" }.sorted())."
-    case .memberCannotJoinEmptyGroup(let groupIds):
+        "Cannot acquire lock: leader '\(lockmanInfo.actionId)' cannot join non-empty groups \(groupIds.map { "\($0)" }.sorted())."
+    case .memberCannotJoinEmptyGroup(let lockmanInfo, _, let groupIds):
       return
-        "Cannot acquire lock: member cannot join empty groups \(groupIds.map { "\($0)" }.sorted())."
-    case .actionAlreadyInGroup(let existingInfo, let groupIds):
+        "Cannot acquire lock: member '\(lockmanInfo.actionId)' cannot join empty groups \(groupIds.map { "\($0)" }.sorted())."
+    case .actionAlreadyInGroup(let lockmanInfo, _, let groupIds):
       return
-        "Cannot acquire lock: action '\(existingInfo.actionId)' is already in groups \(groupIds.map { "\($0)" }.sorted())."
-    case .blockedByExclusiveLeader(let leaderInfo, let groupId, let entryPolicy):
+        "Cannot acquire lock: action '\(lockmanInfo.actionId)' is already in groups \(groupIds.map { "\($0)" }.sorted())."
+    case .blockedByExclusiveLeader(let lockmanInfo, _, let groupId, let entryPolicy):
       return
-        "Cannot acquire lock: blocked by exclusive leader '\(leaderInfo.actionId)' in group '\(groupId)' (policy: \(entryPolicy))."
+        "Cannot acquire lock: blocked by exclusive leader '\(lockmanInfo.actionId)' in group '\(groupId)' (policy: \(entryPolicy))."
     }
   }
 
@@ -54,7 +64,7 @@ extension LockmanGroupCoordinationError: LocalizedError {
       return "Members require existing participants in the group for coordination."
     case .actionAlreadyInGroup:
       return "Each action must have a unique ID within its coordination groups."
-    case .blockedByExclusiveLeader(_, _, let entryPolicy):
+    case .blockedByExclusiveLeader(_, _, _, let entryPolicy):
       switch entryPolicy {
       case .emptyGroup:
         return "Leader with 'emptyGroup' policy requires the group to be completely empty."
@@ -63,6 +73,36 @@ extension LockmanGroupCoordinationError: LocalizedError {
       case .withoutLeader:
         return "Leader with 'withoutLeader' policy requires no other leaders in the group."
       }
+    }
+  }
+}
+
+// MARK: - LockmanStrategyError Conformance
+
+extension LockmanGroupCoordinationError {
+  public var lockmanInfo: any LockmanInfo {
+    switch self {
+    case .leaderCannotJoinNonEmptyGroup(let lockmanInfo, _, _):
+      return lockmanInfo
+    case .memberCannotJoinEmptyGroup(let lockmanInfo, _, _):
+      return lockmanInfo
+    case .actionAlreadyInGroup(let lockmanInfo, _, _):
+      return lockmanInfo
+    case .blockedByExclusiveLeader(let lockmanInfo, _, _, _):
+      return lockmanInfo
+    }
+  }
+
+  public var boundaryId: any LockmanBoundaryId {
+    switch self {
+    case .leaderCannotJoinNonEmptyGroup(_, let boundaryId, _):
+      return boundaryId
+    case .memberCannotJoinEmptyGroup(_, let boundaryId, _):
+      return boundaryId
+    case .actionAlreadyInGroup(_, let boundaryId, _):
+      return boundaryId
+    case .blockedByExclusiveLeader(_, let boundaryId, _, _):
+      return boundaryId
     }
   }
 }

--- a/Sources/Lockman/Core/Strategies/GroupCoordinationStrategy/LockmanGroupCoordinationStrategy.swift
+++ b/Sources/Lockman/Core/Strategies/GroupCoordinationStrategy/LockmanGroupCoordinationStrategy.swift
@@ -144,7 +144,8 @@ public final class LockmanGroupCoordinationStrategy: LockmanStrategy, @unchecked
           failureReason = "Action '\(info.actionId)' is already active in group '\(groupId)'"
           return .cancel(
             LockmanGroupCoordinationError.actionAlreadyInGroup(
-              existingInfo: existingMember.info,
+              lockmanInfo: existingMember.info,
+              boundaryId: boundaryId,
               groupIds: Set([groupId])
             )
           )
@@ -192,6 +193,8 @@ public final class LockmanGroupCoordinationStrategy: LockmanStrategy, @unchecked
             if !canJoin {
               return .cancel(
                 LockmanGroupCoordinationError.leaderCannotJoinNonEmptyGroup(
+                  lockmanInfo: info,
+                  boundaryId: boundaryId,
                   groupIds: Set([groupId])
                 )
               )
@@ -204,6 +207,8 @@ public final class LockmanGroupCoordinationStrategy: LockmanStrategy, @unchecked
             failureReason = "Member cannot join: group '\(groupId)' has no active participants"
             return .cancel(
               LockmanGroupCoordinationError.memberCannotJoinEmptyGroup(
+                lockmanInfo: info,
+                boundaryId: boundaryId,
                 groupIds: Set([groupId])
               )
             )

--- a/Sources/Lockman/Core/Strategies/PriorityBasedStrategy/LockmanPriorityBasedError.swift
+++ b/Sources/Lockman/Core/Strategies/PriorityBasedStrategy/LockmanPriorityBasedError.swift
@@ -15,20 +15,20 @@ public enum LockmanPriorityBasedError: LockmanError {
   /// A higher priority action is already running, blocking the new action.
   case higherPriorityExists(
     requestedInfo: LockmanPriorityBasedInfo,
-    existingInfo: LockmanPriorityBasedInfo,
+    lockmanInfo: LockmanPriorityBasedInfo,
     boundaryId: any LockmanBoundaryId
   )
 
   /// Same priority conflict based on the existing action's concurrency behavior.
   case samePriorityConflict(
     requestedInfo: LockmanPriorityBasedInfo,
-    existingInfo: LockmanPriorityBasedInfo,
+    lockmanInfo: LockmanPriorityBasedInfo,
     boundaryId: any LockmanBoundaryId
   )
 
   /// The existing action was cancelled by a higher priority action.
   case precedingActionCancelled(
-    cancelledInfo: LockmanPriorityBasedInfo,
+    lockmanInfo: LockmanPriorityBasedInfo,
     boundaryId: any LockmanBoundaryId
   )
 }
@@ -38,14 +38,14 @@ public enum LockmanPriorityBasedError: LockmanError {
 extension LockmanPriorityBasedError: LocalizedError {
   public var errorDescription: String? {
     switch self {
-    case .higherPriorityExists(let requestedInfo, let existingInfo, _):
+    case .higherPriorityExists(let requestedInfo, let lockmanInfo, _):
       return
-        "Cannot acquire lock: Current priority \(existingInfo.priority) is higher than requested priority \(requestedInfo.priority)."
-    case .samePriorityConflict(_, let existingInfo, _):
+        "Cannot acquire lock: Current priority \(lockmanInfo.priority) is higher than requested priority \(requestedInfo.priority)."
+    case .samePriorityConflict(_, let lockmanInfo, _):
       return
-        "Cannot acquire lock: Another action with priority \(existingInfo.priority) is already running with exclusive behavior."
-    case .precedingActionCancelled(let cancelledInfo, _):
-      return "Lock acquired, preceding action '\(cancelledInfo.actionId)' will be cancelled."
+        "Cannot acquire lock: Another action with priority \(lockmanInfo.priority) is already running with exclusive behavior."
+    case .precedingActionCancelled(let lockmanInfo, _):
+      return "Lock acquired, preceding action '\(lockmanInfo.actionId)' will be cancelled."
     }
   }
 
@@ -70,8 +70,8 @@ extension LockmanPriorityBasedError: LockmanPrecedingCancellationError {
       return requestedInfo
     case .samePriorityConflict(let requestedInfo, _, _):
       return requestedInfo
-    case .precedingActionCancelled(let cancelledInfo, _):
-      return cancelledInfo
+    case .precedingActionCancelled(let lockmanInfo, _):
+      return lockmanInfo
     }
   }
 

--- a/Sources/Lockman/Core/Strategies/PriorityBasedStrategy/LockmanPriorityBasedStrategy.swift
+++ b/Sources/Lockman/Core/Strategies/PriorityBasedStrategy/LockmanPriorityBasedStrategy.swift
@@ -165,7 +165,7 @@ public final class LockmanPriorityBasedStrategy: LockmanStrategy, @unchecked Sen
       result = .cancel(
         LockmanPriorityBasedError.higherPriorityExists(
           requestedInfo: info,
-          existingInfo: mostRecentPriorityInfo,
+          lockmanInfo: mostRecentPriorityInfo,
           boundaryId: boundaryId
         )
       )
@@ -190,7 +190,7 @@ public final class LockmanPriorityBasedStrategy: LockmanStrategy, @unchecked Sen
       // Requested action has higher priority - can preempt current
       result = .successWithPrecedingCancellation(
         error: LockmanPriorityBasedError.precedingActionCancelled(
-          cancelledInfo: mostRecentPriorityInfo,
+          lockmanInfo: mostRecentPriorityInfo,
           boundaryId: boundaryId
         )
       )
@@ -336,7 +336,7 @@ extension LockmanPriorityBasedStrategy {
       return .cancel(
         LockmanPriorityBasedError.samePriorityConflict(
           requestedInfo: requested,
-          existingInfo: current,
+          lockmanInfo: current,
           boundaryId: boundaryId
         )
       )
@@ -346,7 +346,7 @@ extension LockmanPriorityBasedStrategy {
       // → Existing action gets canceled, new action succeeds
       return .successWithPrecedingCancellation(
         error: LockmanPriorityBasedError.precedingActionCancelled(
-          cancelledInfo: current,
+          lockmanInfo: current,
           boundaryId: boundaryId
         )
       )

--- a/Sources/Lockman/Core/Strategies/SingleExecutionStrategy/LockmanSingleExecutionError.swift
+++ b/Sources/Lockman/Core/Strategies/SingleExecutionStrategy/LockmanSingleExecutionError.swift
@@ -7,13 +7,14 @@ import Foundation
 /// This error is returned when a new action cannot proceed because:
 /// - The boundary already has an active lock (boundary mode)
 /// - An action with the same ID is already running (action mode)
-public enum LockmanSingleExecutionError: LockmanError {
+public enum LockmanSingleExecutionError: LockmanStrategyError {
   /// The boundary already has an active lock.
   case boundaryAlreadyLocked(
-    boundaryId: any LockmanBoundaryId, existingInfo: LockmanSingleExecutionInfo)
+    boundaryId: any LockmanBoundaryId, lockmanInfo: LockmanSingleExecutionInfo)
 
   /// An action with the same ID is already running.
-  case actionAlreadyRunning(existingInfo: LockmanSingleExecutionInfo)
+  case actionAlreadyRunning(
+    boundaryId: any LockmanBoundaryId, lockmanInfo: LockmanSingleExecutionInfo)
 }
 
 // MARK: - LocalizedError Conformance
@@ -21,11 +22,11 @@ public enum LockmanSingleExecutionError: LockmanError {
 extension LockmanSingleExecutionError: LocalizedError {
   public var errorDescription: String? {
     switch self {
-    case .boundaryAlreadyLocked(let boundaryId, let existingInfo):
+    case .boundaryAlreadyLocked(let boundaryId, let lockmanInfo):
       return
-        "Cannot acquire lock: boundary '\(boundaryId)' already has an active lock for action '\(existingInfo.actionId)'."
-    case .actionAlreadyRunning(let existingInfo):
-      return "Cannot acquire lock: action '\(existingInfo.actionId)' is already running."
+        "Cannot acquire lock: boundary '\(boundaryId)' already has an active lock for action '\(lockmanInfo.actionId)'."
+    case .actionAlreadyRunning(_, let lockmanInfo):
+      return "Cannot acquire lock: action '\(lockmanInfo.actionId)' is already running."
     }
   }
 
@@ -36,6 +37,28 @@ extension LockmanSingleExecutionError: LocalizedError {
         "SingleExecutionStrategy with boundary mode prevents multiple operations in the same boundary."
     case .actionAlreadyRunning:
       return "SingleExecutionStrategy with action mode prevents duplicate action execution."
+    }
+  }
+}
+
+// MARK: - LockmanStrategyError Conformance
+
+extension LockmanSingleExecutionError {
+  public var lockmanInfo: any LockmanInfo {
+    switch self {
+    case .boundaryAlreadyLocked(_, let lockmanInfo):
+      return lockmanInfo
+    case .actionAlreadyRunning(_, let lockmanInfo):
+      return lockmanInfo
+    }
+  }
+
+  public var boundaryId: any LockmanBoundaryId {
+    switch self {
+    case .boundaryAlreadyLocked(let boundaryId, _):
+      return boundaryId
+    case .actionAlreadyRunning(let boundaryId, _):
+      return boundaryId
     }
   }
 }

--- a/Sources/Lockman/Core/Strategies/SingleExecutionStrategy/LockmanSingleExecutionStrategy.swift
+++ b/Sources/Lockman/Core/Strategies/SingleExecutionStrategy/LockmanSingleExecutionStrategy.swift
@@ -103,7 +103,7 @@ public final class LockmanSingleExecutionStrategy: LockmanStrategy, @unchecked S
         result = .cancel(
           LockmanSingleExecutionError.boundaryAlreadyLocked(
             boundaryId: boundaryId,
-            existingInfo: existingInfo
+            lockmanInfo: existingInfo
           )
         )
         failureReason = "Boundary '\(boundaryId)' already has an active lock"
@@ -115,7 +115,8 @@ public final class LockmanSingleExecutionStrategy: LockmanStrategy, @unchecked S
         let existingInfo = state.currentLocks(in: boundaryId, matching: info.actionId).first!
         result = .cancel(
           LockmanSingleExecutionError.actionAlreadyRunning(
-            existingInfo: existingInfo
+            boundaryId: boundaryId,
+            lockmanInfo: existingInfo
           )
         )
         failureReason = "Action '\(info.actionId)' is already locked"

--- a/Tests/LockmanTests/Core/LockmanPrecedingCancellationErrorTests.swift
+++ b/Tests/LockmanTests/Core/LockmanPrecedingCancellationErrorTests.swift
@@ -17,7 +17,7 @@ final class LockmanPrecedingCancellationErrorTests: XCTestCase {
     let boundaryId = TestBoundaryId("testBoundary")
 
     let error = LockmanPriorityBasedError.precedingActionCancelled(
-      cancelledInfo: cancelledInfo,
+      lockmanInfo: cancelledInfo,
       boundaryId: boundaryId
     )
 
@@ -34,12 +34,12 @@ final class LockmanPrecedingCancellationErrorTests: XCTestCase {
   func testLockmanPriorityBasedError_PrecedingActionCancelled_LockmanInfo() {
     let cancelledInfo = LockmanPriorityBasedInfo(
       actionId: "cancelledAction",
-      priority: .low(.replaceable)
+      priority: LockmanPriorityBasedInfo.Priority.low(.replaceable)
     )
     let boundaryId = TestBoundaryId("boundary123")
 
     let error = LockmanPriorityBasedError.precedingActionCancelled(
-      cancelledInfo: cancelledInfo,
+      lockmanInfo: cancelledInfo,
       boundaryId: boundaryId
     )
 
@@ -52,7 +52,7 @@ final class LockmanPrecedingCancellationErrorTests: XCTestCase {
       XCTFail("lockmanInfo should be castable to LockmanPriorityBasedInfo")
       return
     }
-    XCTAssertEqual(priorityInfo.priority, .low(.replaceable))
+    XCTAssertEqual(priorityInfo.priority, LockmanPriorityBasedInfo.Priority.low(.replaceable))
   }
 
   func testLockmanPriorityBasedError_PrecedingActionCancelled_BoundaryId() {
@@ -63,7 +63,7 @@ final class LockmanPrecedingCancellationErrorTests: XCTestCase {
     let boundaryId = TestBoundaryId("uniqueBoundary")
 
     let error = LockmanPriorityBasedError.precedingActionCancelled(
-      cancelledInfo: cancelledInfo,
+      lockmanInfo: cancelledInfo,
       boundaryId: boundaryId
     )
 
@@ -75,7 +75,7 @@ final class LockmanPrecedingCancellationErrorTests: XCTestCase {
   func testLockmanPriorityBasedError_HigherPriorityExists_LockmanInfo() {
     let requestedInfo = LockmanPriorityBasedInfo(
       actionId: "requestedAction",
-      priority: .low(.exclusive)
+      priority: LockmanPriorityBasedInfo.Priority.low(.exclusive)
     )
     let existingInfo = LockmanPriorityBasedInfo(
       actionId: "existingAction",
@@ -85,7 +85,7 @@ final class LockmanPrecedingCancellationErrorTests: XCTestCase {
 
     let error = LockmanPriorityBasedError.higherPriorityExists(
       requestedInfo: requestedInfo,
-      existingInfo: existingInfo,
+      lockmanInfo: existingInfo,
       boundaryId: boundaryId
     )
 
@@ -98,23 +98,23 @@ final class LockmanPrecedingCancellationErrorTests: XCTestCase {
       XCTFail("lockmanInfo should be castable to LockmanPriorityBasedInfo")
       return
     }
-    XCTAssertEqual(priorityInfo.priority, .low(.exclusive))
+    XCTAssertEqual(priorityInfo.priority, LockmanPriorityBasedInfo.Priority.low(.exclusive))
   }
 
   func testLockmanPriorityBasedError_SamePriorityConflict_LockmanInfo() {
     let requestedInfo = LockmanPriorityBasedInfo(
       actionId: "requestedAction",
-      priority: .low(.exclusive)
+      priority: LockmanPriorityBasedInfo.Priority.low(.exclusive)
     )
     let existingInfo = LockmanPriorityBasedInfo(
       actionId: "existingAction",
-      priority: .low(.exclusive)
+      priority: LockmanPriorityBasedInfo.Priority.low(.exclusive)
     )
     let boundaryId = TestBoundaryId("testBoundary")
 
     let error = LockmanPriorityBasedError.samePriorityConflict(
       requestedInfo: requestedInfo,
-      existingInfo: existingInfo,
+      lockmanInfo: existingInfo,
       boundaryId: boundaryId
     )
 
@@ -127,7 +127,7 @@ final class LockmanPrecedingCancellationErrorTests: XCTestCase {
       XCTFail("lockmanInfo should be castable to LockmanPriorityBasedInfo")
       return
     }
-    XCTAssertEqual(priorityInfo.priority, .low(.exclusive))
+    XCTAssertEqual(priorityInfo.priority, LockmanPriorityBasedInfo.Priority.low(.exclusive))
   }
 
   // MARK: - LockmanResult Integration Tests
@@ -135,12 +135,12 @@ final class LockmanPrecedingCancellationErrorTests: XCTestCase {
   func testLockmanResult_SuccessWithPrecedingCancellation_TypeSafety() {
     let cancelledInfo = LockmanPriorityBasedInfo(
       actionId: "cancelledAction",
-      priority: .low(.exclusive)
+      priority: LockmanPriorityBasedInfo.Priority.low(.exclusive)
     )
     let boundaryId = TestBoundaryId("testBoundary")
 
     let error = LockmanPriorityBasedError.precedingActionCancelled(
-      cancelledInfo: cancelledInfo,
+      lockmanInfo: cancelledInfo,
       boundaryId: boundaryId
     )
 
@@ -161,12 +161,12 @@ final class LockmanPrecedingCancellationErrorTests: XCTestCase {
   func testLockmanResult_SuccessWithPrecedingCancellation_DirectAccess() {
     let cancelledInfo = LockmanPriorityBasedInfo(
       actionId: "directAccessTest",
-      priority: .high(.replaceable)
+      priority: LockmanPriorityBasedInfo.Priority.high(.replaceable)
     )
     let boundaryId = TestBoundaryId("directBoundary")
 
     let error = LockmanPriorityBasedError.precedingActionCancelled(
-      cancelledInfo: cancelledInfo,
+      lockmanInfo: cancelledInfo,
       boundaryId: boundaryId
     )
 
@@ -185,7 +185,7 @@ final class LockmanPrecedingCancellationErrorTests: XCTestCase {
         XCTFail("Should be able to cast to LockmanPriorityBasedInfo")
         return
       }
-      XCTAssertEqual(priorityInfo.priority, .high(.replaceable))
+      XCTAssertEqual(priorityInfo.priority, LockmanPriorityBasedInfo.Priority.high(.replaceable))
     } else {
       XCTFail("Result should be successWithPrecedingCancellation")
     }

--- a/Tests/LockmanTests/Core/Strategies/ConcurrencyLimitedStrategy/LockmanConcurrencyLimitedStrategyTests.swift
+++ b/Tests/LockmanTests/Core/Strategies/ConcurrencyLimitedStrategy/LockmanConcurrencyLimitedStrategyTests.swift
@@ -135,13 +135,11 @@ final class LockmanConcurrencyLimitedStrategyTests: XCTestCase {
       let concurrencyError = error as? LockmanConcurrencyLimitedError
     {
       switch concurrencyError {
-      case .concurrencyLimitReached(let requestedInfo, let existingInfos, let currentCount):
-        XCTAssertEqual(requestedInfo.concurrencyId, "file_operations")
-        XCTAssertEqual(requestedInfo.actionId, "upload3")
-        XCTAssertEqual(existingInfos.count, 2)
-        XCTAssertTrue(existingInfos.contains { $0.actionId == "upload1" })
-        XCTAssertTrue(existingInfos.contains { $0.actionId == "upload2" })
+      case .concurrencyLimitReached(let lockmanInfo, let boundaryId, let currentCount):
+        XCTAssertEqual(lockmanInfo.concurrencyId, "file_operations")
+        XCTAssertEqual(lockmanInfo.actionId, "upload3")
         XCTAssertEqual(currentCount, 2)
+        XCTAssertNotNil(boundaryId)
       }
     } else {
       XCTFail("Expected LockmanConcurrencyLimitedError")


### PR DESCRIPTION
## Summary

This PR introduces the **LockmanStrategyError protocol** to unify error handling across all Lockman strategies, providing a consistent and type-safe interface for strategy error management.

## Background & Problem

Previously, each strategy error had its own independent design:
- **Inconsistent parameter naming**: `existingInfo`, `cancelledInfo`, `requestedInfo` 
- **Optional boundaryId**: Required defensive programming with optional checking
- **No unified interface**: Each error type needed separate handling logic
- **Complex error structures**: Like `LockmanConcurrencyLimitedError` with unnecessary `existingInfos` array

This made error handling cumbersome and error-prone for developers.

## Solution: LockmanStrategyError Protocol

### 🔄 **New Unified Protocol**
```swift
public protocol LockmanStrategyError: LockmanError {
  var lockmanInfo: any LockmanInfo { get }
  var boundaryId: any LockmanBoundaryId { get }
}
```

### ✨ **Benefits**
- **Consistent API**: All strategy errors now have the same interface
- **Type Safety**: Guaranteed access to `lockmanInfo` and `boundaryId`
- **Simplified Error Handling**: Single pattern for all strategy errors
- **Better IntelliSense**: Protocol provides unified completion support

### 🔗 **Protocol Inheritance**
- `LockmanPrecedingCancellationError` now inherits from `LockmanStrategyError`
- All strategy errors conform to the unified protocol
- Maintains backward compatibility where possible

## 🚨 Breaking Changes

### 1. **boundaryId is now non-optional**
```swift
// Before (optional)
if let boundaryId = error.boundaryId {
  // handle boundary
}

// After (guaranteed)
let boundaryId = error.boundaryId // Always available
```

### 2. **Unified parameter naming**
```swift
// Before (inconsistent)
case .precedingActionCancelled(cancelledInfo: info, boundaryId: boundary)
case .concurrencyLimitReached(requestedInfo: info, existingInfos: infos, currentCount: count)

// After (consistent)
case .precedingActionCancelled(lockmanInfo: info, boundaryId: boundary)
case .concurrencyLimitReached(lockmanInfo: info, boundaryId: boundary, currentCount: count)
```

### 3. **Simplified error structures**
- `LockmanConcurrencyLimitedError`: Removed complex `existingInfos` array
- All errors now use single `lockmanInfo` parameter

## Updated Strategy Errors

### 📝 **All Errors Now Conform to LockmanStrategyError**
- `LockmanSingleExecutionError`: Added `boundaryId` parameter to all cases
- `LockmanPriorityBasedError`: Updated parameter names and added missing `boundaryId`
- `LockmanConcurrencyLimitedError`: Simplified to single `lockmanInfo` parameter
- `LockmanGroupCoordinationError`: Added `boundaryId` parameter to all cases

## Implementation Updates

### 🔧 **Core Changes**
- **Strategy implementations**: Updated to provide `boundaryId` when creating errors
- **Effect+LockmanInternal.swift**: Removed optional `boundaryId` checking
- **Test files**: Updated to match new parameter structures  
- **Example applications**: Fixed to use new parameter names

### ✅ **Verification**
- [x] All main project tests pass
- [x] All example projects build successfully
- [x] Breaking changes are intentional and documented

## Migration Guide

### Error Pattern Matching
```swift
// Before
switch error {
case let priorityError as LockmanPriorityBasedError:
  switch priorityError {
  case .precedingActionCancelled(let cancelledInfo, let boundaryId):
    // handle with inconsistent naming
  }
}

// After  
switch error {
case let strategyError as LockmanStrategyError:
  // Unified access to lockmanInfo and boundaryId
  let info = strategyError.lockmanInfo
  let boundary = strategyError.boundaryId
  
case let priorityError as LockmanPriorityBasedError:
  switch priorityError {
  case .precedingActionCancelled(let lockmanInfo, let boundaryId):
    // handle with consistent naming
  }
}
```

## Test Plan

```bash
# Run main project tests
xcodebuild test -configuration Debug -scheme "Lockman" -destination "platform=macOS,name=My Mac" -workspace .github/package.xcworkspace -skipMacroValidation

# Build examples
xcodebuild build -scheme Strategies -configuration Debug -destination "platform=iOS Simulator,name=iPhone 16" -workspace Examples/Strategies/Strategies.xcodeproj/project.xcworkspace -skipMacroValidation
```

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>