### PR TITLE
refactor: make Swift 6.0 the default Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.9
+// swift-tools-version: 6.0
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import CompilerPluginSupport
@@ -56,16 +56,21 @@ let package = Package(
         .product(name: "MacroTesting", package: "swift-macro-testing"),
       ]
     ),
-  ]
+  ],
+  swiftLanguageModes: [.v6]
 )
 
-#if compiler(>=6)
-  for target in package.targets where target.type != .system && target.type != .test {
-    target.swiftSettings = target.swiftSettings ?? []
-    target.swiftSettings?.append(contentsOf: [
-      .enableExperimentalFeature("StrictConcurrency"),
-      .enableUpcomingFeature("ExistentialAny"),
-      .enableUpcomingFeature("InferSendableFromCaptures"),
-    ])
-  }
-#endif
+for target in package.targets {
+  target.swiftSettings = target.swiftSettings ?? []
+  target.swiftSettings?.append(contentsOf: [
+    .enableUpcomingFeature("ExistentialAny")
+  ])
+}
+
+for target in package.targets where target.type == .system || target.type == .test {
+  target.swiftSettings?.append(contentsOf: [
+    .swiftLanguageMode(.v5),
+    .enableExperimentalFeature("StrictConcurrency"),
+    .enableUpcomingFeature("InferSendableFromCaptures"),
+  ])
+}

--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.0
+// swift-tools-version: 5.9
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import CompilerPluginSupport
@@ -56,21 +56,16 @@ let package = Package(
         .product(name: "MacroTesting", package: "swift-macro-testing"),
       ]
     ),
-  ],
-  swiftLanguageModes: [.v6]
+  ]
 )
 
-for target in package.targets {
-  target.swiftSettings = target.swiftSettings ?? []
-  target.swiftSettings?.append(contentsOf: [
-    .enableUpcomingFeature("ExistentialAny")
-  ])
-}
-
-for target in package.targets where target.type == .system || target.type == .test {
-  target.swiftSettings?.append(contentsOf: [
-    .swiftLanguageMode(.v5),
-    .enableExperimentalFeature("StrictConcurrency"),
-    .enableUpcomingFeature("InferSendableFromCaptures"),
-  ])
-}
+#if compiler(>=6)
+  for target in package.targets where target.type != .system && target.type != .test {
+    target.swiftSettings = target.swiftSettings ?? []
+    target.swiftSettings?.append(contentsOf: [
+      .enableExperimentalFeature("StrictConcurrency"),
+      .enableUpcomingFeature("ExistentialAny"),
+      .enableUpcomingFeature("InferSendableFromCaptures"),
+    ])
+  }
+#endif


### PR DESCRIPTION
## Summary
Make Swift 6.0 the default by swapping Package.swift file names.

## Changes
- `Package.swift` → `Package@swift-5.9.swift` (for Swift 5.9/5.10)
- `Package@swift-6.0.swift` → `Package.swift` (now default)

## Rationale
Swift 6.0 is now the primary development target. This change makes Swift 6.0 configuration the default while maintaining backward compatibility with Swift 5.9/5.10.

## Testing
- All 589 tests pass
- Build successful with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)