### PR TITLE
refactor: simplify acquireLock method by removing redundant overloads and strategyId parameter

### DIFF
--- a/Sources/Lockman/Composable/LockmanDynamicConditionReducer+Internal.swift
+++ b/Sources/Lockman/Composable/LockmanDynamicConditionReducer+Internal.swift
@@ -155,7 +155,6 @@ extension LockmanDynamicConditionReducer {
     do {
       let result = try effectForLock.acquireLock(
         lockmanInfo: dynamicInfo,
-        strategyId: .dynamicCondition,
         boundaryId: boundaryId
       )
 
@@ -228,7 +227,6 @@ extension LockmanDynamicConditionReducer {
     do {
       let result = try effectForLock.acquireLock(
         lockmanInfo: lockmanInfo,
-        strategyId: lockmanInfo.strategyId,
         boundaryId: boundaryId
       )
 


### PR DESCRIPTION
## Summary

Simplified the `acquireLock` method API by removing redundant overloads and unnecessary `strategyId` parameter, improving code consistency and reducing complexity.

## Changes

- **Removed duplicate `acquireLock` overload** that explicitly required `strategyId` parameter
- **Simplified API** to use only `lockmanInfo` and `boundaryId` parameters  
- **Automated strategyId resolution** from `lockmanInfo.strategyId` internally
- **Updated all call sites** to use the simplified API across:
  - `LockmanReducer.swift`
  - `Effect+Lockman.swift` 
  - `LockmanDynamicConditionReducer+Internal.swift`

## Benefits

- **Cleaner API**: Callers no longer need to manually specify `strategyId`
- **Reduced redundancy**: Eliminated duplicate methods with different parameter counts
- **Better consistency**: Single method handles all use cases uniformly
- **Maintained functionality**: All existing behavior preserved, just simpler to use

## Technical Details

Before:
```swift
// Two different overloads
acquireLock(lockmanInfo: info, boundaryId: boundary)
acquireLock(lockmanInfo: info, strategyId: id, boundaryId: boundary)
```

After:
```swift
// Single simplified method
acquireLock(lockmanInfo: info, boundaryId: boundary)
// strategyId automatically resolved from lockmanInfo.strategyId
```

All tests pass and functionality remains identical.