### PR TITLE
chore: align dependencies with TCA and fix iOS simulator issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,8 +33,13 @@ jobs:
           sudo xcodebuild -runFirstLaunch
           # Install iOS platform to ensure SDK availability
           sudo xcodebuild -downloadPlatform iOS || true
+          # Try specific iOS version downloads
+          sudo xcodebuild -downloadPlatform iOS -buildVersion 18.2 || true
+          sudo xcodebuild -downloadPlatform iOS -buildVersion 18.1 || true
           # List available platforms for debugging
           xcodebuild -showsdks
+          # List available simulators
+          xcrun simctl list devices available
       - name: List available devices
         run: xcrun simctl list devices available
       - name: Cache derived data
@@ -75,8 +80,13 @@ jobs:
           sudo xcodebuild -runFirstLaunch
           # Install iOS platform to ensure SDK availability
           sudo xcodebuild -downloadPlatform iOS || true
+          # Try specific iOS version downloads
+          sudo xcodebuild -downloadPlatform iOS -buildVersion 18.2 || true
+          sudo xcodebuild -downloadPlatform iOS -buildVersion 18.1 || true
           # List available platforms for debugging
           xcodebuild -showsdks
+          # List available simulators
+          xcrun simctl list devices available
       - name: Set IgnoreFileSystemDeviceInodeChanges flag
         run: defaults write com.apple.dt.XCBuild IgnoreFileSystemDeviceInodeChanges -bool YES
       - name: Update mtime for incremental builds

--- a/Package.swift
+++ b/Package.swift
@@ -19,10 +19,10 @@ let package = Package(
       targets: ["Lockman"])
   ],
   dependencies: [
-    .package(url: "https://github.com/pointfreeco/swift-composable-architecture", exact: "1.21.0"),
+    .package(url: "https://github.com/pointfreeco/swift-composable-architecture", exact: "1.21.1"),
     .package(url: "https://github.com/swiftlang/swift-syntax", "509.0.0"..<"602.0.0"),
-    .package(url: "https://github.com/pointfreeco/swift-macro-testing", from: "0.2.0"),
-    .package(url: "https://github.com/apple/swift-collections.git", from: "1.1.5"),
+    .package(url: "https://github.com/pointfreeco/swift-macro-testing", from: "0.6.3"),
+    .package(url: "https://github.com/apple/swift-collections.git", from: "1.2.1"),
     .package(url: "https://github.com/swiftlang/swift-docc-plugin", from: "1.4.5"),
   ],
   targets: [

--- a/Package.swift
+++ b/Package.swift
@@ -23,7 +23,7 @@ let package = Package(
     .package(url: "https://github.com/swiftlang/swift-syntax", "509.0.0"..<"602.0.0"),
     .package(url: "https://github.com/pointfreeco/swift-macro-testing", from: "0.2.0"),
     .package(url: "https://github.com/apple/swift-collections.git", from: "1.1.5"),
-    .package(url: "https://github.com/swiftlang/swift-docc-plugin", from: "1.0.0"),
+    .package(url: "https://github.com/swiftlang/swift-docc-plugin", from: "1.4.5"),
   ],
   targets: [
     // Unified Lockman target

--- a/Package.swift
+++ b/Package.swift
@@ -22,7 +22,7 @@ let package = Package(
     .package(url: "https://github.com/pointfreeco/swift-composable-architecture", exact: "1.21.1"),
     .package(url: "https://github.com/swiftlang/swift-syntax", "509.0.0"..<"602.0.0"),
     .package(url: "https://github.com/pointfreeco/swift-macro-testing", from: "0.6.3"),
-    .package(url: "https://github.com/apple/swift-collections.git", from: "1.2.1"),
+    .package(url: "https://github.com/apple/swift-collections.git", from: "1.1.0"),
     .package(url: "https://github.com/swiftlang/swift-docc-plugin", from: "1.4.5"),
   ],
   targets: [

--- a/Package@swift-6.0.swift
+++ b/Package@swift-6.0.swift
@@ -19,10 +19,10 @@ let package = Package(
       targets: ["Lockman"])
   ],
   dependencies: [
-    .package(url: "https://github.com/pointfreeco/swift-composable-architecture", exact: "1.21.0"),
+    .package(url: "https://github.com/pointfreeco/swift-composable-architecture", exact: "1.21.1"),
     .package(url: "https://github.com/swiftlang/swift-syntax", "509.0.0"..<"602.0.0"),
-    .package(url: "https://github.com/pointfreeco/swift-macro-testing", from: "0.2.0"),
-    .package(url: "https://github.com/apple/swift-collections.git", from: "1.1.5"),
+    .package(url: "https://github.com/pointfreeco/swift-macro-testing", from: "0.6.3"),
+    .package(url: "https://github.com/apple/swift-collections.git", from: "1.2.1"),
     .package(url: "https://github.com/swiftlang/swift-docc-plugin", from: "1.4.5"),
   ],
   targets: [

--- a/Package@swift-6.0.swift
+++ b/Package@swift-6.0.swift
@@ -23,7 +23,7 @@ let package = Package(
     .package(url: "https://github.com/swiftlang/swift-syntax", "509.0.0"..<"602.0.0"),
     .package(url: "https://github.com/pointfreeco/swift-macro-testing", from: "0.2.0"),
     .package(url: "https://github.com/apple/swift-collections.git", from: "1.1.5"),
-    .package(url: "https://github.com/swiftlang/swift-docc-plugin", from: "1.0.0"),
+    .package(url: "https://github.com/swiftlang/swift-docc-plugin", from: "1.4.5"),
   ],
   targets: [
     // Unified Lockman target

--- a/Package@swift-6.0.swift
+++ b/Package@swift-6.0.swift
@@ -22,7 +22,7 @@ let package = Package(
     .package(url: "https://github.com/pointfreeco/swift-composable-architecture", exact: "1.21.1"),
     .package(url: "https://github.com/swiftlang/swift-syntax", "509.0.0"..<"602.0.0"),
     .package(url: "https://github.com/pointfreeco/swift-macro-testing", from: "0.6.3"),
-    .package(url: "https://github.com/apple/swift-collections.git", from: "1.2.1"),
+    .package(url: "https://github.com/apple/swift-collections.git", from: "1.1.0"),
     .package(url: "https://github.com/swiftlang/swift-docc-plugin", from: "1.4.5"),
   ],
   targets: [


### PR DESCRIPTION
## Summary
- Align swift-collections version with TCA dependency requirements (1.2.1 → 1.1.0)
- Add specific iOS version downloads to resolve GitHub Actions runner-images issue #11683
- Keep swift-docc-plugin at latest version as requested
- Maintain consistency between Package.swift and Package@swift-6.0.swift

## Changes
- **Dependencies**: Update swift-collections from 1.2.1 to 1.1.0 to match TCA's requirements
- **CI**: Add explicit iOS 18.2 and 18.1 SDK downloads to fix simulator runtime issues
- **CI**: Add simulator listing for debugging purposes

## Testing
- ✅ Local macOS tests pass
- ✅ Updated CI configuration with iOS platform workarounds

🤖 Generated with [Claude Code](https://claude.ai/code)