### PR TITLE
chore: prepare for 1.7.6 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ Add the dependency to your Package.swift file:
 
 ```swift
 dependencies: [
-  .package(url: "https://github.com/takeshishimada/Lockman", from: "1.7.5")
+  .package(url: "https://github.com/takeshishimada/Lockman", from: "1.7.6")
 ]
 ```
 
@@ -258,8 +258,8 @@ Add the dependency to your target:
 
 | Lockman | The Composable Architecture |
 |---------|----------------------------|
+| 1.7.6   | 1.23.0                     |
 | 1.7.5   | 1.22.3                     |
-| 1.7.4   | 1.22.2                     |
 | 1.7.3   | 1.22.1                     |
 | 1.7.2   | 1.22.1                     |
 | 1.7.1   | 1.22.0                     |
@@ -273,6 +273,7 @@ Add the dependency to your target:
 
 | Lockman | The Composable Architecture |
 |---------|----------------------------|
+| 1.7.4   | 1.22.2                     |
 | 1.4.0   | 1.20.2                     |
 | 1.3.2   | 1.20.2                     |
 | 1.3.1   | 1.20.2                     |


### PR DESCRIPTION
## Summary
Prepare for version 1.7.6 release

## Changes
- Update installation version in README.md from 1.7.5 to 1.7.6
- Add 1.7.6 (TCA 1.23.0) to Version Compatibility table
- Move 1.7.4 to Other versions section

## Release Notes
- Update The Composable Architecture to 1.23.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)