### PR TITLE
fix: add `any` keyword for CompilerPlugin existential type

### DIFF
--- a/Tests/LockmanMacrosTests/MacroPluginTests.swift
+++ b/Tests/LockmanMacrosTests/MacroPluginTests.swift
@@ -19,7 +19,7 @@ import XCTest
 
     func testPluginConformsToCompilerPlugin() {
       let plugin = LockmanMacroPlugin()
-      XCTAssertTrue(plugin is CompilerPlugin)
+      XCTAssertTrue(plugin is any CompilerPlugin)
     }
 
     func testProvidingMacrosCount() {


### PR DESCRIPTION
## Summary
Fix Swift 6.0 CI build failure caused by missing `any` keyword.

## Problem
CI failed with error:
```
error: use of protocol 'CompilerPlugin' as a type must be written 'any CompilerPlugin'
```

## Solution
Add `any` keyword to existential type check in `MacroPluginTests.swift:22`:
```swift
// Before
XCTAssertTrue(plugin is CompilerPlugin)

// After
XCTAssertTrue(plugin is any CompilerPlugin)
```

## Testing
- All 589 tests pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)