### PR TITLE
chore: update TCA to version 1.23.1

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
       targets: ["Lockman"])
   ],
   dependencies: [
-    .package(url: "https://github.com/pointfreeco/swift-composable-architecture", exact: "1.23.0"),
+    .package(url: "https://github.com/pointfreeco/swift-composable-architecture", exact: "1.23.1"),
     .package(url: "https://github.com/swiftlang/swift-syntax", "509.0.0"..<"603.0.0"),
     .package(url: "https://github.com/pointfreeco/swift-macro-testing", from: "0.6.3"),
     .package(url: "https://github.com/apple/swift-collections.git", from: "1.1.0"),

--- a/Package@swift-6.0.swift
+++ b/Package@swift-6.0.swift
@@ -19,7 +19,7 @@ let package = Package(
       targets: ["Lockman"])
   ],
   dependencies: [
-    .package(url: "https://github.com/pointfreeco/swift-composable-architecture", exact: "1.23.0"),
+    .package(url: "https://github.com/pointfreeco/swift-composable-architecture", exact: "1.23.1"),
     .package(url: "https://github.com/swiftlang/swift-syntax", "509.0.0"..<"603.0.0"),
     .package(url: "https://github.com/pointfreeco/swift-macro-testing", from: "0.6.3"),
     .package(url: "https://github.com/apple/swift-collections.git", from: "1.1.0"),


### PR DESCRIPTION
## Summary
- Update The Composable Architecture from 1.23.0 to 1.23.1

## TCA 1.23.1 Release Notes (Bug fixes only)
- Store.publisher perception check fix
- reportIssue format improvement
- Compiler warning fixes (existential `any` keyword, deprecated APIs)
- swift-navigation dependency update
- ShareChangeTracker initialization error fix

## Testing
- All 589 tests pass
- Build successful with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)